### PR TITLE
fix: separate canonical query fields in Dataset.list() (#67)

### DIFF
--- a/src/kpubdata/core/dataset.py
+++ b/src/kpubdata/core/dataset.py
@@ -7,6 +7,10 @@ from kpubdata.core.models import DatasetRef, Query, RecordBatch, SchemaDescripto
 from kpubdata.core.protocol import ProviderAdapter
 from kpubdata.exceptions import UnsupportedCapabilityError
 
+_CANONICAL_QUERY_KEYS = frozenset(
+    {"page", "page_size", "cursor", "start_date", "end_date", "fields", "sort"}
+)
+
 
 class Dataset:
     """Bound dataset that routes operations to a provider adapter."""
@@ -47,10 +51,13 @@ class Dataset:
 
         return self._ref.operations
 
-    def list(self, **filters: object) -> RecordBatch:
+    def list(self, **kwargs: object) -> RecordBatch:
         """Query records from this dataset using canonical list semantics.
 
-        Pass provider-specific query parameters as keyword arguments.
+        Canonical query parameters (``page``, ``page_size``, ``cursor``,
+        ``start_date``, ``end_date``, ``fields``, ``sort``) are extracted
+        into the corresponding ``Query`` fields.  Remaining kwargs are
+        passed as provider-specific ``filters``.
 
         Raises:
             UnsupportedCapabilityError: If this dataset does not support ``list``.
@@ -63,7 +70,44 @@ class Dataset:
                 dataset_id=self._ref.id,
                 operation=Operation.LIST.value,
             )
-        query = Query(filters=filters)
+
+        page: int | None = None
+        page_size: int | None = None
+        cursor: str | None = None
+        start_date: str | None = None
+        end_date: str | None = None
+        fields_list: list[str] | None = None
+        sort_list: list[str] | None = None
+        filters: dict[str, object] = {}
+
+        for key, value in kwargs.items():
+            if key == "page" and isinstance(value, int):
+                page = value
+            elif key == "page_size" and isinstance(value, int):
+                page_size = value
+            elif key == "cursor" and isinstance(value, str):
+                cursor = value
+            elif key == "start_date" and isinstance(value, str):
+                start_date = value
+            elif key == "end_date" and isinstance(value, str):
+                end_date = value
+            elif key == "fields" and isinstance(value, list):
+                fields_list = value
+            elif key == "sort" and isinstance(value, list):
+                sort_list = value
+            else:
+                filters[key] = value
+
+        query = Query(
+            filters=filters,
+            page=page,
+            page_size=page_size,
+            cursor=cursor,
+            start_date=start_date,
+            end_date=end_date,
+            fields=fields_list,
+            sort=sort_list,
+        )
         return self._adapter.query_records(self._ref, query)
 
     def get(self, **key: object) -> dict[str, object] | None:

--- a/tests/unit/core/test_dataset.py
+++ b/tests/unit/core/test_dataset.py
@@ -95,3 +95,45 @@ class TestDataset:
         adapter = MockAdapter()
         ds = Dataset(ref=_ref(), adapter=adapter)  # type: ignore[arg-type]
         assert "mock.test" in repr(ds)
+
+    def test_list_separates_canonical_query_fields(self) -> None:
+        adapter = MockAdapter()
+        ds = Dataset(ref=_ref(), adapter=adapter)  # type: ignore[arg-type]
+
+        ds.list(
+            start_date="202401",
+            end_date="202412",
+            page=2,
+            page_size=50,
+            region="서울",
+        )
+
+        assert adapter.last_query is not None
+        assert adapter.last_query.start_date == "202401"
+        assert adapter.last_query.end_date == "202412"
+        assert adapter.last_query.page == 2
+        assert adapter.last_query.page_size == 50
+        assert adapter.last_query.filters == {"region": "서울"}
+
+    def test_list_canonical_fields_not_in_filters(self) -> None:
+        adapter = MockAdapter()
+        ds = Dataset(ref=_ref(), adapter=adapter)  # type: ignore[arg-type]
+
+        ds.list(cursor="abc", fields=["name", "age"], sort=["name"])
+
+        assert adapter.last_query is not None
+        assert adapter.last_query.cursor == "abc"
+        assert adapter.last_query.fields == ["name", "age"]
+        assert adapter.last_query.sort == ["name"]
+        assert adapter.last_query.filters == {}
+
+    def test_list_only_filters_no_canonical(self) -> None:
+        adapter = MockAdapter()
+        ds = Dataset(ref=_ref(), adapter=adapter)  # type: ignore[arg-type]
+
+        ds.list(lawd_code="11680", deal_ym="202503")
+
+        assert adapter.last_query is not None
+        assert adapter.last_query.page is None
+        assert adapter.last_query.start_date is None
+        assert adapter.last_query.filters == {"lawd_code": "11680", "deal_ym": "202503"}


### PR DESCRIPTION
## Summary

- `Dataset.list()`에서 canonical query 파라미터(`page`, `page_size`, `cursor`, `start_date`, `end_date`, `fields`, `sort`)를 `Query`의 해당 필드로 분리합니다.
- 나머지 kwargs는 provider-specific `filters`로 전달됩니다.
- BOK, KOSIS 등 `start_date`/`end_date`를 canonical 필드로 읽는 adapter와의 정합성 확보

## Before

```python
ds.list(start_date="202401", end_date="202412", region="서울")
# → Query(filters={"start_date": "202401", "end_date": "202412", "region": "서울"})
```

## After

```python
ds.list(start_date="202401", end_date="202412", region="서울")
# → Query(start_date="202401", end_date="202412", filters={"region": "서울"})
```

## Changes

- `core/dataset.py`: `list()` 메서드에서 canonical 키 분리 로직 추가
- 테스트 3건 추가 (canonical 분리, 필터 전용, 혼합)

## Quality Gates

- ✅ `ruff check .` — All checks passed
- ✅ `ruff format --check .` — 71 files formatted
- ✅ `mypy src` — no issues found
- ✅ `pytest` — 294 passed

Closes #67