### PR TITLE
Extract shared adapter utilities into providers._common

### DIFF
--- a/src/kpubdata/providers/_common.py
+++ b/src/kpubdata/providers/_common.py
@@ -1,0 +1,177 @@
+"""Shared catalogue and schema utilities for provider adapters."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from importlib.resources import files
+from types import MappingProxyType
+from typing import cast
+
+from kpubdata.core.capability import Operation, PaginationMode, QuerySupport
+from kpubdata.core.models import (
+    DatasetRef,
+    FieldDescriptor,
+    SchemaDescriptor,
+)
+from kpubdata.core.representation import Representation
+
+
+def load_catalogue(package_name: str, provider: str) -> tuple[DatasetRef, ...]:
+    """Load and parse a catalogue.json from a provider package."""
+    package_files = files(package_name)
+    catalogue_text = package_files.joinpath("catalogue.json").read_text(encoding="utf-8")
+    parsed_catalogue = cast(object, json.loads(catalogue_text))
+    if not isinstance(parsed_catalogue, list):
+        msg = f"{provider} catalogue.json must contain a top-level JSON array"
+        raise ValueError(msg)
+
+    catalogue_entries = cast(list[object], parsed_catalogue)
+    datasets: list[DatasetRef] = []
+    for entry_object in catalogue_entries:
+        if not isinstance(entry_object, dict):
+            msg = f"{provider} catalogue entries must be JSON objects"
+            raise ValueError(msg)
+        typed_entry_object = cast(dict[object, object], entry_object)
+        entry: dict[str, object] = {}
+        for key, value in typed_entry_object.items():
+            if not isinstance(key, str):
+                msg = f"{provider} catalogue entry keys must be strings"
+                raise ValueError(msg)
+            entry[key] = value
+        datasets.append(build_dataset_ref(provider, entry))
+    return tuple(datasets)
+
+
+def build_dataset_ref(provider: str, entry: dict[str, object]) -> DatasetRef:
+    """Build a DatasetRef from a raw catalogue entry dict."""
+    dataset_key = require_string_field(entry, "dataset_key", provider)
+    name = require_string_field(entry, "name", provider)
+    representation_value = require_string_field(entry, "representation", provider)
+    representation = Representation(representation_value)
+
+    ops_raw_obj = entry.get("operations", [])
+    ops_raw = ops_raw_obj if isinstance(ops_raw_obj, list) else []
+    valid_ops = {member.value for member in Operation}
+    operations = frozenset(
+        Operation(op) for op in ops_raw if isinstance(op, str) and op in valid_ops
+    )
+
+    query_support = _parse_query_support(entry, provider)
+
+    raw_metadata = MappingProxyType(
+        {
+            key: value
+            for key, value in entry.items()
+            if key not in ("dataset_key", "name", "representation", "operations", "query_support")
+        }
+    )
+
+    return DatasetRef(
+        id=f"{provider}.{dataset_key}",
+        provider=provider,
+        dataset_key=dataset_key,
+        name=name,
+        representation=representation,
+        operations=operations,
+        query_support=query_support,
+        raw_metadata=raw_metadata,
+    )
+
+
+def _parse_query_support(entry: dict[str, object], provider: str) -> QuerySupport | None:
+    """Parse query_support from a catalogue entry."""
+    qs_raw_obj = entry.get("query_support")
+    if not isinstance(qs_raw_obj, dict):
+        return None
+
+    qs_raw = cast(dict[str, object], qs_raw_obj)
+    pagination_raw = qs_raw.get("pagination", "none")
+    valid_pagination = {member.value for member in PaginationMode}
+    pagination = (
+        PaginationMode(pagination_raw)
+        if isinstance(pagination_raw, str) and pagination_raw in valid_pagination
+        else PaginationMode.NONE
+    )
+
+    max_page_size = None
+    if "max_page_size" in qs_raw:
+        max_page_size_raw = qs_raw["max_page_size"]
+        if isinstance(max_page_size_raw, int):
+            max_page_size = max_page_size_raw
+        elif isinstance(max_page_size_raw, str):
+            max_page_size = int(max_page_size_raw)
+        else:
+            msg = f"{provider} query_support.max_page_size must be int-like"
+            raise ValueError(msg)
+
+    return QuerySupport(pagination=pagination, max_page_size=max_page_size)
+
+
+def build_schema_from_metadata(dataset: DatasetRef) -> SchemaDescriptor | None:
+    """Build SchemaDescriptor from catalogue metadata fields."""
+    fields_raw = dataset.raw_metadata.get("fields")
+    if not isinstance(fields_raw, list) or not fields_raw:
+        return None
+
+    entries = cast(list[object], fields_raw)
+    field_descriptors: list[FieldDescriptor] = []
+    for entry_obj in entries:
+        if not isinstance(entry_obj, dict):
+            continue
+        entry = cast(dict[str, object], entry_obj)
+        name_raw = entry.get("name")
+        if not isinstance(name_raw, str) or not name_raw:
+            continue
+        title_raw = entry.get("title")
+        type_raw = entry.get("type")
+        desc_raw = entry.get("description")
+        nullable_raw = entry.get("nullable")
+        field_descriptors.append(
+            FieldDescriptor(
+                name=name_raw,
+                title=title_raw if isinstance(title_raw, str) else None,
+                type=type_raw if isinstance(type_raw, str) else None,
+                description=desc_raw if isinstance(desc_raw, str) else None,
+                nullable=nullable_raw if isinstance(nullable_raw, bool) else None,
+                raw=MappingProxyType({k: v for k, v in entry.items() if k != "name"}),
+            )
+        )
+
+    if not field_descriptors:
+        return None
+
+    return SchemaDescriptor(
+        dataset=dataset,
+        fields=field_descriptors,
+        raw=MappingProxyType({"source": "catalogue"}),
+    )
+
+
+def coerce_int(value: object, default: int) -> int:
+    """Coerce a value to int, returning default on failure."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    return default
+
+
+def require_string_field(entry: Mapping[str, object], field_name: str, provider: str) -> str:
+    """Extract a required non-empty string field from a catalogue entry."""
+    value = entry.get(field_name)
+    if isinstance(value, str) and value:
+        return value
+    raise ValueError(f"{provider} catalogue entry missing non-empty string field: {field_name}")
+
+
+__all__ = [
+    "build_dataset_ref",
+    "build_schema_from_metadata",
+    "coerce_int",
+    "load_catalogue",
+    "require_string_field",
+]

