### PR TITLE
refactor: replace Any with object in data model fields and transport layer

### DIFF
--- a/src/kpubdata/config.py
+++ b/src/kpubdata/config.py
@@ -25,7 +25,7 @@ class KPubDataConfig:
     provider_keys: dict[str, str] = field(default_factory=dict)
     timeout: float = 30.0
     max_retries: int = 3
-    extra: dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, object] = field(default_factory=dict)
 
     def __repr__(self) -> str:
         """Return concise debug representation without exposing secrets."""

--- a/src/kpubdata/core/dataset.py
+++ b/src/kpubdata/core/dataset.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from kpubdata.core.capability import Operation
 from kpubdata.core.models import DatasetRef, Query, RecordBatch, SchemaDescriptor
 from kpubdata.core.protocol import ProviderAdapter
@@ -51,7 +49,7 @@ class Dataset:
 
         return self._ref.operations
 
-    def list(self, **filters: Any) -> RecordBatch:
+    def list(self, **filters: object) -> RecordBatch:
         """Query records from this dataset using canonical list semantics.
 
         Pass provider-specific query parameters as keyword arguments.
@@ -70,7 +68,7 @@ class Dataset:
         query = Query(filters=filters)
         return self._adapter.query_records(self._ref, query)
 
-    def get(self, **key: Any) -> dict[str, object] | None:
+    def get(self, **key: object) -> dict[str, object] | None:
         """Return a single record matching the provided key fields.
 
         Return ``None`` when no matching record is found.
@@ -94,7 +92,7 @@ class Dataset:
 
         return self._adapter.get_schema(self._ref)
 
-    def call_raw(self, operation: str, **params: Any) -> object:
+    def call_raw(self, operation: str, **params: object) -> object:
         """Execute a provider-native operation without canonical normalization.
 
         Use this escape hatch for provider features not represented in the

--- a/src/kpubdata/core/models.py
+++ b/src/kpubdata/core/models.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass as _stdlib_dataclass
 from dataclasses import field
 from types import MappingProxyType
-from typing import Any, TypeVar
+from typing import TypeVar
 
 from typing_extensions import dataclass_transform
 
@@ -30,7 +30,7 @@ def _dataclass(
     return _decorate
 
 
-def _empty_proxy() -> MappingProxyType[str, Any]:
+def _empty_proxy() -> MappingProxyType[str, object]:
     """Return an empty immutable string-keyed mapping proxy."""
     return MappingProxyType({})
 
@@ -56,7 +56,7 @@ class DatasetRef:
     representation: Representation
     operations: frozenset[Operation] = frozenset()
     query_support: QuerySupport | None = None
-    raw_metadata: MappingProxyType[str, Any] = field(default_factory=_empty_proxy)
+    raw_metadata: MappingProxyType[str, object] = field(default_factory=_empty_proxy)
 
     def supports(self, op: Operation) -> bool:
         """Return whether this dataset supports the requested operation."""
@@ -78,7 +78,7 @@ class Query:
         extra: Additional provider-native parameters not covered canonically.
     """
 
-    filters: dict[str, Any] = field(default_factory=dict)
+    filters: dict[str, object] = field(default_factory=dict)
     page: int | None = None
     page_size: int | None = None
     cursor: str | None = None
@@ -86,7 +86,7 @@ class Query:
     end_date: str | None = None
     fields: list[str] | None = None
     sort: list[str] | None = None
-    extra: dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, object] = field(default_factory=dict)
 
 
 @_dataclass(slots=True)
