### PR TITLE
Delegate Catalog.search() to adapter.search_datasets()

### DIFF
--- a/src/kpubdata/catalog.py
+++ b/src/kpubdata/catalog.py
@@ -37,19 +37,24 @@ class Catalog:
         return datasets
 
     def search(self, text: str, *, provider: str | None = None) -> builtins.list[DatasetRef]:
-        """Search datasets by case-insensitive id or name matching.
+        """Search datasets by delegating to each adapter's search logic.
+
+        Each adapter implements its own ``search_datasets(text)`` method,
+        allowing provider-specific search semantics.
 
         Raises:
             ProviderNotRegisteredError: If ``provider`` is given but unknown.
         """
 
-        needle = text.casefold()
-        candidates = self.list(provider=provider)
-        return [
-            dataset
-            for dataset in candidates
-            if needle in dataset.id.casefold() or needle in dataset.name.casefold()
-        ]
+        if provider is not None:
+            adapter = self._get_adapter(provider)
+            return adapter.search_datasets(text)
+
+        results: builtins.list[DatasetRef] = []
+        for provider_name in self._registry:
+            adapter = self._get_adapter(provider_name)
+            results.extend(adapter.search_datasets(text))
+        return results
 
     def resolve(self, dataset_id: str) -> tuple[ProviderAdapter, DatasetRef]:
         """Resolve ``provider.dataset_key`` into an adapter and dataset ref.

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -103,6 +103,23 @@ class TestCatalog:
         result = catalog.search("ALPHA")
         assert len(result) == 2
 
+    def test_search_with_provider_filter(self) -> None:
+        catalog = self._build()
+        result = catalog.search("dataset", provider="alpha")
+        assert len(result) == 2
+        assert all(r.provider == "alpha" for r in result)
+
+    def test_search_delegates_to_adapter(self) -> None:
+        catalog = self._build()
+        result = catalog.search("subway")
+        assert len(result) == 1
+        assert result[0].name == "Beta Subway Data"
+
+    def test_search_no_match_returns_empty(self) -> None:
+        catalog = self._build()
+        result = catalog.search("nonexistent_xyz")
+        assert result == []
+
     def test_resolve(self) -> None:
         catalog = self._build()
         adapter, ref = catalog.resolve("beta.subway")


### PR DESCRIPTION
## Summary

- `Catalog.search()` now delegates to each adapter's `search_datasets(text)` instead of performing its own casefold string matching
- This activates the `ProviderAdapter.search_datasets()` Protocol method which was previously dead code
- Adapters can now implement provider-specific search logic (e.g., remote API search, fuzzy matching)

## Changes

- **`src/kpubdata/catalog.py`**: Rewrote `search()` to call `adapter.search_datasets(text)` for each registered provider, mirroring the delegation pattern already used in `list()`
- **`tests/unit/test_catalog.py`**: Added 3 tests — provider-filtered search, delegation verification, and no-match empty result

## Quality Gates

- [x] `ruff check .` — passed
- [x] `ruff format --check .` — passed
- [x] `mypy src` — passed
- [x] `pytest` — 294 passed
- [x] `python -m build` — passed

Closes #68