### PR TITLE
refactor: remove unused _transport field from Dataset class

### DIFF
--- a/src/kpubdata/client.py
+++ b/src/kpubdata/client.py
@@ -83,7 +83,7 @@ class Client:
         """
 
         adapter, ref = self._catalog.resolve(dataset_id)
-        return Dataset(ref=ref, adapter=adapter, transport=self._transport)
+        return Dataset(ref=ref, adapter=adapter)
 
     def register_provider(self, adapter: Any) -> None:
         """Register a provider adapter in this client's registry.

--- a/src/kpubdata/core/dataset.py
+++ b/src/kpubdata/core/dataset.py
@@ -8,18 +8,16 @@ from kpubdata.core.capability import Operation
 from kpubdata.core.models import DatasetRef, Query, RecordBatch, SchemaDescriptor
 from kpubdata.core.protocol import ProviderAdapter
 from kpubdata.exceptions import UnsupportedCapabilityError
-from kpubdata.transport.http import HttpTransport
 
 
 class Dataset:
     """Bound dataset that routes operations to a provider adapter."""
 
-    def __init__(self, ref: DatasetRef, adapter: ProviderAdapter, transport: HttpTransport) -> None:
+    def __init__(self, ref: DatasetRef, adapter: ProviderAdapter) -> None:
         """Initialize a dataset bound to its canonical ref and adapter."""
 
         self._ref = ref
         self._adapter = adapter
-        self._transport = transport
 
     @property
     def ref(self) -> DatasetRef:

--- a/tests/unit/core/test_dataset.py
+++ b/tests/unit/core/test_dataset.py
@@ -9,7 +9,6 @@ from kpubdata.core.dataset import Dataset
 from kpubdata.core.models import DatasetRef, Query, RecordBatch
 from kpubdata.core.representation import Representation
 from kpubdata.exceptions import UnsupportedCapabilityError
-from kpubdata.transport.http import HttpTransport
 
 
 class MockAdapter:
@@ -61,7 +60,7 @@ def _ref(ops: frozenset[Operation] | None = None) -> DatasetRef:
 class TestDataset:
     def test_list(self) -> None:
         adapter = MockAdapter()
-        ds = Dataset(ref=_ref(), adapter=adapter, transport=HttpTransport())  # type: ignore[arg-type]
+        ds = Dataset(ref=_ref(), adapter=adapter)  # type: ignore[arg-type]
         result = ds.list(code="11680")
         assert len(result) == 1
         assert adapter.last_query is not None
@@ -69,34 +68,30 @@ class TestDataset:
 
     def test_list_unsupported(self) -> None:
         adapter = MockAdapter()
-        ds = Dataset(
-            ref=_ref(frozenset({Operation.RAW})), adapter=adapter, transport=HttpTransport()
-        )  # type: ignore[arg-type]
+        ds = Dataset(ref=_ref(frozenset({Operation.RAW})), adapter=adapter)  # type: ignore[arg-type]
         with pytest.raises(UnsupportedCapabilityError, match="list"):
             ds.list()
 
     def test_get(self) -> None:
         adapter = MockAdapter()
-        ds = Dataset(ref=_ref(), adapter=adapter, transport=HttpTransport())  # type: ignore[arg-type]
+        ds = Dataset(ref=_ref(), adapter=adapter)  # type: ignore[arg-type]
         record = ds.get(id="1")
         assert record == {"id": "1"}
 
     def test_get_unsupported(self) -> None:
         adapter = MockAdapter()
-        ds = Dataset(
-            ref=_ref(frozenset({Operation.LIST})), adapter=adapter, transport=HttpTransport()
-        )  # type: ignore[arg-type]
+        ds = Dataset(ref=_ref(frozenset({Operation.LIST})), adapter=adapter)  # type: ignore[arg-type]
         with pytest.raises(UnsupportedCapabilityError, match="get"):
             ds.get(id="1")
 
     def test_call_raw(self) -> None:
         adapter = MockAdapter()
-        ds = Dataset(ref=_ref(), adapter=adapter, transport=HttpTransport())  # type: ignore[arg-type]
+        ds = Dataset(ref=_ref(), adapter=adapter)  # type: ignore[arg-type]
         result = ds.call_raw("list", param="value")
         assert result == {"raw": True}
         assert adapter.last_raw_op == "list"
 
     def test_repr(self) -> None:
         adapter = MockAdapter()
-        ds = Dataset(ref=_ref(), adapter=adapter, transport=HttpTransport())  # type: ignore[arg-type]
+        ds = Dataset(ref=_ref(), adapter=adapter)  # type: ignore[arg-type]
         assert "mock.test" in repr(ds)

--- a/tests/unit/core/test_dataset_coverage.py
+++ b/tests/unit/core/test_dataset_coverage.py
@@ -4,7 +4,6 @@ from kpubdata.core.capability import Operation
 from kpubdata.core.dataset import Dataset
 from kpubdata.core.models import DatasetRef, Query, RecordBatch, SchemaDescriptor
 from kpubdata.core.representation import Representation
-from kpubdata.transport.http import HttpTransport
 
 
 class _Adapter:
@@ -43,6 +42,6 @@ def test_ref_property_returns_bound_reference() -> None:
         representation=Representation.API_JSON,
         operations=frozenset({Operation.LIST}),
     )
-    dataset = Dataset(ref=ref, adapter=_Adapter(), transport=HttpTransport())
+    dataset = Dataset(ref=ref, adapter=_Adapter())
 
     assert dataset.ref is ref


### PR DESCRIPTION
## Summary

- `Dataset.__init__()` 에서 미사용 `transport: HttpTransport` 파라미터 및 `self._transport` 필드 제거
- `client.py`에서 `Dataset()` 호출 시 `transport=` 인자 제거
- 관련 테스트 (`test_dataset.py`, `test_dataset_coverage.py`)에서 `transport=HttpTransport()` 인자 제거 및 미사용 import 정리

## Rationale

Adapter가 이미 자체 transport를 소유하고 있어, Dataset에 transport를 별도로 주입하는 것은 소유권 경계가 불분명했습니다. 이 변경으로 Dataset은 adapter만 의존하도록 단순화됩니다.

## Changed Files

| File | Change |
|---|---|
| `src/kpubdata/core/dataset.py` | `transport` 파라미터, `self._transport`, `HttpTransport` import 제거 |
| `src/kpubdata/client.py` | `Dataset()` 호출에서 `transport=self._transport` 제거 |
| `tests/unit/core/test_dataset.py` | 모든 `Dataset()` 호출에서 `transport=` 제거, `HttpTransport` import 제거 |
| `tests/unit/core/test_dataset_coverage.py` | `Dataset()` 호출에서 `transport=` 제거, `HttpTransport` import 제거 |

## Quality Gates

- ✅ `ruff check` — passed
- ✅ `ruff format --check` — passed
- ✅ `mypy` — 0 errors
- ✅ `pytest` — 261 passed

Closes #71