### PR TITLE
feat(lofin): add FIACRV (revenue by source) dataset (#115)

### DIFF
--- a/SUPPORTED_DATA.md
+++ b/SUPPORTED_DATA.md
@@ -30,6 +30,7 @@
 | 지원 | 실API 검증 | 지방재정365 (`lofin`) | `expenditure_function` | 기능별세출 | [지방재정365](https://www.lofin365.go.kr) 인증키 | [lofin365.go.kr](https://www.lofin365.go.kr) | API 코드: GGNSE |
 | 지원 | 실API 검증 | 지방재정365 (`lofin`) | `debt_ratio` | 채무비율현황 | [지방재정365](https://www.lofin365.go.kr) 인증키 | [lofin365.go.kr](https://www.lofin365.go.kr) | API 코드: HEDFC |
 | 지원 | 실API 검증 | 지방재정365 (`lofin`) | `fiscal_independence` | 재정자립도현황 | [지방재정365](https://www.lofin365.go.kr) 인증키 | [lofin365.go.kr](https://www.lofin365.go.kr) | API 코드: JFIED |
+| 지원 | 실API 검증 | 지방재정365 (`lofin`) | `revenue_by_source` | 재원별 회계별 세입결산 | [지방재정365](https://www.lofin365.go.kr) 인증키 | [lofin365.go.kr](https://www.lofin365.go.kr) | API 코드: FIACRV |
 
 ## 진행 예정 / 진행 중
 

--- a/src/kpubdata/providers/lofin/catalogue.json
+++ b/src/kpubdata/providers/lofin/catalogue.json
@@ -77,6 +77,37 @@
     ]
   },
   {
+    "dataset_key": "revenue_by_source",
+    "name": "지방재정 재원별 회계별 세입결산 (LOFIN Revenue by Source & Account)",
+    "api_code": "FIACRV",
+    "base_url": "https://www.lofin365.go.kr/lf/hub",
+    "representation": "api_json",
+    "default_operation": "list",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000
+    },
+    "fields": [
+      {"name": "fyr", "title": "회계연도", "type": "string"},
+      {"name": "wa_laf_cd", "title": "광역자치단체코드", "type": "string"},
+      {"name": "wa_laf_hg_nm", "title": "광역자치단체명", "type": "string"},
+      {"name": "laf_cd", "title": "자치단체코드", "type": "string"},
+      {"name": "laf_hg_nm", "title": "자치단체명", "type": "string"},
+      {"name": "armk_cd", "title": "재원분류코드", "type": "string"},
+      {"name": "armk_nm", "title": "재원분류명", "type": "string"},
+      {"name": "lvl_no", "title": "분류레벨", "type": "string"},
+      {"name": "tott_sum_amt", "title": "합계총액", "type": "integer"},
+      {"name": "gen_acnt_tott_amt", "title": "일반회계총액", "type": "integer"},
+      {"name": "pbco_spc_acnt_tott_amt", "title": "공기업특별회계총액", "type": "integer"},
+      {"name": "etc_spc_acnt_tott_amt", "title": "기타특별회계총액", "type": "integer"},
+      {"name": "prsm_amt", "title": "예산액합계", "type": "integer"},
+      {"name": "gen_acnt_prsm_amt", "title": "일반회계예산액", "type": "integer"},
+      {"name": "pbco_spc_acnt_prsm_amt", "title": "공기업특별회계예산액", "type": "integer"},
+      {"name": "etc_spc_acnt_prsm_amt", "title": "기타특별회계예산액", "type": "integer"}
+    ]
+  },
+  {
     "dataset_key": "debt_ratio",
     "name": "지방재정 채무비율현황 (LOFIN Debt Ratio Status)",
     "api_code": "HEDFC",

--- a/tests/contract/test_lofin.py
+++ b/tests/contract/test_lofin.py
@@ -135,3 +135,27 @@ class TestLofinAdapterContract(ProviderAdapterContract):
             _ = adapter.query_records(dataset, Query())
 
         assert exc_info.value.provider_code == "ERROR-290"
+
+    def test_query_records_fiacrv_dataset(self) -> None:
+        transport = _FixtureTransport(["success_fiacrv.json"])
+        config = KPubDataConfig(provider_keys={"lofin": "test-key"})
+        adapter_module = import_module("kpubdata.providers.lofin.adapter")
+        adapter_class_obj = cast(object, adapter_module.LofinAdapter)
+        if not isinstance(adapter_class_obj, type):
+            raise AssertionError("LofinAdapter is not a class")
+        adapter_class = cast(_AdapterFactory, adapter_class_obj)
+        adapter = adapter_class(
+            config=config,
+            transport=cast(HttpTransport, cast(object, transport)),
+        )
+
+        dataset = adapter.get_dataset("revenue_by_source")
+        result = adapter.query_records(dataset, Query())
+
+        assert result.total_count == 2
+        assert len(result.items) == 2
+        assert result.items[0]["armk_nm"] == "총괄"
+        assert result.items[1]["armk_nm"] == "지방세수입"
+
+        request_url = cast(str, transport.calls[0]["url"])
+        assert "FIACRV" in request_url

--- a/tests/fixtures/lofin/success_fiacrv.json
+++ b/tests/fixtures/lofin/success_fiacrv.json
@@ -1,0 +1,50 @@
+{
+  "FIACRV": [
+    {
+      "head": [
+        {"list_total_count": 2},
+        {"RESULT": {"CODE": "INFO-000", "MESSAGE": "정상 처리되었습니다."}}
+      ]
+    },
+    {
+      "row": [
+        {
+          "fyr": "2023",
+          "wa_laf_cd": "1100000",
+          "wa_laf_hg_nm": "서울",
+          "laf_cd": "1100000",
+          "laf_hg_nm": "서울본청",
+          "armk_cd": "00000",
+          "armk_nm": "총괄",
+          "lvl_no": "1",
+          "tott_sum_amt": 50758554122542,
+          "gen_acnt_tott_amt": 36215268788968,
+          "pbco_spc_acnt_tott_amt": 2044885546695,
+          "etc_spc_acnt_tott_amt": 12498399786879,
+          "prsm_amt": 43198111530812,
+          "gen_acnt_prsm_amt": 34286863686638,
+          "pbco_spc_acnt_prsm_amt": 1990186526365,
+          "etc_spc_acnt_prsm_amt": 6921061317809
+        },
+        {
+          "fyr": "2023",
+          "wa_laf_cd": "1100000",
+          "wa_laf_hg_nm": "서울",
+          "laf_cd": "1100000",
+          "laf_hg_nm": "서울본청",
+          "armk_cd": "10000",
+          "armk_nm": "지방세수입",
+          "lvl_no": "2",
+          "tott_sum_amt": 23862799379391,
+          "gen_acnt_tott_amt": 23862799379391,
+          "pbco_spc_acnt_tott_amt": 0,
+          "etc_spc_acnt_tott_amt": 0,
+          "prsm_amt": 22164767618391,
+          "gen_acnt_prsm_amt": 22164767618391,
+          "pbco_spc_acnt_prsm_amt": 0,
+          "etc_spc_acnt_prsm_amt": 0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/test_lofin_live.py
+++ b/tests/integration/test_lofin_live.py
@@ -197,3 +197,40 @@ def test_usage_fiscal_independence_rates(live_client: Client) -> None:
         rate1 = item["rate1"]
         assert isinstance(rate1, (int, float))
         assert 0.0 <= rate1 <= 100.0
+
+
+# ---------------------------------------------------------------------------
+# FIACRV (Revenue by Source & Account)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_lofin_key")
+def test_revenue_by_source_returns_record_batch(live_client: Client) -> None:
+    ds = live_client.dataset("lofin.revenue_by_source")
+    result = ds.list(fyr="2023")
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) > 0
+    assert "armk_nm" in result.items[0]
+    assert "tott_sum_amt" in result.items[0]
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_lofin_key")
+def test_revenue_by_source_raw_returns_envelope(live_client: Client) -> None:
+    ds = live_client.dataset("lofin.revenue_by_source")
+    result = ds.call_raw("list", pIndex="1", pSize="5", fyr="2023")
+
+    assert isinstance(result, dict)
+    assert "FIACRV" in result
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_lofin_key")
+def test_revenue_by_source_has_hierarchy_levels(live_client: Client) -> None:
+    ds = live_client.dataset("lofin.revenue_by_source")
+    result = ds.list(fyr="2023", wa_laf_cd="1100000", page_size=50)
+
+    lvl_values = {item["lvl_no"] for item in result.items}
+    assert "1" in lvl_values


### PR DESCRIPTION
## Summary

LOFIN catalogue에 `FIACRV`(재원별 회계별 세입결산) dataset 추가

### 변경사항
- `catalogue.json`에 `revenue_by_source` 항목 추가 (16 fields)
- fixture `success_fiacrv.json` 추가
- contract test: FIACRV 파싱 검증
- integration test: 실API 3건 pass (14초)
- `SUPPORTED_DATA.md`: 실API 검증 완료

### API Info
- **Code**: `FIACRV`
- **Endpoint**: `https://www.lofin365.go.kr/lf/hub/FIACRV`
- **필수 파라미터**: `fyr` (회계연도)
- **주요 필드**: `armk_cd`/`armk_nm` (재원분류), `lvl_no` (계층 레벨), `tott_sum_amt` (합계총액), 회계별 금액

### Quality Gates
- ✅ 316 tests passed
- ✅ 3 integration tests passed (live API)
- ✅ ruff, mypy clean

Closes #115