@@ -100,18 +100,18 @@ class RecordBatch:
         meta: Additional adapter metadata that does not fit canonical fields.
     """
 
-    items: list[dict[str, Any]]
+    items: list[dict[str, object]]
     dataset: DatasetRef
     total_count: int | None = None
     next_page: int | None = None
     next_cursor: str | None = None
-    raw: Any | None = None
-    meta: dict[str, Any] = field(default_factory=dict)
+    raw: object | None = None
+    meta: dict[str, object] = field(default_factory=dict)
 
     def __len__(self) -> int:
         return len(self.items)
 
-    def __iter__(self) -> Iterator[dict[str, Any]]:
+    def __iter__(self) -> Iterator[dict[str, object]]:
         return iter(self.items)
 
     def __bool__(self) -> bool:

--- a/src/kpubdata/exceptions.py
+++ b/src/kpubdata/exceptions.py
@@ -18,7 +18,7 @@ class PublicDataError(Exception):
         status_code: int | None = None,
         provider_code: str | None = None,
         retryable: bool = False,
-        detail: Any = None,
+        detail: object = None,
     ) -> None:
         """Initialize an error with optional provider and transport metadata."""
 

--- a/src/kpubdata/transport/decode.py
+++ b/src/kpubdata/transport/decode.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import json
 from importlib import import_module
-from typing import Any
+
+import httpx
 
 
-def detect_content_type(response: Any) -> str:
+def detect_content_type(response: httpx.Response) -> str:
     """Detect whether response is JSON, XML, or other based on content-type header."""
     header_value_obj = response.headers.get("content-type", "")
     content_type = str(header_value_obj).lower()
@@ -18,7 +19,7 @@ def detect_content_type(response: Any) -> str:
     return "other"
 
 
-def decode_json(data: str | bytes) -> Any:
+def decode_json(data: str | bytes) -> object:
     """Decode JSON with clear error on failure."""
     try:
         payload = data.decode("utf-8") if isinstance(data, bytes) else data
@@ -33,7 +34,7 @@ def decode_json(data: str | bytes) -> Any:
         raise ValueError(msg) from exc
 
 
-def decode_xml(data: str | bytes) -> dict[str, Any]:
+def decode_xml(data: str | bytes) -> dict[str, object]:
     """Decode XML to dict.
 
     Raises:
@@ -56,7 +57,7 @@ def decode_xml(data: str | bytes) -> dict[str, Any]:
         raise ValueError(msg) from exc
 
     try:
-        parsed: Any = xmltodict.parse(payload)
+        parsed: object = xmltodict.parse(payload)
     except Exception as exc:  # noqa: BLE001
         msg = "Failed to decode XML payload"
         raise ValueError(msg) from exc

--- a/src/kpubdata/transport/http.py
+++ b/src/kpubdata/transport/http.py
@@ -14,7 +14,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-from typing import Any, cast
+from typing import cast
 
 import httpx
 
@@ -97,10 +97,10 @@ class HttpTransport:
         method: str,
         url: str,
         *,
-        params: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         content: bytes | None = None,
-        json_body: Any = None,
+        json_body: object = None,
     ) -> httpx.Response:
         """Execute HTTP request with retry logic.
 
@@ -247,7 +247,7 @@ def _is_retryable_status(status_code: int) -> bool:
     return status_code == 429 or 500 <= status_code <= 599
 
 
-def _sanitize_params(params: dict[str, Any] | None) -> dict[str, str]:
+def _sanitize_params(params: dict[str, str] | None) -> dict[str, str]:
     if params is None:
         return {}
 


### PR DESCRIPTION
## Summary

- 데이터 모델 필드(`Query.filters`, `RecordBatch.items/raw/meta`, `DatasetRef.raw_metadata`, `PublicDataError.detail`)에서 `typing.Any`를 `object`로 교체
- Transport 레이어에서 `params`를 `dict[str, str]`로, `json_body`를 `object`로, `detect_content_type`의 파라미터를 `httpx.Response`로 정확히 타이핑
- `Config.extra`를 `dict[str, object]`로 변경
- Python 의미론상 필요한 곳(variadic `**kwargs`, duck-typed adapter registration)에서만 `Any` 유지

## Changed Files

| File | Change |
|---|---|
| `src/kpubdata/core/models.py` | `Query.filters/extra`, `RecordBatch.items/raw/meta`, `DatasetRef.raw_metadata` → `object` |
| `src/kpubdata/exceptions.py` | `PublicDataError.detail` → `object` |
| `src/kpubdata/core/dataset.py` | `**filters`, `**key`, `**params` → `object` |
| `src/kpubdata/transport/decode.py` | Return types → `object`, param type → `httpx.Response` |
| `src/kpubdata/transport/http.py` | `params` → `dict[str, str]`, `json_body` → `object` |
| `src/kpubdata/config.py` | `extra` → `dict[str, object]` |

## Quality Gates

- ✅ `ruff check` — passed
- ✅ `ruff format --check` — passed
- ✅ `mypy` — 0 errors on changed files
- ✅ `pytest` — 261 passed

Closes #70