### PR TITLE
docs: 검증 상태 컬럼 추가 및 AGENTS.md 규칙 강화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ The project is a Python 3.10+ framework with a small stable public API and provi
 - Do not mark a capability as supported unless tests prove it.
 - Keep provider complexity in provider adapters.
 - Update tests and docs with every behavior change.
+- `SUPPORTED_DATA.md`는 지원 Provider/Dataset 현황의 단일 기준 문서(single source of truth)다.
+- Provider/Dataset의 지원 상태 또는 검증 수준이 바뀌면, 같은 PR에서 `SUPPORTED_DATA.md`를 반드시 업데이트한다.
+- `✅ 지원`은 fixture/unit/contract 테스트가 통과했을 때만 표시한다.
+- `🌐 실API 검증`은 실 API integration 테스트가 존재하고 통과했을 때만 표시한다. 그 전에는 `🧪 테스트 검증`으로 유지한다.
 
 ## Language policy
 
@@ -194,6 +198,7 @@ graph TD
 5. [ ] `call_raw`가 항상 원본 데이터를 반환하도록 보장
 6. [ ] `tests/unit/adapters/`에 유닛 테스트 추가
 7. [ ] `tests/contract/`에 계약 테스트(Contract Test) 추가
+8. [ ] `SUPPORTED_DATA.md` 업데이트 (`상태`, `검증`, `인증`, `공식 문서`, `비고`)
 
 ```mermaid
 flowchart TD
@@ -204,7 +209,8 @@ flowchart TD
     F4 --> F5[5. call_raw 보장]
     F5 --> F6[6. 유닛 테스트 추가]
     F6 --> F7[7. 계약 테스트 통과 확인]
-    F7 --> End[완료]
+    F7 --> F8[8. SUPPORTED_DATA.md 업데이트]
+    F8 --> End[완료]
 ```
 
 ### 핵심 추상 클래스 설명

--- a/SUPPORTED_DATA.md
+++ b/SUPPORTED_DATA.md
@@ -7,19 +7,24 @@
 > - ✅ 지원: 구현 완료 + fixture/unit/contract 테스트 통과
 > - 🔄 진행 중: 구현 중이지만 아직 테스트가 완료되지 않음
 > - 📋 예정: 후보 단계 (이슈 등록 또는 아이디어)
+>
+> **검증 정의**
+>
+> - 🧪 테스트 검증: fixture 기반 unit 테스트 + contract 테스트 통과
+> - 🌐 실API 검증: 위 조건 + 실 API integration 테스트 통과 ([#80](https://github.com/yeongseon/kpubdata/issues/80))
 
 ## 현재 지원
 
-| 상태 | Provider | Dataset ID | 데이터셋명 | 인증 | 공식 문서 | 비고 |
-|---|---|---|---|---|---|---|
-| ✅ 지원 | 공공데이터포털 (`datago`) | `apt_trade` | 아파트매매 실거래가 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 국토교통부 제공 |
-| ✅ 지원 | 공공데이터포털 (`datago`) | `village_fcst` | 단기예보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 기상청 제공 |
-| ✅ 지원 | 공공데이터포털 (`datago`) | `ultra_srt_ncst` | 초단기실황 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 기상청 제공 |
-| ✅ 지원 | 공공데이터포털 (`datago`) | `air_quality` | 대기오염정보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
-| ✅ 지원 | 공공데이터포털 (`datago`) | `bus_arrival` | 경기도 버스도착정보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
-| ✅ 지원 | 공공데이터포털 (`datago`) | `hospital_info` | 병원정보서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
-| ✅ 지원 | 한국은행 ECOS (`bok`) | `base_rate` | 한국은행 기준금리 | [ECOS](https://ecos.bok.or.kr/api/) 인증키 | [ecos.bok.or.kr](https://ecos.bok.or.kr/api/) | |
-| ✅ 지원 | 통계청 KOSIS (`kosis`) | `population_migration` | 시도별 이동자수 | [KOSIS](https://kosis.kr/openapi/index/index.jsp) 인증키 | [kosis.kr](https://kosis.kr/openapi/index/index.jsp) | |
+| 상태 | 검증 | Provider | Dataset ID | 데이터셋명 | 인증 | 공식 문서 | 비고 |
+|---|---|---|---|---|---|---|---|
+| ✅ 지원 | 🧪 테스트 검증 | 공공데이터포털 (`datago`) | `apt_trade` | 아파트매매 실거래가 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 국토교통부 제공 |
+| ✅ 지원 | 🧪 테스트 검증 | 공공데이터포털 (`datago`) | `village_fcst` | 단기예보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 기상청 제공 |
+| ✅ 지원 | 🧪 테스트 검증 | 공공데이터포털 (`datago`) | `ultra_srt_ncst` | 초단기실황 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 기상청 제공 |
+| ✅ 지원 | 🧪 테스트 검증 | 공공데이터포털 (`datago`) | `air_quality` | 대기오염정보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
+| ✅ 지원 | 🧪 테스트 검증 | 공공데이터포털 (`datago`) | `bus_arrival` | 경기도 버스도착정보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
+| ✅ 지원 | 🧪 테스트 검증 | 공공데이터포털 (`datago`) | `hospital_info` | 병원정보서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
+| ✅ 지원 | 🧪 테스트 검증 | 한국은행 ECOS (`bok`) | `base_rate` | 한국은행 기준금리 | [ECOS](https://ecos.bok.or.kr/api/) 인증키 | [ecos.bok.or.kr](https://ecos.bok.or.kr/api/) | |
+| ✅ 지원 | 🧪 테스트 검증 | 통계청 KOSIS (`kosis`) | `population_migration` | 시도별 이동자수 | [KOSIS](https://kosis.kr/openapi/index/index.jsp) 인증키 | [kosis.kr](https://kosis.kr/openapi/index/index.jsp) | |
 
 ## 진행 예정 / 진행 중
 


### PR DESCRIPTION
## Summary

- `SUPPORTED_DATA.md`에 `검증` 컬럼 추가 — 지원 여부(상태)와 검증 깊이를 분리
- `AGENTS.md`에 `SUPPORTED_DATA.md` 관리 규칙 4개 추가 + 어댑터 체크리스트 8단계 추가

## 변경 내용

### SUPPORTED_DATA.md
- **검증 정의 추가**: `🧪 테스트 검증` (unit+contract) / `🌐 실API 검증` (+ integration test, #80)
- **검증 컬럼 추가**: 현재 8개 데이터셋 모두 `🧪 테스트 검증`으로 표기
- `🌐 실API 검증`은 issue #80 (integration test) 완료 시 전환

### AGENTS.md
- **Rules of engagement**에 4개 규칙 추가:
  - `SUPPORTED_DATA.md`는 단일 기준 문서(single source of truth)
  - 상태/검증 변경 시 같은 PR에서 반드시 업데이트
  - `✅ 지원` 표시 기준: fixture/unit/contract 테스트 통과
  - `🌐 실API 검증` 표시 기준: integration 테스트 존재 + 통과
- **어댑터 개발 체크리스트**: 8단계 `SUPPORTED_DATA.md 업데이트` 추가
- **Mermaid 플로우차트**: F8 단계 추가

## Quality Gates
- ✅ ruff check / format
- ✅ mypy
- ✅ pytest (301 tests passed)
- ✅ build