### PR TITLE
Oracle 리뷰 피드백: Operation.GET 제거 및 문서 정합성 수정

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -14,7 +14,7 @@ from kpubdata import Client
 client = Client(
     provider_keys={
         "datago": "...",
-        "seoul": "...",
+        "bok": "...",
     },
     timeout=10.0,
 )
@@ -31,7 +31,7 @@ client = Client.from_env()
 ```python
 client.datasets.list()
 client.datasets.search("지하철")
-client.dataset("molit.apartment_trades")
+client.dataset("datago.apt_trade")
 ```
 
 ## 4. Bound dataset operations
@@ -39,8 +39,8 @@ client.dataset("molit.apartment_trades")
 ### List/query
 
 ```python
-dataset = client.dataset("molit.apartment_trades")
-result = dataset.list(lawd_code="11680", deal_ym="202503")
+dataset = client.dataset("datago.apt_trade")
+result = dataset.list(LAWD_CD="11680", DEAL_YMD="202503")
 ```
 
 `list()` returns exactly one page of results. When another page is available,
@@ -49,8 +49,8 @@ the returned `RecordBatch.next_page` is set.
 ### List all pages
 
 ```python
-dataset = client.dataset("molit.apartment_trades")
-for batch in dataset.list_all(lawd_code="11680", deal_ym="202503"):
+dataset = client.dataset("datago.apt_trade")
+for batch in dataset.list_all(LAWD_CD="11680", DEAL_YMD="202503"):
     for item in batch.items:
         print(item)
 ```
@@ -67,7 +67,7 @@ schema = dataset.schema()
 ### Raw
 
 ```python
-raw = dataset.call_raw(operation="list", lawd_code="11680", deal_ym="202503")
+raw = dataset.call_raw(operation="list", LAWD_CD="11680", DEAL_YMD="202503")
 ```
 
 ## 5. Convenience aliases
@@ -77,7 +77,7 @@ Optional convenience aliases may be added for common datasets, but only if they 
 Example:
 
 ```python
-client.apartment_trades.list(lawd_code="11680", deal_ym="202503")
+client.apt_trade.list(LAWD_CD="11680", DEAL_YMD="202503")
 ```
 
 Rules:
@@ -94,6 +94,12 @@ Returns `RecordBatch`.
 ### `list_all()`
 
 Returns a generator of `RecordBatch` values, one per page.
+
+### `to_pandas()`
+
+`RecordBatch.to_pandas()` converts items to a pandas DataFrame.
+Requires optional `pandas` dependency (`pip install kpubdata[pandas]`).
+Returns `object` (a `pandas.DataFrame` at runtime).
 
 ### `schema()`
 
@@ -134,19 +140,19 @@ Avoid turning the public API into:
 Preferred:
 
 ```python
-client.dataset("seoul.subway.arrivals").list(station_name="강남")
+client.dataset("datago.village_fcst").list(base_date="20250401", base_time="0500", nx="55", ny="127")
 ```
 
 Acceptable advanced usage:
 
 ```python
-client.dataset("seoul.subway.arrivals").call_raw(operation="list", stationNm="강남")
+client.dataset("datago.village_fcst").call_raw("getVilageFcst", base_date="20250401", base_time="0500", nx="55", ny="127")
 ```
 
 Discouraged as the main public entry point:
 
 ```python
-client.call_provider_endpoint("seoul", "SearchSTNTimeTableByIDService", ...)
+client.call_provider_endpoint("datago", "getVilageFcst", ...)
 ```
 
 ---

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,7 +107,7 @@ KPubData는 이 모든 은행을 대신 처리해주는 **"통합 키오스크"*
 
 ### 4.3 Provider Adapter (통역사)
 *   **이 레이어가 하는 일**: 기관별로 제각각인 API 요청 방식을 KPubData 표준 방식으로 변환합니다. 한국어를 영어로, 영어를 한국어로 바꿔주는 통역사와 같습니다.
-*   **핵심 파일**: `providers/datago/adapter.py`, `providers/seoul/adapter.py`
+*   **핵심 파일**: `providers/datago/adapter.py`, `providers/bok/adapter.py`
 *   **수정 상황 예시**: 기상청 API의 주소가 바뀌었거나, 결과 데이터의 이름이 `nx`에서 `grid_x`로 변경되었을 때.
 *   **코드 예시**:
     ```python
@@ -451,13 +451,15 @@ graph TD
     core --> core_files[capability.py, dataset.py, query.py, result.py, schema.py]
     transport --> transport_files[http.py, auth.py, parse.py, retry.py]
     providers --> datago[datago/]
-    providers --> seoul[seoul/]
-    providers --> airkorea[airkorea/]
+    providers --> bok[bok/]
+    providers --> kosis[kosis/]
+    providers --> lofin[lofin/]
 
     subgraph Adapters [Provider Implementation]
     datago
-    seoul
-    airkorea
+    bok
+    kosis
+    lofin
     end
 ```
 
