### PR TITLE
chore: 수동 트리거 릴리스 workflow + 배포 프로세스 문서화

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,17 +4,94 @@ on:
   release:
     types: [published]
 
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - pre
+        default: patch
+      dry_run:
+        description: "Dry run (skip PyPI publish)"
+        required: false
+        type: boolean
+        default: false
+
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
+  bump-version:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    timeout-minutes: 5
+    outputs:
+      new_version: ${{ steps.bump.outputs.new_version }}
+      tag: ${{ steps.bump.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        id: bump
+        run: |
+          current=$(grep -oP 'version = "\K[^"]+' pyproject.toml)
+          IFS='.' read -r major minor patch_raw <<< "$current"
+
+          patch="${patch_raw%%a*}"
+          pre="${patch_raw#*a}"
+
+          case "${{ inputs.bump }}" in
+            patch)
+              new_version="${major}.${minor}.$((patch + 1))"
+              ;;
+            minor)
+              new_version="${major}.$((minor + 1)).0"
+              ;;
+            pre)
+              if [[ "$patch_raw" == *a* ]]; then
+                new_version="${major}.${minor}.${patch}a$((pre + 1))"
+              else
+                new_version="${major}.${minor}.$((patch + 1))a0"
+              fi
+              ;;
+          esac
+
+          sed -i "s/version = \"${current}\"/version = \"${new_version}\"/" pyproject.toml
+          echo "new_version=${new_version}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${new_version}" >> "$GITHUB_OUTPUT"
+          echo "Bumped: ${current} → ${new_version}"
+
+      - name: Commit and tag
+        run: |
+          git add pyproject.toml
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }}"
+          git tag "${{ steps.bump.outputs.tag }}"
+          git push origin main --tags
+
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    needs: [bump-version]
+    if: always() && (needs.bump-version.result == 'success' || needs.bump-version.result == 'skipped')
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
 
       - uses: astral-sh/setup-uv@v4
         with:
@@ -44,10 +121,35 @@ jobs:
           name: dist
           path: dist/
 
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [bump-version, build]
+    if: github.event_name == 'workflow_dispatch' && !inputs.dry_run
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ needs.bump-version.outputs.tag }}" \
+            --title "${{ needs.bump-version.outputs.tag }}" \
+            --generate-notes \
+            --target main
+
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: build
+    needs: [bump-version, build]
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run))
     environment: pypi
     steps:
       - name: Download artifacts

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -82,11 +82,55 @@ uv run python -m build
 
 ### Release
 
-1. bump version
-2. update changelog
-3. run full quality gates
-4. build sdist + wheel
-5. publish to TestPyPI/PyPI
+GitHub Actions `Publish to PyPI` workflow를 통해 배포합니다.
+
+#### 방법 1: 수동 트리거 (권장)
+
+1. GitHub → Actions → **Publish to PyPI** → **Run workflow**
+2. 옵션 선택:
+   - **bump**: `patch` (0.1.0 → 0.1.1), `minor` (0.1.0 → 0.2.0), `pre` (0.1.0 → 0.1.1a0)
+   - **dry_run**: 체크하면 PyPI 배포 없이 빌드만 확인
+3. workflow가 자동으로 수행하는 작업:
+   - `pyproject.toml` 버전 bump + commit + tag
+   - quality gates 실행 (ruff, mypy, pytest)
+   - sdist + wheel 빌드
+   - GitHub Release 생성 (자동 release notes)
+   - PyPI 배포 (trusted publisher / OIDC)
+
+#### 방법 2: GitHub Release 수동 생성
+
+1. 직접 `pyproject.toml` 버전 수정 + commit + push
+2. GitHub → Releases → **Create a new release**
+3. 태그: `v{version}` (예: `v0.2.0`)
+4. Release 생성 시 workflow가 자동으로 빌드 + PyPI 배포
+
+#### 배포 전 체크리스트
+
+- [ ] main 브랜치에 모든 변경사항 merge 완료
+- [ ] CI 통과 확인 (ruff, mypy, pytest)
+- [ ] `SUPPORTED_DATA.md` 최신 상태
+
+#### 배포 흐름도
+
+```mermaid
+flowchart TD
+    A[변경사항 main에 merge] --> B{배포 방식}
+    B -->|수동 트리거| C[Actions > Run workflow]
+    C --> D[bump type 선택]
+    D --> E[자동: 버전 bump + commit + tag]
+    B -->|Release 생성| F[수동: 버전 수정 + Release 생성]
+    E --> G[Quality gates]
+    F --> G
+    G --> H[Build sdist + wheel]
+    H --> I[GitHub Release 생성]
+    I --> J[PyPI 배포]
+```
+
+#### 환경 설정
+
+- **PyPI trusted publisher**: GitHub Actions OIDC — 별도 API 토큰 불필요
+- **GitHub environment**: `pypi` (Settings → Environments)
+- **Workflow 파일**: `.github/workflows/publish-pypi.yml`
 
 ## 7. Versioning policy
 


### PR DESCRIPTION
## Summary

배포 프로세스를 자동화하고 문서화합니다.

### publish-pypi.yml 변경
- `workflow_dispatch` 트리거 추가 (GitHub Actions UI에서 수동 실행)
- bump type 선택: `patch`, `minor`, `pre`
- `dry_run` 옵션: PyPI 배포 없이 빌드만 확인
- 자동: 버전 bump → commit → tag → quality gates → build → GitHub Release → PyPI publish
- 기존 `release` 트리거 유지 (하위 호환)

### PACKAGING.md 업데이트
- 배포 방법 2가지 (수동 트리거 / Release 생성) 상세 문서화
- 배포 흐름도 (mermaid)
- 배포 전 체크리스트
- 환경 설정 안내