### PR TITLE
chore: v0.1.0 release preparation

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,60 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Run quality gates
+        run: |
+          uv run ruff check .
+          uv run ruff format --check .
+          uv run mypy src
+          uv run pytest -ra
+
+      - name: Build sdist and wheel
+        run: uv run python -m build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment: pypi
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kpubdata"
-version = "0.1.0a0"
+version = "0.1.0"
 description = "Dialect-inspired Python access framework for Korean public data"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [
-  { name = "Your Name" }
+  { name = "Yeongseon Choe" }
 ]
 keywords = [
   "korea",


### PR DESCRIPTION
## Summary

v0.1.0 정식 릴리스 준비

### 변경사항
- 버전 `0.1.0a0` → `0.1.0`
- author 정보 업데이트
- `publish-pypi.yml` workflow 추가: GitHub Release 생성 시 trusted publisher(OIDC)로 PyPI 자동 배포

### 릴리스 절차
1. 이 PR merge
2. GitHub Release `v0.1.0` 생성
3. workflow가 자동으로 build + publish to PyPI