@@ -485,13 +487,12 @@ src/kpubdata/
       adapter.py
       discovery.py
       mappings.py
-    seoul/
+    bok/
       adapter.py
-      discovery.py
-      mappings.py
-    airkorea/
+    kosis/
       adapter.py
-      discovery.py
+    lofin/
+      adapter.py
       mappings.py
   adapters/
     pandas.py
@@ -512,7 +513,7 @@ Client.datasets.search("지하철")
 ### 9.2 Query flow
 
 ```text
-client.dataset("molit.apartment_trades").list(...)
+client.dataset("datago.apt_trade").list(...)
   -> Dataset.list(...)
   -> build Query
   -> ProviderAdapter.query_records(dataset_ref, query)

--- a/CANONICAL_MODEL.md
+++ b/CANONICAL_MODEL.md
@@ -24,7 +24,7 @@ classDiagram
         +str dataset_key
         +str name
         +Representation representation
-        +frozenset[Capability] capabilities
+        +frozenset[Operation] operations
     }
     class Query {
         +dict filters
@@ -160,7 +160,6 @@ from enum import Enum
 
 class Capability(str, Enum):
     LIST = "list"
-    GET = "get"
     SCHEMA = "schema"
     RAW = "raw"
     PAGEABLE = "pageable"
@@ -188,7 +187,6 @@ class Representation(str, Enum):
 graph TD
     subgraph Capabilities [Dataset Capabilities]
         LIST[LIST: Browse multiple records]
-        GET[GET: Fetch single record by ID]
         SCHEMA[SCHEMA: Metadata about fields]
         RAW[RAW: Provider escape hatch]
         PAGEABLE[PAGEABLE: Supports pagination]
@@ -215,13 +213,13 @@ class DatasetRef:
     dataset_key: str
     name: str
     representation: Representation
-    capabilities: frozenset[Capability] = frozenset()
+    operations: frozenset[Operation] = frozenset()
     raw_metadata: dict[str, Any] = field(default_factory=dict)
 ```
 
 Notes:
 
-- `id` is the stable bound identifier, e.g. `molit.apartment_trades`
+- `id` is the stable bound identifier, e.g. `datago.apt_trade`
 - `representation` matters because the same logical dataset may be offered in more than one form
 
 ### 3.4 Query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2025-04-17
+## [0.2.1] - 2025-04-17
+
+_Note: v0.2.0 was tagged but never published to PyPI due to CI formatting failures. v0.2.1 is the first public release of the 0.2.x series._
+
+## [0.2.0] - 2025-04-17 (not published)
 
 ### Added
 - Single-page pagination contract for all adapters (datago, bok, lofin, kosis)

--- a/PROVIDER_ADAPTER_CONTRACT.md
+++ b/PROVIDER_ADAPTER_CONTRACT.md
@@ -34,7 +34,7 @@ sequenceDiagram
     participant T as 전송 계층 (Transport)
     participant P as 공공 API (Public API)
 
-    U->>D: 데이터 요청 (list/get)
+    U->>D: 데이터 요청 (list)
     D->>A: 요청 전달
     A->>A: 표준 Query -> 기관용 파라미터 변환
     A->>T: HTTP 요청 실행

--- a/src/kpubdata/core/capability.py
+++ b/src/kpubdata/core/capability.py
@@ -19,7 +19,7 @@ def _dataclass(
     frozen: bool = False,
 ) -> Callable[[type[_T]], type[_T]]:
     def _decorate(cls: type[_T]) -> type[_T]:
-        return _stdlib_dataclass(slots=slots, frozen=frozen)(cls)  # pyright: ignore[reportCallIssue]
+        return _stdlib_dataclass(slots=slots, frozen=frozen)(cls)
 
     return _decorate
 
@@ -28,7 +28,6 @@ class Operation(str, Enum):
     """Major operations a dataset can support."""
 
     LIST = "list"
