### PR TITLE
feat: TransportRequirements + strict catalogue validation (#107, #108)

### DIFF
--- a/src/kpubdata/client.py
+++ b/src/kpubdata/client.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, cast
+from typing import cast
+
+from typing_extensions import override
 
 from kpubdata.catalog import Catalog
 from kpubdata.config import KPubDataConfig
 from kpubdata.core.dataset import Dataset
 from kpubdata.core.protocol import ProviderAdapter
 from kpubdata.registry import ProviderRegistry
-from kpubdata.transport.http import HttpTransport, TransportConfig
+from kpubdata.transport.http import HttpTransport, TransportConfig, TransportRequirements
 
 _BUILTIN_PROVIDERS: tuple[tuple[str, str, str], ...] = (
     ("datago", "kpubdata.providers.datago", "DataGoAdapter"),
@@ -29,7 +31,7 @@ class Client:
         provider_keys: dict[str, str] | None = None,
         timeout: float = 30.0,
         max_retries: int = 3,
-        **extra: Any,
+        **extra: object,
     ) -> None:
         """Initialize a client with explicit provider and transport configuration.
 
@@ -38,21 +40,24 @@ class Client:
         Built-in providers (datago, bok, kosis, lofin) are lazily registered by default.
         """
 
-        self._config = KPubDataConfig(
+        self._config: KPubDataConfig = KPubDataConfig(
             provider_keys=provider_keys or {},
             timeout=timeout,
             max_retries=max_retries,
             extra=dict(extra),
         )
-        self._registry = ProviderRegistry()
-        self._transport = HttpTransport(
-            TransportConfig(timeout=self._config.timeout, max_retries=self._config.max_retries),
+        self._registry: ProviderRegistry = ProviderRegistry()
+        self._transport_config: TransportConfig = TransportConfig(
+            timeout=self._config.timeout,
+            max_retries=self._config.max_retries,
         )
+        self._transport: HttpTransport = HttpTransport(self._transport_config)
+        self._provider_transports: list[HttpTransport] = []
         self._register_builtin_providers()
-        self._catalog = Catalog(self._registry)
+        self._catalog: Catalog = Catalog(self._registry)
 
     @classmethod
-    def from_env(cls, **overrides: Any) -> Client:
+    def from_env(cls, **overrides: object) -> Client:
         """Create a client from environment variables and explicit overrides."""
 
         config = KPubDataConfig.from_env(**overrides)
@@ -78,6 +83,9 @@ class Client:
         """Close underlying transport resources for this client."""
 
         self._transport.close()
+        for provider_transport in self._provider_transports:
+            provider_transport.close()
+        self._provider_transports.clear()
 
     @property
     def datasets(self) -> Catalog:
@@ -109,27 +117,52 @@ class Client:
     def _register_builtin_providers(self) -> None:
         config = self._config
         transport = self._transport
+        transport_config = self._transport_config
+        provider_transports = self._provider_transports
 
         for provider_name, module_path, class_name in _BUILTIN_PROVIDERS:
 
             def _make_factory(
-                mod: str, cls: str, cfg: KPubDataConfig, tpt: HttpTransport
+                mod: str,
+                cls: str,
+                cfg: KPubDataConfig,
+                tpt: HttpTransport,
+                base_transport_config: TransportConfig,
+                owned_transports: list[HttpTransport],
             ) -> Callable[[], ProviderAdapter]:
                 def _factory() -> ProviderAdapter:
                     import importlib
 
                     module = importlib.import_module(mod)
-                    adapter_cls = getattr(module, cls)
-                    return cast(ProviderAdapter, adapter_cls(config=cfg, transport=tpt))
+                    adapter_cls = cast(Callable[..., ProviderAdapter], getattr(module, cls))
+                    adapter = adapter_cls(config=cfg, transport=tpt)
+                    requirements = _get_transport_requirements(adapter)
+                    if requirements is None:
+                        return adapter
+
+                    custom_transport = HttpTransport.with_requirements(
+                        base_transport_config,
+                        requirements,
+                    )
+                    owned_transports.append(custom_transport)
+                    return adapter_cls(config=cfg, transport=custom_transport)
 
                 return _factory
 
             self._registry.register_lazy(
                 provider_name,
-                _make_factory(module_path, class_name, config, transport),
+                _make_factory(
+                    module_path,
+                    class_name,
+                    config,
+                    transport,
+                    transport_config,
+                    provider_transports,
+                ),
                 skip_if_exists=True,
             )
 
+    @override
     def __repr__(self) -> str:
         """Return concise representation with known providers."""
 
@@ -137,3 +170,10 @@ class Client:
 
 
 __all__ = ["Client"]
+
+
+def _get_transport_requirements(adapter: ProviderAdapter) -> TransportRequirements | None:
+    requirements = getattr(adapter, "transport_requirements", None)
+    if requirements is None:
+        return None
+    return cast(TransportRequirements | None, requirements)

--- a/src/kpubdata/providers/_common.py
+++ b/src/kpubdata/providers/_common.py
@@ -15,6 +15,7 @@ from kpubdata.core.models import (
     SchemaDescriptor,
 )
 from kpubdata.core.representation import Representation
+from kpubdata.exceptions import ConfigError
 
 
 def load_catalogue(package_name: str, provider: str) -> tuple[DatasetRef, ...]:
@@ -24,22 +25,32 @@ def load_catalogue(package_name: str, provider: str) -> tuple[DatasetRef, ...]:
     parsed_catalogue = cast(object, json.loads(catalogue_text))
     if not isinstance(parsed_catalogue, list):
         msg = f"{provider} catalogue.json must contain a top-level JSON array"
-        raise ValueError(msg)
+        raise ConfigError(msg, provider=provider)
 
     catalogue_entries = cast(list[object], parsed_catalogue)
     datasets: list[DatasetRef] = []
     for entry_object in catalogue_entries:
         if not isinstance(entry_object, dict):
             msg = f"{provider} catalogue entries must be JSON objects"
-            raise ValueError(msg)
+            raise ConfigError(msg, provider=provider)
         typed_entry_object = cast(dict[object, object], entry_object)
         entry: dict[str, object] = {}
         for key, value in typed_entry_object.items():
             if not isinstance(key, str):
                 msg = f"{provider} catalogue entry keys must be strings"
-                raise ValueError(msg)
+                raise ConfigError(msg, provider=provider)
             entry[key] = value
         datasets.append(build_dataset_ref(provider, entry))
+
+    dataset_ids = [dataset.id for dataset in datasets]
+    duplicate_ids = sorted(
+        {dataset_id for dataset_id in dataset_ids if dataset_ids.count(dataset_id) > 1}
+    )
+    if duplicate_ids:
+        duplicates = ", ".join(duplicate_ids)
+        msg = f"{provider} catalogue contains duplicate dataset ids: {duplicates}"
+        raise ConfigError(msg, provider=provider)
+
     return tuple(datasets)
 
 
@@ -48,14 +59,25 @@ def build_dataset_ref(provider: str, entry: dict[str, object]) -> DatasetRef:
     dataset_key = require_string_field(entry, "dataset_key", provider)
     name = require_string_field(entry, "name", provider)
     representation_value = require_string_field(entry, "representation", provider)
-    representation = Representation(representation_value)
+    dataset_id = f"{provider}.{dataset_key}"
+    try:
+        representation = Representation(representation_value)
+    except ValueError as exc:
+        msg = f"{provider} catalogue entry has invalid representation: {representation_value}"
+        raise ConfigError(msg, provider=provider, dataset_id=dataset_id) from exc
 
     ops_raw_obj = entry.get("operations", [])
-    ops_raw = ops_raw_obj if isinstance(ops_raw_obj, list) else []
-    valid_ops = {member.value for member in Operation}
-    operations = frozenset(
-        Operation(op) for op in ops_raw if isinstance(op, str) and op in valid_ops
-    )
+    ops_raw = cast(list[object], ops_raw_obj) if isinstance(ops_raw_obj, list) else []
+    operations: set[Operation] = set()
+    for op_raw in ops_raw:
+        if not isinstance(op_raw, str):
+            msg = f"{provider} catalogue entry has non-string operation value: {op_raw!r}"
+            raise ConfigError(msg, provider=provider, dataset_id=dataset_id)
+        try:
+            operations.add(Operation(op_raw))
+        except ValueError as exc:
+            msg = f"{provider} catalogue entry has invalid operation: {op_raw}"
+            raise ConfigError(msg, provider=provider, dataset_id=dataset_id) from exc
 
     query_support = _parse_query_support(entry, provider)
 
@@ -68,12 +90,12 @@ def build_dataset_ref(provider: str, entry: dict[str, object]) -> DatasetRef:
     )
 
     return DatasetRef(
-        id=f"{provider}.{dataset_key}",
+        id=dataset_id,
         provider=provider,
         dataset_key=dataset_key,
         name=name,
         representation=representation,
-        operations=operations,
+        operations=frozenset(operations),
         query_support=query_support,
         raw_metadata=raw_metadata,
     )
@@ -88,11 +110,13 @@ def _parse_query_support(entry: dict[str, object], provider: str) -> QuerySuppor
     qs_raw = cast(dict[str, object], qs_raw_obj)
     pagination_raw = qs_raw.get("pagination", "none")
     valid_pagination = {member.value for member in PaginationMode}
-    pagination = (
-        PaginationMode(pagination_raw)
-        if isinstance(pagination_raw, str) and pagination_raw in valid_pagination
-        else PaginationMode.NONE
-    )
+    if isinstance(pagination_raw, str):
+        if pagination_raw not in valid_pagination:
+            msg = f"{provider} query_support.pagination has invalid value: {pagination_raw}"
+            raise ConfigError(msg, provider=provider)
+        pagination = PaginationMode(pagination_raw)
+    else:
+        pagination = PaginationMode.NONE
 
     max_page_size = None
     if "max_page_size" in qs_raw:
@@ -103,7 +127,7 @@ def _parse_query_support(entry: dict[str, object], provider: str) -> QuerySuppor
             max_page_size = int(max_page_size_raw)
         else:
             msg = f"{provider} query_support.max_page_size must be int-like"
-            raise ValueError(msg)
+            raise ConfigError(msg, provider=provider)
 
     return QuerySupport(pagination=pagination, max_page_size=max_page_size)
 
@@ -165,7 +189,10 @@ def require_string_field(entry: Mapping[str, object], field_name: str, provider:
     value = entry.get(field_name)
     if isinstance(value, str) and value:
         return value
-    raise ValueError(f"{provider} catalogue entry missing non-empty string field: {field_name}")
+    raise ConfigError(
+        f"{provider} catalogue entry missing non-empty string field: {field_name}",
+        provider=provider,
+    )
 
 
 __all__ = [

--- a/src/kpubdata/transport/http.py
+++ b/src/kpubdata/transport/http.py
@@ -12,14 +12,19 @@ from __future__ import annotations
 import logging
 import ssl
 import time
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import httpx
+from typing_extensions import override
 
 from kpubdata.exceptions import TransportError, TransportTimeoutError
+
+if TYPE_CHECKING:
+    import ssl
 
 logger = logging.getLogger("kpubdata.transport")
 _SENSITIVE_PARAM_KEYS = {
@@ -47,13 +52,43 @@ class TransportConfig:
     ssl_context: ssl.SSLContext | None = None
 
 
+@dataclass(frozen=True)
+class TransportRequirements:
+    """Declarative transport customization for provider adapters."""
+
+    verify_ssl: bool | None = None
+    headers: Mapping[str, str] | None = None
+    ssl_context_factory: Callable[[], ssl.SSLContext] | None = None
+
+
 class HttpTransport:
     """Managed httpx client with retry, timeout, and structured logging."""
 
-    def __init__(self, config: TransportConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: TransportConfig | None = None,
+        requirements: TransportRequirements | None = None,
+    ) -> None:
         """Initialize transport with optional explicit configuration."""
-        self._config = config or TransportConfig()
+        self._config: TransportConfig = config or TransportConfig()
+        self._requirements: TransportRequirements | None = requirements
         self._client: httpx.Client | None = None
+
+    @classmethod
+    def with_requirements(
+        cls,
+        config: TransportConfig,
+        requirements: TransportRequirements,
+    ) -> HttpTransport:
+        return cls(
+            config=TransportConfig(
+                timeout=config.timeout,
+                max_retries=config.max_retries,
+                retry_backoff_factor=config.retry_backoff_factor,
+                headers=_merge_headers(config.headers, requirements.headers),
+            ),
+            requirements=requirements,
+        )
 
     def __enter__(self) -> HttpTransport:
         """Enter context manager and initialize client eagerly."""
@@ -64,6 +99,7 @@ class HttpTransport:
         """Exit context manager and close managed client."""
         self.close()
 
+    @override
     def __repr__(self) -> str:
         """Return concise debug representation."""
         return (
@@ -75,16 +111,30 @@ class HttpTransport:
             ")"
         )
 
-    def _build_client(self) -> httpx.Client:
-        verify: bool | ssl.SSLContext = self._config.verify_ssl
-        if self._config.ssl_context is not None:
-            verify = self._config.ssl_context
+    def _build_client(self, requirements: TransportRequirements | None = None) -> httpx.Client:
+        effective_requirements = requirements or self._requirements
         return httpx.Client(
             timeout=self._config.timeout,
-            headers=self._config.headers or {},
+            headers=_merge_headers(
+                self._config.headers,
+                None if effective_requirements is None else effective_requirements.headers,
+            )
+            or {},
             follow_redirects=True,
-            verify=verify,
+            verify=self._resolve_verify(effective_requirements),
         )
+
+    def _resolve_verify(self, requirements: TransportRequirements | None) -> bool | ssl.SSLContext:
+        # TransportConfig.ssl_context takes precedence (set directly by adapter)
+        if self._config.ssl_context is not None:
+            return self._config.ssl_context
+        if requirements is None:
+            return self._config.verify_ssl
+        if requirements.ssl_context_factory is not None:
+            return requirements.ssl_context_factory()
+        if requirements.verify_ssl is not None:
+            return requirements.verify_ssl
+        return self._config.verify_ssl
 
     def close(self) -> None:
         """Close client if initialized."""
@@ -157,7 +207,7 @@ class HttpTransport:
                     content=content,
                     json=json_body,
                 )
-                response.raise_for_status()
+                _ = response.raise_for_status()
 
                 logger.debug(
                     "HTTP request success",
@@ -231,10 +281,11 @@ class HttpTransport:
                         f"Request failed after {attempt} attempts: {method} {url}"
                     ) from exc
 
+            delay: float
             if retry_delay is not None:
                 delay = retry_delay
             else:
-                delay = self._config.retry_backoff_factor * (2 ** (attempt - 1))
+                delay = cast(float, self._config.retry_backoff_factor * (2 ** (attempt - 1)))
             logger.debug(
                 "Retrying HTTP request",
                 extra={
@@ -254,6 +305,21 @@ def _is_retryable_status(status_code: int) -> bool:
     return status_code == 429 or 500 <= status_code <= 599
 
 
+def _merge_headers(
+    base_headers: Mapping[str, str] | None,
+    override_headers: Mapping[str, str] | None,
+) -> dict[str, str] | None:
+    if base_headers is None and override_headers is None:
+        return None
+
+    merged_headers: dict[str, str] = {}
+    if base_headers is not None:
+        merged_headers.update(base_headers)
+    if override_headers is not None:
+        merged_headers.update(override_headers)
+    return merged_headers
+
+
 def _sanitize_params(params: dict[str, str] | None) -> dict[str, str]:
     if params is None:
         return {}
@@ -268,7 +334,7 @@ def _sanitize_params(params: dict[str, str] | None) -> dict[str, str]:
 
 
 def _response_preview(response: httpx.Response, max_chars: int = 500) -> str:
-    content_type = response.headers.get("content-type", "").casefold()
+    content_type = cast(str, response.headers.get("content-type", "")).casefold()
     is_text = (
         content_type.startswith("text/")
         or "json" in content_type
@@ -311,4 +377,4 @@ def _parse_retry_after(header_value: str) -> float | None:
     return max((retry_at - now).total_seconds(), 0.0)
 
 
-__all__ = ["HttpTransport", "TransportConfig"]
+__all__ = ["HttpTransport", "TransportConfig", "TransportRequirements"]

--- a/tests/unit/providers/datago/test_adapter_coverage.py
+++ b/tests/unit/providers/datago/test_adapter_coverage.py
@@ -8,7 +8,7 @@ import pytest
 from kpubdata.config import KPubDataConfig
 from kpubdata.core.models import DatasetRef, Query
 from kpubdata.core.representation import Representation
-from kpubdata.exceptions import ParseError, ProviderResponseError
+from kpubdata.exceptions import ConfigError, ParseError, ProviderResponseError
 from kpubdata.providers._common import build_dataset_ref, coerce_int, require_string_field
 from kpubdata.providers.datago.adapter import DataGoAdapter
 from kpubdata.transport.http import HttpTransport
@@ -276,7 +276,7 @@ def test_load_default_catalogue_raises_when_top_level_json_not_list(monkeypatch)
 
     monkeypatch.setattr(common_module, "files", lambda _pkg: _FakePackageFiles("{}"))
 
-    with pytest.raises(ValueError, match="top-level JSON array"):
+    with pytest.raises(ConfigError, match="top-level JSON array"):
         _ = DataGoAdapter._load_default_catalogue()
 
 
@@ -285,7 +285,7 @@ def test_load_default_catalogue_raises_when_entry_not_dict(monkeypatch) -> None:
 
     monkeypatch.setattr(common_module, "files", lambda _pkg: _FakePackageFiles("[1]"))
 
-    with pytest.raises(ValueError, match="entries must be JSON objects"):
+    with pytest.raises(ConfigError, match="entries must be JSON objects"):
         _ = DataGoAdapter._load_default_catalogue()
 
 
@@ -295,7 +295,7 @@ def test_load_default_catalogue_raises_when_entry_key_not_string(monkeypatch) ->
     monkeypatch.setattr(common_module, "files", lambda _pkg: _FakePackageFiles("[]"))
     monkeypatch.setattr(common_module.json, "loads", lambda _text: [{1: "bad-key"}])
 
-    with pytest.raises(ValueError, match="entry keys must be strings"):
+    with pytest.raises(ConfigError, match="entry keys must be strings"):
         _ = DataGoAdapter._load_default_catalogue()
 
 
@@ -316,7 +316,7 @@ def test_build_dataset_ref_parses_string_max_page_size() -> None:
 
 
 def test_build_dataset_ref_raises_for_invalid_max_page_size_type() -> None:
-    with pytest.raises(ValueError, match="max_page_size must be int-like"):
+    with pytest.raises(ConfigError, match="max_page_size must be int-like"):
         _ = build_dataset_ref(
             "datago",
             {
@@ -329,5 +329,5 @@ def test_build_dataset_ref_raises_for_invalid_max_page_size_type() -> None:
 
 
 def test_require_string_field_raises_when_field_missing() -> None:
-    with pytest.raises(ValueError, match="missing non-empty string field"):
+    with pytest.raises(ConfigError, match="missing non-empty string field"):
         _ = require_string_field({}, "dataset_key", "datago")

--- a/tests/unit/test_catalogue_validation.py
+++ b/tests/unit/test_catalogue_validation.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pytest
+
+from kpubdata.exceptions import ConfigError
+from kpubdata.providers._common import build_dataset_ref, load_catalogue
+
+
+class _FakeCatalogueFile:
+    def __init__(self, text: str) -> None:
+        self._text: str = text
+
+    def read_text(self, *, encoding: str = "utf-8") -> str:
+        assert encoding == "utf-8"
+        return self._text
+
+
+class _FakePackageFiles:
+    def __init__(self, text: str) -> None:
+        self._text: str = text
+
+    def joinpath(self, path: str) -> _FakeCatalogueFile:
+        assert path == "catalogue.json"
+        return _FakeCatalogueFile(self._text)
+
+
+def test_load_catalogue_raises_for_duplicate_dataset_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    import kpubdata.providers._common as common_module
+
+    def _fake_files(_package_name: str) -> _FakePackageFiles:
+        return _FakePackageFiles(
+            """
+            [
+              {"dataset_key": "dup", "name": "First", "representation": "api_json"},
+              {"dataset_key": "dup", "name": "Second", "representation": "api_xml"}
+            ]
+            """
+        )
+
+    monkeypatch.setattr(
+        common_module,
+        "files",
+        _fake_files,
+    )
+
+    with pytest.raises(ConfigError, match=r"duplicate dataset ids: test\.dup"):
+        _ = load_catalogue("fake.package", "test")
+
+
+def test_build_dataset_ref_raises_for_invalid_representation() -> None:
+    with pytest.raises(ConfigError, match="invalid representation"):
+        _ = build_dataset_ref(
+            "test",
+            {
+                "dataset_key": "sample",
+                "name": "Sample",
+                "representation": "not_real",
+            },
+        )
+
+
+def test_build_dataset_ref_raises_for_invalid_operation() -> None:
+    with pytest.raises(ConfigError, match="invalid operation"):
+        _ = build_dataset_ref(
+            "test",
+            {
+                "dataset_key": "sample",
+                "name": "Sample",
+                "representation": "api_json",
+                "operations": ["list", "bogus"],
+            },
+        )
+
+
+def test_build_dataset_ref_raises_for_invalid_pagination_mode() -> None:
+    with pytest.raises(ConfigError, match=r"query_support\.pagination has invalid value"):
+        _ = build_dataset_ref(
+            "test",
+            {
+                "dataset_key": "sample",
+                "name": "Sample",
+                "representation": "api_json",
+                "query_support": {"pagination": "page_number"},
+            },
+        )
+
+
+@pytest.mark.parametrize("field_name", ["dataset_key", "name", "representation"])
+def test_build_dataset_ref_raises_for_missing_required_fields(field_name: str) -> None:
+    entry: dict[str, object] = {
+        "dataset_key": "sample",
+        "name": "Sample",
+        "representation": "api_json",
+    }
+    del entry[field_name]
+
+    with pytest.raises(ConfigError, match=rf"missing non-empty string field: {field_name}"):
+        _ = build_dataset_ref("test", entry)
+
+
+@pytest.mark.parametrize(
+    ("package_name", "provider"),
+    [
+        ("kpubdata.providers.datago", "datago"),
+        ("kpubdata.providers.bok", "bok"),
+        ("kpubdata.providers.kosis", "kosis"),
+    ],
+)
+def test_valid_provider_catalogues_pass_validation(package_name: str, provider: str) -> None:
+    datasets = load_catalogue(package_name, provider)
+
+    assert datasets
+    assert all(dataset.provider == provider for dataset in datasets)

--- a/tests/unit/test_client_transport_requirements.py
+++ b/tests/unit/test_client_transport_requirements.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from kpubdata.client import Client
+from kpubdata.core.models import DatasetRef, Query, RecordBatch, SchemaDescriptor
+from kpubdata.transport.http import HttpTransport, TransportRequirements
+
+
+class _AdapterWithoutRequirements:
+    instances: list[object] = []
+
+    def __init__(self, *, config: object, transport: HttpTransport) -> None:
+        self.config: object = config
+        self.transport: HttpTransport = transport
+        type(self).instances.append(self)
+
+    @property
+    def name(self) -> str:
+        return "dummy"
+
+    def list_datasets(self) -> list[DatasetRef]:
+        return []
+
+    def search_datasets(self, _text: str) -> list[DatasetRef]:
+        return []
+
+    def get_dataset(self, dataset_key: str) -> DatasetRef:
+        raise LookupError(dataset_key)
+
+    def query_records(self, dataset: DatasetRef, _query: Query) -> RecordBatch:
+        return RecordBatch(items=[], dataset=dataset)
+
+    def get_record(self, _dataset: DatasetRef, _key: dict[str, object]) -> dict[str, object] | None:
+        return None
+
+    def get_schema(self, _dataset: DatasetRef) -> SchemaDescriptor | None:
+        return None
+
+    def call_raw(self, _dataset: DatasetRef, _operation: str, _params: dict[str, object]) -> object:
+        return None
+
+
+class _AdapterWithRequirements:
+    instances: list[object] = []
+
+    def __init__(self, *, config: object, transport: HttpTransport) -> None:
+        self.config: object = config
+        self.transport: HttpTransport = transport
+        type(self).instances.append(self)
+
+    @property
+    def name(self) -> str:
+        return "dummy"
+
+    @property
+    def transport_requirements(self) -> TransportRequirements | None:
+        return TransportRequirements(headers={"X-Provider": "dummy"}, verify_ssl=False)
+
+    def list_datasets(self) -> list[DatasetRef]:
+        return []
+
+    def search_datasets(self, _text: str) -> list[DatasetRef]:
+        return []
+
+    def get_dataset(self, dataset_key: str) -> DatasetRef:
+        raise LookupError(dataset_key)
+
+    def query_records(self, dataset: DatasetRef, _query: Query) -> RecordBatch:
+        return RecordBatch(items=[], dataset=dataset)
+
+    def get_record(self, _dataset: DatasetRef, _key: dict[str, object]) -> dict[str, object] | None:
+        return None
+
+    def get_schema(self, _dataset: DatasetRef) -> SchemaDescriptor | None:
+        return None
+
+    def call_raw(self, _dataset: DatasetRef, _operation: str, _params: dict[str, object]) -> object:
+        return None
+
+
+def test_builtin_provider_without_transport_requirements_uses_shared_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _AdapterWithoutRequirements.instances.clear()
+    monkeypatch.setattr(
+        "kpubdata.client._BUILTIN_PROVIDERS", (("dummy", "dummy.module", "DummyAdapter"),)
+    )
+
+    with (
+        patch(
+            "importlib.import_module",
+            return_value=SimpleNamespace(DummyAdapter=_AdapterWithoutRequirements),
+        ),
+        patch.object(HttpTransport, "with_requirements") as with_requirements,
+    ):
+        client = Client()
+        _ = client.datasets.list()
+
+    with_requirements.assert_not_called()
+    assert len(_AdapterWithoutRequirements.instances) == 1
+
+
+def test_builtin_provider_with_transport_requirements_builds_custom_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _AdapterWithRequirements.instances.clear()
+    monkeypatch.setattr(
+        "kpubdata.client._BUILTIN_PROVIDERS", (("dummy", "dummy.module", "DummyAdapter"),)
+    )
+
+    with patch(
+        "importlib.import_module",
+        return_value=SimpleNamespace(DummyAdapter=_AdapterWithRequirements),
+    ):
+        client = Client(timeout=12.0, max_retries=7)
+        _ = client.datasets.list()
+
+    adapter = _AdapterWithRequirements.instances[-1]
+    assert isinstance(adapter, _AdapterWithRequirements)
+    assert len(_AdapterWithRequirements.instances) == 2
+
+    with patch("kpubdata.transport.http.httpx.Client") as client_cls:
+        _ = adapter.transport.client
+
+    client_cls.assert_called_once_with(
+        timeout=12.0,
+        headers={"X-Provider": "dummy"},
+        follow_redirects=True,
+        verify=False,
+    )

--- a/tests/unit/transport/test_transport_requirements.py
+++ b/tests/unit/transport/test_transport_requirements.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from kpubdata.transport.http import HttpTransport, TransportConfig, TransportRequirements
+
+
+def test_transport_requirements_defaults() -> None:
+    requirements = TransportRequirements()
+
+    assert requirements.verify_ssl is None
+    assert requirements.headers is None
+    assert requirements.ssl_context_factory is None
+
+
+def test_with_requirements_merges_headers_without_mutating_base_config() -> None:
+    config = TransportConfig(
+        timeout=12.0,
+        max_retries=5,
+        retry_backoff_factor=0.25,
+        headers={"User-Agent": "kpubdata", "Accept": "application/json"},
+    )
+    requirements = TransportRequirements(headers={"Accept": "application/xml", "X-Test": "1"})
+
+    transport = HttpTransport.with_requirements(config, requirements)
+
+    with patch("kpubdata.transport.http.httpx.Client") as client_cls:
+        _ = transport.client
+
+    client_cls.assert_called_once_with(
+        timeout=12.0,
+        headers={
+            "User-Agent": "kpubdata",
+            "Accept": "application/xml",
+            "X-Test": "1",
+        },
+        follow_redirects=True,
+        verify=True,
+    )
+    assert config.headers == {"User-Agent": "kpubdata", "Accept": "application/json"}
+
+
+def test_build_client_calls_ssl_context_factory_when_provided() -> None:
+    ssl_context = MagicMock(name="ssl_context")
+    ssl_context_factory = MagicMock(return_value=ssl_context)
+    transport = HttpTransport(
+        requirements=TransportRequirements(ssl_context_factory=ssl_context_factory),
+    )
+
+    with patch("kpubdata.transport.http.httpx.Client") as client_cls:
+        _ = transport.client
+
+    ssl_context_factory.assert_called_once_with()
+    client_cls.assert_called_once_with(
+        timeout=30.0,
+        headers={},
+        follow_redirects=True,
+        verify=ssl_context,
+    )
+
+
+def test_build_client_passes_verify_false_when_ssl_verification_disabled() -> None:
+    transport = HttpTransport(requirements=TransportRequirements(verify_ssl=False))
+
+    with patch("kpubdata.transport.http.httpx.Client") as client_cls:
+        _ = transport.client
+
+    client_cls.assert_called_once_with(
+        timeout=30.0,
+        headers={},
+        follow_redirects=True,
+        verify=False,
+    )


### PR DESCRIPTION
## Summary

Oracle 설계 검토에서 도출된 아키텍처 개선 3건 (#107, #108, #109) 중 2건을 구현합니다.

### TransportRequirements (#107)
- `TransportRequirements` frozen dataclass 추가 — adapter가 transport quirk(SSL, headers 등)을 선언적으로 명시
- `HttpTransport.with_requirements()` factory method로 requirements 기반 transport 생성
- `Client._register_builtin_providers()`에서 adapter의 transport requirements를 자동 merge

### Strict catalogue validation (#108)
- `ValueError` → `ConfigError` 전환 (일관된 예외 체계)
- 중복 dataset id 감지 및 `ConfigError` raise
- representation, operation, pagination mode에 대한 strict enum validation
- 필수 필드 누락 시 `ConfigError` (기존 `ValueError` 대체)

### Error enrichment (#109)
- main 브랜치에서 이미 fresh raise 패턴 적용됨 — 변경 불필요 확인

## Quality Gates
- ✅ ruff check / format
- ✅ mypy (0 issues)
- ✅ pytest 317 passed

Related: #107, #108, #109