--- a/src/kpubdata/providers/bok/adapter.py
+++ b/src/kpubdata/providers/bok/adapter.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import NoReturn, cast
+
+from kpubdata.config import KPubDataConfig
+from kpubdata.core.models import (
+    DatasetRef,
+    Query,
+    RecordBatch,
+    SchemaDescriptor,
+)
+from kpubdata.exceptions import (
+    AuthError,
+    DatasetNotFoundError,
+    InvalidRequestError,
+    ParseError,
+    ProviderResponseError,
+    RateLimitError,
+    ServiceUnavailableError,
+)
+from kpubdata.providers._common import build_schema_from_metadata, coerce_int, load_catalogue
+from kpubdata.transport.decode import decode_json, detect_content_type
+from kpubdata.transport.http import HttpTransport, TransportConfig
+
+logger = logging.getLogger("kpubdata.provider.bok")
+
+
+class BokAdapter:
+    def __init__(
+        self,
+        *,
+        config: KPubDataConfig | None = None,
+        transport: HttpTransport | None = None,
+        catalogue: Sequence[DatasetRef] | None = None,
+    ) -> None:
+        self._config: KPubDataConfig = config or KPubDataConfig()
+        transport_config = TransportConfig(
+            timeout=self._config.timeout,
+            max_retries=self._config.max_retries,
+        )
+        self._transport: HttpTransport = transport or HttpTransport(transport_config)
+
+        datasets = tuple(catalogue) if catalogue is not None else self._load_default_catalogue()
+        self._datasets: tuple[DatasetRef, ...] = datasets
+        self._datasets_by_key: dict[str, DatasetRef] = {
+            dataset.dataset_key: dataset for dataset in self._datasets
+        }
+
+    @property
+    def name(self) -> str:
+        return "bok"
+
+    def list_datasets(self) -> list[DatasetRef]:
+        return list(self._datasets)
+
+    def search_datasets(self, text: str) -> list[DatasetRef]:
+        needle = text.casefold()
+        return [
+            dataset
+            for dataset in self._datasets
+            if needle in dataset.id.casefold() or needle in dataset.name.casefold()
+        ]
+
+    def get_dataset(self, dataset_key: str) -> DatasetRef:
+        dataset = self._datasets_by_key.get(dataset_key)
+        if dataset is not None:
+            return dataset
+
+        raise DatasetNotFoundError(
+            f"Dataset not found: bok.{dataset_key}",
+            provider="bok",
+            dataset_id=f"bok.{dataset_key}",
+        )
+
+    def query_records(self, dataset: DatasetRef, query: Query) -> RecordBatch:
+        page = query.page or 1
+        page_size = query.page_size or 10
+        frequency = self._resolve_frequency(query)
+        start_date = query.start_date or self._resolve_string_param(query, "start_date")
+        end_date = query.end_date or self._resolve_string_param(query, "end_date")
+
+        if start_date is None or end_date is None:
+            raise InvalidRequestError(
+                "BOK ECOS queries require start_date and end_date",
+                provider="bok",
+                dataset_id=dataset.id,
+            )
+
+        all_items: list[dict[str, object]] = []
+        raw_pages: list[dict[str, object]] = []
+        total_count: int | None = None
+
+        while True:
+            start_index = (page - 1) * page_size + 1
+            end_index = page * page_size
+            url = self._build_request_url(
+                dataset,
+                operation=None,
+                start_index=start_index,
+                end_index=end_index,
+                frequency=frequency,
+                start_date=start_date,
+                end_date=end_date,
+            )
+
+            payload = self._request_and_decode(url)
+            raw_pages.append(payload)
+
+            body, items = self._validate_envelope(payload, dataset.id)
+            all_items.extend(items)
+
+            total_count = coerce_int(body.get("list_total_count"), 0)
+            if not items:
+                break
+            if len(items) < page_size:
+                break
+            if page * page_size >= total_count:
+                break
+
+            page += 1
+
+        return RecordBatch(
+            items=all_items,
+            dataset=dataset,
+            total_count=total_count,
+            next_page=None,
+            raw=raw_pages,
+        )
+
+    def get_record(self, _dataset: DatasetRef, _key: dict[str, object]) -> dict[str, object] | None:
+        raise NotImplementedError("TODO: implement bok get_record")
+
+    def get_schema(self, dataset: DatasetRef) -> SchemaDescriptor | None:
+        return build_schema_from_metadata(dataset)
+
+    def call_raw(self, dataset: DatasetRef, operation: str, params: dict[str, object]) -> object:
+        frequency = self._string_param(params, "frequency") or "M"
+        start_date = self._require_param(params, "start_date")
+        end_date = self._require_param(params, "end_date")
+        start_index = self._int_param(params, "start_index", 1)
+        end_index = self._int_param(params, "end_index", 10)
+
+        url = self._build_request_url(
+            dataset,
+            operation=operation,
+            start_index=start_index,
+            end_index=end_index,
+            frequency=frequency,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        payload = self._request_and_decode(url)
+        _ = self._validate_envelope(payload, dataset.id)
+        return payload
+
+    def _require_api_key(self) -> str:
+        return self._config.require_provider_key("bok")
+
+    def _build_request_url(
+        self,
+        dataset: DatasetRef,
+        *,
+        operation: str | None,
+        start_index: int,
+        end_index: int,
+        frequency: str,
+        start_date: str,
+        end_date: str,
+    ) -> str:
+        base_url_raw = dataset.raw_metadata.get("base_url")
+        if not isinstance(base_url_raw, str) or not base_url_raw:
+            raise ProviderResponseError(
+                "Dataset metadata missing base_url",
+                provider="bok",
+                dataset_id=dataset.id,
+            )
+
+        selected_operation = operation or dataset.raw_metadata.get("default_operation")
+        if not isinstance(selected_operation, str) or not selected_operation:
+            raise ProviderResponseError(
+                "Dataset metadata missing default_operation",
+                provider="bok",
+                dataset_id=dataset.id,
+            )
+
+        stat_code = self._require_dataset_metadata(dataset, "stat_code")
+        item_code1 = self._require_dataset_metadata(dataset, "item_code1")
+        api_key = self._require_api_key()
+        return (
+            f"{base_url_raw}/{api_key}/json/{selected_operation}/"
+            f"{start_index}/{end_index}/{stat_code}/{frequency}/{start_date}/{end_date}/{item_code1}"
+        )
+
+    def _request_and_decode(self, url: str) -> dict[str, object]:
+        response = self._transport.request("GET", url)
+
+        try:
+            content_type = detect_content_type(response)
+            decoded_obj: object = (
+                cast(object, decode_json(response.content))
+                if content_type == "json"
+                else cast(object, decode_json(response.content))
+            )
+        except ValueError as exc:
+            raise ParseError("Failed to parse BOK ECOS response", provider="bok") from exc
+
+        if isinstance(decoded_obj, dict):
+            return cast(dict[str, object], decoded_obj)
+
+        raise ParseError("Decoded payload is not an object", provider="bok")
+
+    def _validate_envelope(
+        self, payload: dict[str, object], dataset_id: str = ""
+    ) -> tuple[dict[str, object], list[dict[str, object]]]:
+        self._raise_for_result(payload, dataset_id)
+
+        body_obj = payload.get("StatisticSearch")
+        if not isinstance(body_obj, dict):
+            raise ProviderResponseError(
+                "Malformed response envelope: missing StatisticSearch",
+                provider="bok",
+                dataset_id=dataset_id or None,
+            )
+
+        body_dict = cast(dict[str, object], body_obj)
+        items = self._normalize_rows(body_dict.get("row"))
+        return body_dict, items
+
+    def _raise_for_result(self, payload: Mapping[str, object], dataset_id: str) -> None:
+        result_obj = payload.get("RESULT")
+        if not isinstance(result_obj, dict):
+            return
+
+        result_dict = cast(dict[str, object], result_obj)
+        code_raw = result_dict.get("CODE")
+        message_raw = result_dict.get("MESSAGE")
+        code = code_raw if isinstance(code_raw, str) else "ERROR"
+        message = message_raw if isinstance(message_raw, str) else "Provider returned error"
+        logger.debug(
+            "BOK ECOS result",
+            extra={"result_code": code, "result_msg": message, "dataset_id": dataset_id},
+        )
+
+        if code != "ERROR":
+            return
+
+        self._raise_for_result_code(code, message, dataset_id)
+
+    def _raise_for_result_code(self, code: str, msg: str, dataset_id: str) -> NoReturn:
+        normalized_msg = msg.casefold()
+        if "인증키" in msg or "api key" in normalized_msg or "auth" in normalized_msg:
+            raise AuthError(msg, provider="bok", provider_code=code, dataset_id=dataset_id or None)
+        if "호출한도" in msg or "too many" in normalized_msg or "rate limit" in normalized_msg:
+            raise RateLimitError(
+                msg, provider="bok", provider_code=code, dataset_id=dataset_id or None
+            )
+        if (
+            "점검" in msg
+            or "service unavailable" in normalized_msg
+            or "temporarily unavailable" in normalized_msg
+        ):
+            raise ServiceUnavailableError(
+                msg,
+                provider="bok",
+                provider_code=code,
+                dataset_id=dataset_id or None,
+            )
+        if "필수" in msg or "invalid" in normalized_msg or "잘못" in msg:
+            raise InvalidRequestError(
+                msg, provider="bok", provider_code=code, dataset_id=dataset_id or None
+            )
+        raise ProviderResponseError(
+            msg, provider="bok", provider_code=code, dataset_id=dataset_id or None
+        )
+
+    def _resolve_frequency(self, query: Query) -> str:
+        return self._resolve_string_param(query, "frequency") or "M"
+
+    def _resolve_string_param(self, query: Query, key: str) -> str | None:
+        if key in query.extra:
+            value = cast(object, query.extra[key])
+            if isinstance(value, str) and value:
+                return value
+        if key in query.filters:
+            value = cast(object, query.filters[key])
+            if isinstance(value, str) and value:
+                return value
+        return None
+
+    def _require_dataset_metadata(self, dataset: DatasetRef, key: str) -> str:
+        value = dataset.raw_metadata.get(key)
+        if isinstance(value, str) and value:
+            return value
+        raise ProviderResponseError(
+            f"Dataset metadata missing {key}",
+            provider="bok",
+            dataset_id=dataset.id,
+        )
+
+    def _normalize_rows(self, rows_wrapper: object) -> list[dict[str, object]]:
+        if rows_wrapper is None:
+            return []
+        if isinstance(rows_wrapper, list):
+            rows = cast(list[object], rows_wrapper)
+            return [cast(dict[str, object], item) for item in rows if isinstance(item, dict)]
+        if isinstance(rows_wrapper, dict):
+            return [cast(dict[str, object], rows_wrapper)]
+        return []
+
+    @staticmethod
+    def _string_param(params: Mapping[str, object], key: str) -> str | None:
+        value = params.get(key)
+        if isinstance(value, str) and value:
+            return value
+        return None
+
+    @classmethod
+    def _require_param(cls, params: Mapping[str, object], key: str) -> str:
+        value = cls._string_param(params, key)
+        if value is not None:
+            return value
+        raise InvalidRequestError(f"BOK ECOS raw calls require {key}", provider="bok")
+
+    @classmethod
+    def _int_param(cls, params: Mapping[str, object], key: str, default: int) -> int:
+        value = params.get(key)
+        coerced = coerce_int(value, default)
+        return coerced if coerced > 0 else default
+
+    @staticmethod
+    def _load_default_catalogue() -> tuple[DatasetRef, ...]:
+        return load_catalogue("kpubdata.providers.bok", "bok")
+
+
+__all__ = ["BokAdapter"]

--- a/src/kpubdata/providers/datago/adapter.py
+++ b/src/kpubdata/providers/datago/adapter.py
@@ -2,23 +2,17 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import Mapping, Sequence
-from importlib.resources import files
-from types import MappingProxyType
 from typing import NoReturn, cast
 
 from kpubdata.config import KPubDataConfig
-from kpubdata.core.capability import Operation, PaginationMode, QuerySupport
 from kpubdata.core.models import (
     DatasetRef,
-    FieldDescriptor,
     Query,
     RecordBatch,
     SchemaDescriptor,
 )
-from kpubdata.core.representation import Representation
 from kpubdata.exceptions import (
     AuthError,
     DatasetNotFoundError,
@@ -28,6 +22,7 @@ from kpubdata.exceptions import (
     RateLimitError,
     ServiceUnavailableError,
 )
+from kpubdata.providers._common import build_schema_from_metadata, coerce_int, load_catalogue
 from kpubdata.transport.decode import decode_json, decode_xml, detect_content_type
 from kpubdata.transport.http import HttpTransport, TransportConfig
 
@@ -124,8 +119,8 @@ class DataGoAdapter:
             body, items = self._validate_envelope(payload, dataset.id)
             all_items.extend(items)
 
-            total_count = self._coerce_int(body.get("totalCount"), 0)
-            current_num_of_rows = self._coerce_int(body.get("numOfRows"), page_size)
+            total_count = coerce_int(body.get("totalCount"), 0)
+            current_num_of_rows = coerce_int(body.get("numOfRows"), page_size)
 
             if not items:
                 break
@@ -157,41 +152,7 @@ class DataGoAdapter:
         returns ``None`` for datasets without explicitly curated field
         definitions in the catalogue.
         """
-        fields_raw = dataset.raw_metadata.get("fields")
-        if not isinstance(fields_raw, list) or not fields_raw:
-            return None
-
-        field_descriptors: list[FieldDescriptor] = []
-        for entry_obj in fields_raw:
-            if not isinstance(entry_obj, dict):
-                continue
-            entry = cast(dict[str, object], entry_obj)
-            name_raw = entry.get("name")
-            if not isinstance(name_raw, str) or not name_raw:
-                continue
-            title_raw = entry.get("title")
-            type_raw = entry.get("type")
-            desc_raw = entry.get("description")
-            nullable_raw = entry.get("nullable")
-            field_descriptors.append(
-                FieldDescriptor(
-                    name=name_raw,
-                    title=title_raw if isinstance(title_raw, str) else None,
-                    type=type_raw if isinstance(type_raw, str) else None,
-                    description=desc_raw if isinstance(desc_raw, str) else None,
-                    nullable=nullable_raw if isinstance(nullable_raw, bool) else None,
-                    raw=MappingProxyType({k: v for k, v in entry.items() if k != "name"}),
-                )
-            )
-
-        if not field_descriptors:
-            return None
-
-        return SchemaDescriptor(
-            dataset=dataset,
-            fields=field_descriptors,
-            raw=MappingProxyType({"source": "catalogue"}),
-        )
+        return build_schema_from_metadata(dataset)
 
     def call_raw(self, dataset: DatasetRef, operation: str, params: dict[str, object]) -> object:
         """Call provider-native data.go.kr API operation."""
@@ -342,113 +303,8 @@ class DataGoAdapter:
         return []
 
     @staticmethod
-    def _coerce_int(value: object, default: int) -> int:
-        if isinstance(value, int):
-            return value
-        if isinstance(value, str):
-            try:
-                return int(value)
-            except ValueError:
-                return default
-        return default
-
-    @staticmethod
     def _load_default_catalogue() -> tuple[DatasetRef, ...]:
-        package_files = files("kpubdata.providers.datago")
-        catalogue_text = package_files.joinpath("catalogue.json").read_text(encoding="utf-8")
-        parsed_catalogue = cast(object, json.loads(catalogue_text))
-        if not isinstance(parsed_catalogue, list):
-            msg = "datago catalogue.json must contain a top-level JSON array"
-            raise ValueError(msg)
-
-        catalogue_entries = cast(list[object], parsed_catalogue)
-        datasets: list[DatasetRef] = []
-        for entry_object in catalogue_entries:
-            if not isinstance(entry_object, dict):
-                msg = "datago catalogue entries must be JSON objects"
-                raise ValueError(msg)
-            typed_entry_object = cast(dict[object, object], entry_object)
-            entry: dict[str, object] = {}
-            for key, value in typed_entry_object.items():
-                if not isinstance(key, str):
-                    msg = "datago catalogue entry keys must be strings"
-                    raise ValueError(msg)
-                entry[key] = value
-            datasets.append(DataGoAdapter._build_dataset_ref(entry))
-        return tuple(datasets)
-
-    @staticmethod
-    def _build_dataset_ref(entry: dict[str, object]) -> DatasetRef:
-        dataset_key = DataGoAdapter._require_string_field(entry, "dataset_key")
-        name = DataGoAdapter._require_string_field(entry, "name")
-        representation_value = DataGoAdapter._require_string_field(entry, "representation")
-        representation = Representation(representation_value)
-        ops_raw_obj = entry.get("operations", [])
-        ops_raw = ops_raw_obj if isinstance(ops_raw_obj, list) else []
-        operations = frozenset(
-            Operation(op)
-            for op in ops_raw
-            if isinstance(op, str) and op in {member.value for member in Operation}
-        )
-
-        qs_raw_obj = entry.get("query_support")
-        query_support = None
-        if isinstance(qs_raw_obj, dict):
-            qs_raw = cast(dict[str, object], qs_raw_obj)
-            pagination_raw = qs_raw.get("pagination", "none")
-            pagination = (
-                PaginationMode(pagination_raw)
-                if isinstance(pagination_raw, str)
-                and pagination_raw in {member.value for member in PaginationMode}
-                else PaginationMode.NONE
-            )
-            max_page_size = None
-            if "max_page_size" in qs_raw:
-                max_page_size_raw = qs_raw["max_page_size"]
-                if isinstance(max_page_size_raw, int):
-                    max_page_size = max_page_size_raw
-                elif isinstance(max_page_size_raw, str):
-                    max_page_size = int(max_page_size_raw)
-                else:
-                    msg = "datago query_support.max_page_size must be int-like"
-                    raise ValueError(msg)
-            query_support = QuerySupport(
-                pagination=pagination,
-                max_page_size=max_page_size,
-            )
-
-        raw_metadata = MappingProxyType(
-            {
-                key: value
-                for key, value in entry.items()
-                if key
-                not in (
-                    "dataset_key",
-                    "name",
-                    "representation",
-                    "operations",
-                    "query_support",
-                )
-            }
-        )
-
-        return DatasetRef(
-            id=f"datago.{dataset_key}",
-            provider="datago",
-            dataset_key=dataset_key,
-            name=name,
-            representation=representation,
-            operations=operations,
-            query_support=query_support,
-            raw_metadata=raw_metadata,
-        )
-
-    @staticmethod
-    def _require_string_field(entry: Mapping[str, object], field_name: str) -> str:
-        value = entry.get(field_name)
-        if isinstance(value, str) and value:
-            return value
-        raise ValueError(f"datago catalogue entry missing non-empty string field: {field_name}")
+        return load_catalogue("kpubdata.providers.datago", "datago")
 
 
 __all__ = ["DataGoAdapter"]

--- a/src/kpubdata/providers/kosis/adapter.py
+++ b/src/kpubdata/providers/kosis/adapter.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import NoReturn, cast
+from urllib.parse import urlencode
+
+from kpubdata.config import KPubDataConfig
+from kpubdata.core.models import (
+    DatasetRef,
+    Query,
+    RecordBatch,
+    SchemaDescriptor,
+)
+from kpubdata.exceptions import (
+    AuthError,
+    DatasetNotFoundError,
+    InvalidRequestError,
+    ParseError,
+    ProviderResponseError,
+)
+from kpubdata.providers._common import build_schema_from_metadata, load_catalogue
+from kpubdata.transport.decode import decode_json
+from kpubdata.transport.http import HttpTransport, TransportConfig
+
+logger = logging.getLogger("kpubdata.provider.kosis")
+
+
+class KosisAdapter:
+    def __init__(
+        self,
+        *,
+        config: KPubDataConfig | None = None,
+        transport: HttpTransport | None = None,
+        catalogue: Sequence[DatasetRef] | None = None,
+    ) -> None:
+        self._config: KPubDataConfig = config or KPubDataConfig()
+        transport_config = TransportConfig(
+            timeout=self._config.timeout,
+            max_retries=self._config.max_retries,
+        )
+        self._transport: HttpTransport = transport or HttpTransport(transport_config)
+
+        datasets = tuple(catalogue) if catalogue is not None else self._load_default_catalogue()
+        self._datasets: tuple[DatasetRef, ...] = datasets
+        self._datasets_by_key: dict[str, DatasetRef] = {
+            dataset.dataset_key: dataset for dataset in self._datasets
+        }
+
+    @property
+    def name(self) -> str:
+        return "kosis"
+
+    def list_datasets(self) -> list[DatasetRef]:
+        return list(self._datasets)
+
+    def search_datasets(self, text: str) -> list[DatasetRef]:
+        needle = text.casefold()
+        return [
+            dataset
+            for dataset in self._datasets
+            if needle in dataset.id.casefold() or needle in dataset.name.casefold()
+        ]
+
+    def get_dataset(self, dataset_key: str) -> DatasetRef:
+        dataset = self._datasets_by_key.get(dataset_key)
+        if dataset is not None:
+            return dataset
+
+        raise DatasetNotFoundError(
+            f"Dataset not found: kosis.{dataset_key}",
+            provider="kosis",
+            dataset_id=f"kosis.{dataset_key}",
+        )
+
+    def query_records(self, dataset: DatasetRef, query: Query) -> RecordBatch:
+        url = self._build_request_url(dataset, query)
+        payload = self._request_and_decode(url)
+        items = self._extract_items(payload, dataset.id)
+
+        return RecordBatch(
+            items=items,
+            dataset=dataset,
+            total_count=len(items),
+            next_page=None,
+            raw=payload,
+        )
+
+    def get_record(self, _dataset: DatasetRef, _key: dict[str, object]) -> dict[str, object] | None:
+        raise NotImplementedError("TODO: implement kosis get_record")
+
+    def get_schema(self, dataset: DatasetRef) -> SchemaDescriptor | None:
+        return build_schema_from_metadata(dataset)
+
+    def call_raw(self, dataset: DatasetRef, operation: str, params: dict[str, object]) -> object:
+        url = self._build_raw_url(dataset, operation, params)
+        payload = self._request_and_decode(url)
+        if isinstance(payload, dict):
+            self._raise_for_error_payload(cast(dict[str, object], payload), dataset.id)
+        return payload
+
+    def _require_api_key(self) -> str:
+        return self._config.require_provider_key("kosis")
+
+    def _build_request_url(self, dataset: DatasetRef, query: Query) -> str:
+        start_date = query.start_date
+        end_date = query.end_date
+        if not isinstance(start_date, str) or not start_date:
+            raise InvalidRequestError(
+                "KOSIS queries require start_date",
+                provider="kosis",
+                dataset_id=dataset.id,
+            )
+        if not isinstance(end_date, str) or not end_date:
+            raise InvalidRequestError(
+                "KOSIS queries require end_date",
+                provider="kosis",
+                dataset_id=dataset.id,
+            )
+
+        filters: dict[str, object] = dict(query.filters)
+        params = self._build_base_params(dataset)
+        params["startPrdDe"] = start_date
+        params["endPrdDe"] = end_date
+
+        reserved = {key.casefold() for key in params}
+        for key in ("objL1", "objL2", "itmId", "prdSe"):
+            if key in filters:
+                params[key] = str(filters.pop(key))
+
+        for key, value in filters.items():
+            if key.casefold() not in reserved:
+                params[key] = str(value)
+
+        return self._compose_url(dataset, params)
+
+    def _build_raw_url(
+        self,
+        dataset: DatasetRef,
+        operation: str,
+        params: Mapping[str, object],
+    ) -> str:
+        request_params = self._build_base_params(dataset)
+        selected_operation = operation.strip()
+        if selected_operation and selected_operation != "statisticsParameterData":
+            request_params["operation"] = selected_operation
+        for key, value in params.items():
+            if key != "apiKey":
+                request_params[key] = str(value)
+        return self._compose_url(dataset, request_params)
+
+    def _build_base_params(self, dataset: DatasetRef) -> dict[str, str]:
+        api_key = self._require_api_key()
+        org_id = self._require_dataset_metadata(dataset, "org_id")
+        tbl_id = self._require_dataset_metadata(dataset, "tbl_id")
+        return {
+            "apiKey": api_key,
+            "format": "json",
+            "jsonVD": "Y",
+            "orgId": org_id,
+            "tblId": tbl_id,
+            "objL1": "ALL",
+            "objL2": "ALL",
+            "itmId": "ALL",
+            "prdSe": "M",
+        }
+
+    def _compose_url(self, dataset: DatasetRef, params: Mapping[str, str]) -> str:
+        base_url = self._require_dataset_metadata(dataset, "base_url")
+        query_string = urlencode(params)
+        return f"{base_url}?{query_string}"
+
+    def _request_and_decode(self, url: str) -> object:
+        response = self._transport.request("GET", url)
+
+        try:
+            decoded = cast(object, decode_json(response.content))
+        except ValueError as exc:
+            raise ParseError("Failed to parse KOSIS response", provider="kosis") from exc
+
+        if isinstance(decoded, list):
+            return cast(list[object], decoded)
+        if isinstance(decoded, dict):
+            return cast(dict[str, object], decoded)
+
+        raise ParseError("Decoded payload is neither an object nor an array", provider="kosis")
+
+    def _extract_items(self, payload: object, dataset_id: str) -> list[dict[str, object]]:
+        if isinstance(payload, dict):
+            self._raise_for_error_payload(cast(dict[str, object], payload), dataset_id)
+
+        if not isinstance(payload, list):
+            raise ProviderResponseError(
+                "Malformed KOSIS response: expected array payload",
+                provider="kosis",
+                dataset_id=dataset_id,
+            )
+
+        payload_items = cast(list[object], payload)
+        return [cast(dict[str, object], item) for item in payload_items if isinstance(item, dict)]
+
+    def _raise_for_error_payload(self, payload: Mapping[str, object], dataset_id: str) -> NoReturn:
+        code_raw = payload.get("err")
+        message_raw = payload.get("errMsg")
+        code = code_raw if isinstance(code_raw, str) else None
+        message = message_raw if isinstance(message_raw, str) else "KOSIS returned an error"
+
+        logger.debug(
+            "KOSIS error response",
+            extra={"provider_code": code, "message": message, "dataset_id": dataset_id},
+        )
+
+        if code == "30":
+            raise AuthError(
+                message,
+                provider="kosis",
+                dataset_id=dataset_id,
+                provider_code=code,
+                detail=dict(payload),
+            )
+        if code == "10":
+            raise InvalidRequestError(
+                message,
+                provider="kosis",
+                dataset_id=dataset_id,
+                provider_code=code,
+                detail=dict(payload),
+            )
+        raise ProviderResponseError(
+            message,
+            provider="kosis",
+            dataset_id=dataset_id,
+            provider_code=code,
+            detail=dict(payload),
+        )
+
+    @staticmethod
+    def _require_dataset_metadata(dataset: DatasetRef, field_name: str) -> str:
+        value = dataset.raw_metadata.get(field_name)
+        if isinstance(value, str) and value:
+            return value
+        raise ProviderResponseError(
+            f"Dataset metadata missing {field_name}",
+            provider="kosis",
+            dataset_id=dataset.id,
+        )
+
+    @staticmethod
+    def _load_default_catalogue() -> tuple[DatasetRef, ...]:
+        return load_catalogue("kpubdata.providers.kosis", "kosis")
+
+
+__all__ = ["KosisAdapter"]

--- a/tests/unit/providers/datago/test_adapter_coverage.py
+++ b/tests/unit/providers/datago/test_adapter_coverage.py
@@ -9,6 +9,7 @@ from kpubdata.config import KPubDataConfig
 from kpubdata.core.models import DatasetRef, Query
 from kpubdata.core.representation import Representation
 from kpubdata.exceptions import ParseError, ProviderResponseError
+from kpubdata.providers._common import build_dataset_ref, coerce_int, require_string_field
 from kpubdata.providers.datago.adapter import DataGoAdapter
 from kpubdata.transport.http import HttpTransport
 
@@ -246,11 +247,11 @@ def test_normalize_items_returns_empty_for_unsupported_wrapper() -> None:
 
 
 def test_coerce_int_returns_default_for_non_numeric_string() -> None:
-    assert DataGoAdapter._coerce_int("not-a-number", 7) == 7
+    assert coerce_int("not-a-number", 7) == 7
 
 
 def test_coerce_int_returns_default_for_non_string_non_int() -> None:
-    assert DataGoAdapter._coerce_int(3.14, 11) == 11
+    assert coerce_int(3.14, 11) == 11
 
 
 class _FakeCatalogueFile:
@@ -271,42 +272,43 @@ class _FakePackageFiles:
 
 
 def test_load_default_catalogue_raises_when_top_level_json_not_list(monkeypatch) -> None:
-    import kpubdata.providers.datago.adapter as adapter_module
+    import kpubdata.providers._common as common_module
 
-    monkeypatch.setattr(adapter_module, "files", lambda _pkg: _FakePackageFiles("{}"))
+    monkeypatch.setattr(common_module, "files", lambda _pkg: _FakePackageFiles("{}"))
 
     with pytest.raises(ValueError, match="top-level JSON array"):
         _ = DataGoAdapter._load_default_catalogue()
 
 
 def test_load_default_catalogue_raises_when_entry_not_dict(monkeypatch) -> None:
-    import kpubdata.providers.datago.adapter as adapter_module
+    import kpubdata.providers._common as common_module
 
-    monkeypatch.setattr(adapter_module, "files", lambda _pkg: _FakePackageFiles("[1]"))
+    monkeypatch.setattr(common_module, "files", lambda _pkg: _FakePackageFiles("[1]"))
 
     with pytest.raises(ValueError, match="entries must be JSON objects"):
         _ = DataGoAdapter._load_default_catalogue()
 
 
 def test_load_default_catalogue_raises_when_entry_key_not_string(monkeypatch) -> None:
-    import kpubdata.providers.datago.adapter as adapter_module
+    import kpubdata.providers._common as common_module
 
-    monkeypatch.setattr(adapter_module, "files", lambda _pkg: _FakePackageFiles("[]"))
-    monkeypatch.setattr(adapter_module.json, "loads", lambda _text: [{1: "bad-key"}])
+    monkeypatch.setattr(common_module, "files", lambda _pkg: _FakePackageFiles("[]"))
+    monkeypatch.setattr(common_module.json, "loads", lambda _text: [{1: "bad-key"}])
 
     with pytest.raises(ValueError, match="entry keys must be strings"):
         _ = DataGoAdapter._load_default_catalogue()
 
 
 def test_build_dataset_ref_parses_string_max_page_size() -> None:
-    dataset = DataGoAdapter._build_dataset_ref(
+    dataset = build_dataset_ref(
+        "datago",
         {
             "dataset_key": "test",
             "name": "Test",
             "representation": "api_json",
             "query_support": {"pagination": "offset", "max_page_size": "250"},
             "base_url": "https://example.test",
-        }
+        },
     )
 
     assert dataset.query_support is not None
@@ -315,16 +317,17 @@ def test_build_dataset_ref_parses_string_max_page_size() -> None:
 
 def test_build_dataset_ref_raises_for_invalid_max_page_size_type() -> None:
     with pytest.raises(ValueError, match="max_page_size must be int-like"):
-        _ = DataGoAdapter._build_dataset_ref(
+        _ = build_dataset_ref(
+            "datago",
             {
                 "dataset_key": "test",
                 "name": "Test",
                 "representation": "api_json",
                 "query_support": {"pagination": "offset", "max_page_size": {}},
-            }
+            },
         )
 
 
 def test_require_string_field_raises_when_field_missing() -> None:
     with pytest.raises(ValueError, match="missing non-empty string field"):
-        _ = DataGoAdapter._require_string_field({}, "dataset_key")
+        _ = require_string_field({}, "dataset_key", "datago")


### PR DESCRIPTION
## Summary

- Created `src/kpubdata/providers/_common.py` with shared utilities extracted from 3 adapter implementations
- Refactored `datago`, `bok`, and `kosis` adapters to use the common module, eliminating ~150 lines of duplication per adapter

## Extracted Utilities

| Function | Purpose |
|:---|:---|
| `load_catalogue(package_name, provider)` | Parse catalogue.json from a provider package |
| `build_dataset_ref(provider, entry)` | Build DatasetRef from raw catalogue entry |
| `build_schema_from_metadata(dataset)` | Build SchemaDescriptor from catalogue metadata |
| `coerce_int(value, default)` | Safe int coercion with fallback |
| `require_string_field(entry, field_name, provider)` | Extract required non-empty string field |

## Not Extracted (adapter-specific, per issue specification)

- Envelope parsing (`_validate_envelope`)
- URL construction (`_build_request_url`)
- Error mapping (`_raise_for_result_code`)
- Authentication (`_require_api_key`)

## Quality Gates

- [x] `ruff check .` — passed
- [x] `ruff format --check .` — passed
- [x] `mypy src` — passed (28 source files)
- [x] `pytest` — 291 passed
- [x] `python -m build` — passed

Closes #69