-    GET = "get"
     SCHEMA = "schema"
     RAW = "raw"
     DOWNLOAD = "download"

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from types import MappingProxyType
+from typing import cast
+
+import pytest
 
 from kpubdata.core.capability import Operation, PaginationMode, QuerySupport
 from kpubdata.core.models import DatasetRef, FieldDescriptor, Query, RecordBatch, SchemaDescriptor
@@ -12,7 +15,6 @@ from kpubdata.core.representation import Representation
 class TestOperation:
     def test_values(self) -> None:
         assert Operation.LIST.value == "list"
-        assert Operation.GET.value == "get"
         assert Operation.RAW.value == "raw"
 
     def test_str_mixin(self) -> None:
@@ -35,38 +37,35 @@ class TestQuerySupport:
 
     def test_frozen(self) -> None:
         qs = QuerySupport(pagination=PaginationMode.OFFSET)
-        try:
+        with pytest.raises(AttributeError):
             qs.pagination = PaginationMode.CURSOR  # type: ignore[misc]
-            raise AssertionError("Should be frozen")
-        except AttributeError:
-            pass
 
 
 class TestDatasetRef:
     def _make_ref(self, **kwargs: object) -> DatasetRef:
-        defaults: dict[str, object] = {
-            "id": "test.dataset",
-            "provider": "test",
-            "dataset_key": "dataset",
-            "name": "Test Dataset",
-            "representation": Representation.API_JSON,
-            "operations": frozenset({Operation.LIST, Operation.RAW}),
-        }
-        defaults.update(kwargs)
-        return DatasetRef(**defaults)  # type: ignore[arg-type]
+        return DatasetRef(
+            id=cast(str, kwargs.get("id", "test.dataset")),
+            provider=cast(str, kwargs.get("provider", "test")),
+            dataset_key=cast(str, kwargs.get("dataset_key", "dataset")),
+            name=cast(str, kwargs.get("name", "Test Dataset")),
+            representation=cast(
+                Representation, kwargs.get("representation", Representation.API_JSON)
+            ),
+            operations=cast(
+                frozenset[Operation],
+                kwargs.get("operations", frozenset({Operation.LIST, Operation.RAW})),
+            ),
+        )
 
     def test_supports(self) -> None:
         ref = self._make_ref()
         assert ref.supports(Operation.LIST) is True
-        assert ref.supports(Operation.GET) is False
+        assert ref.supports(Operation.SCHEMA) is False
 
     def test_frozen(self) -> None:
         ref = self._make_ref()
-        try:
+        with pytest.raises(AttributeError):
             ref.id = "changed"  # type: ignore[misc]
-            raise AssertionError("Should be frozen")
-        except AttributeError:
-            pass
 
     def test_raw_metadata_immutable(self) -> None:
         ref = self._make_ref()
@@ -107,7 +106,7 @@ class TestRecordBatch:
         assert len(batch) == 2
 
     def test_iter(self) -> None:
-        items = [{"a": 1}, {"a": 2}]
+        items: list[dict[str, object]] = [{"a": 1}, {"a": 2}]
         batch = RecordBatch(items=items, dataset=self._make_ref())
         assert list(batch) == items
 

--- a/tests/unit/core/test_models_fixtures.py
+++ b/tests/unit/core/test_models_fixtures.py
@@ -114,7 +114,7 @@ class TestDatasetRefFromCatalogue:
         ref = _make_ref(first_entry)
 
         assert ref.supports(Operation.LIST) is True
-        assert ref.supports(Operation.GET) is False
+        assert ref.supports(Operation.SCHEMA) is False
 
     def test_is_frozen(self) -> None:
         first_entry, _ = _load_catalogue_entries()

--- a/uv.lock
+++ b/uv.lock
@@ -462,7 +462,7 @@ wheels = [
 
 [[package]]
 name = "kpubdata"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Oracle 리뷰에서 지적된 #1~#4 항목 일괄 수정
- `Operation.GET` enum 값 제거 (어댑터 미구현 상태였음)
- `CHANGELOG.md`에 v0.2.1 실제 배포 버전 반영
- `API_SPEC.md`, `ARCHITECTURE.md`, `CANONICAL_MODEL.md`, `PROVIDER_ADAPTER_CONTRACT.md`에서 존재하지 않는 seoul/molit 예시를 실제 지원 데이터셋으로 교체
- `API_SPEC.md`에 `RecordBatch.to_pandas()` 문서 추가

## Quality Gates
- ruff check ✅
- ruff format ✅
- mypy ✅ (26 source files)
- pytest ✅ (320 passed)