### PR TITLE
fix: LofinAdapter SSL context ignored when Client passes shared transport

### DIFF
--- a/src/kpubdata/providers/lofin/adapter.py
+++ b/src/kpubdata/providers/lofin/adapter.py
@@ -15,12 +15,29 @@ from kpubdata.exceptions import (
 )
 from kpubdata.providers._common import build_schema_from_metadata, coerce_int, load_catalogue
 from kpubdata.transport.decode import decode_json
-from kpubdata.transport.http import HttpTransport, TransportConfig
+from kpubdata.transport.http import HttpTransport, TransportConfig, TransportRequirements
 
 logger = logging.getLogger("kpubdata.provider.lofin")
 
 
+def _lofin_ssl_context() -> ssl.SSLContext:
+    """Create an SSL context compatible with the LOFIN server.
+
+    The LOFIN server (www.lofin365.go.kr) uses TLSv1.2 with AES256-SHA256,
+    which requires a relaxed security level in OpenSSL 3.x.
+    """
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    ctx.set_ciphers("DEFAULT:@SECLEVEL=1")
+    return ctx
+
+
 class LofinAdapter:
+    transport_requirements: TransportRequirements = TransportRequirements(
+        ssl_context_factory=_lofin_ssl_context,
+    )
+
     def __init__(
         self,
         *,
@@ -32,10 +49,7 @@ class LofinAdapter:
         if transport is not None:
             self._transport: HttpTransport = transport
         else:
-            ssl_ctx = ssl.create_default_context()
-            ssl_ctx.check_hostname = False
-            ssl_ctx.verify_mode = ssl.CERT_NONE
-            ssl_ctx.set_ciphers("DEFAULT:@SECLEVEL=1")
+            ssl_ctx = _lofin_ssl_context()
             transport_config = TransportConfig(
                 timeout=self._config.timeout,
                 max_retries=self._config.max_retries,

--- a/tests/unit/providers/lofin/test_lofin_adapter.py
+++ b/tests/unit/providers/lofin/test_lofin_adapter.py
@@ -83,3 +83,38 @@ def test_query_records_uses_heuristic_next_page_without_total_count() -> None:
 
     assert batch.total_count is None
     assert batch.next_page == 2
+
+
+def test_transport_requirements_includes_ssl_context_factory() -> None:
+    """LofinAdapter exposes transport_requirements with an SSL context factory."""
+    reqs = LofinAdapter.transport_requirements
+    assert reqs is not None
+    assert reqs.ssl_context_factory is not None
+
+    ctx = reqs.ssl_context_factory()
+    import ssl
+
+    assert isinstance(ctx, ssl.SSLContext)
+
+
+def test_client_applies_lofin_ssl_context() -> None:
+    """Client detects LofinAdapter.transport_requirements and builds custom transport."""
+    from unittest.mock import patch
+
+    from kpubdata.client import Client
+    from kpubdata.transport.http import HttpTransport
+
+    with patch.object(
+        HttpTransport, "with_requirements", wraps=HttpTransport.with_requirements
+    ) as spy:
+        client = Client()
+        _ = client.datasets.list()
+
+    assert spy.call_count >= 1
+    for call in spy.call_args_list:
+        reqs = call[0][1] if len(call[0]) > 1 else call.kwargs.get("requirements")
+        if reqs and reqs.ssl_context_factory is not None:
+            return
+    raise AssertionError(
+        "HttpTransport.with_requirements was never called with ssl_context_factory"
+    )


### PR DESCRIPTION
## Summary

Closes #122

- `LofinAdapter`에 `transport_requirements` 클래스 속성을 추가하여 `ssl_context_factory`를 선언
- `Client`가 shared transport 대신 SSL context가 적용된 custom transport를 자동 생성
- LOFIN 서버(`www.lofin365.go.kr`)의 TLSv1.2 + `AES256-SHA256` 요구사항 충족

## Root Cause

`Client`가 모든 adapter에 shared `HttpTransport`를 주입하면서, `LofinAdapter`가 자체 SSL context를 생성하는 코드가 skip됨. `TransportRequirements` 메커니즘은 이미 존재했지만 adapter에서 선언하지 않았음.

## Changes

- `src/kpubdata/providers/lofin/adapter.py`: `_lofin_ssl_context()` 추출 + `transport_requirements` 클래스 속성 추가
- `tests/unit/providers/lofin/test_lofin_adapter.py`: SSL context factory 검증 + Client 통합 검증 테스트 추가

## Testing

- `ruff check` ✅
- `mypy src` ✅  
- `pytest` 325 passed ✅