### PR TITLE
fix(datago): treat resultCode '000' as success for RTMS endpoints

### DIFF
--- a/src/kpubdata/providers/datago/adapter.py
+++ b/src/kpubdata/providers/datago/adapter.py
@@ -29,6 +29,19 @@ from kpubdata.transport.http import HttpTransport, TransportConfig
 logger = logging.getLogger("kpubdata.provider.datago")
 
 
+def _is_success_code(code: str) -> bool:
+    """Return True for any data.go.kr resultCode that signals success.
+
+    Different endpoint families use different widths for the "no error" code:
+    "00" (most APIs) and "000" (RTMS family under apis.data.go.kr/1613000).
+    Both — and any zero-valued numeric variant — should be treated as success.
+    """
+    try:
+        return int(code) == 0
+    except ValueError:
+        return False
+
+
 class DataGoAdapter:
     """Adapter for data.go.kr (공공데이터포털).
 
@@ -245,7 +258,7 @@ class DataGoAdapter:
             "data.go.kr result",
             extra={"result_code": result_code, "result_msg": result_msg, "dataset_id": dataset_id},
         )
-        if result_code != "00":
+        if not _is_success_code(result_code):
             self._raise_for_result_code(result_code, result_msg, dataset_id)
 
         body_obj = response_dict.get("body")

--- a/tests/unit/providers/datago/test_adapter.py
+++ b/tests/unit/providers/datago/test_adapter.py
@@ -335,6 +335,33 @@ class TestDataGoAdapterQueryRecords:
         with pytest.raises(ServiceUnavailableError):
             _ = adapter.query_records(dataset, Query())
 
+    def test_query_records_accepts_three_digit_success_code_000(self) -> None:
+        payload = {
+            "response": {
+                "header": {"resultCode": "000", "resultMsg": "OK"},
+                "body": {
+                    "items": {"item": [{"dealAmount": "82,500", "aptNm": "래미안"}]},
+                    "totalCount": 1,
+                    "numOfRows": 100,
+                    "pageNo": 1,
+                },
+            }
+        }
+        adapter, dataset, _ = _build_adapter_with_transport([FakeResponse(payload)])
+
+        batch = adapter.query_records(dataset, Query(page=1, page_size=100))
+
+        assert len(batch.items) == 1
+        assert batch.items[0]["aptNm"] == "래미안"
+
+    def test_query_records_accepts_two_digit_success_code_00(self) -> None:
+        payload = _success_payload(items=[{"id": 1}], total_count=1, num_of_rows=100, page_no=1)
+        adapter, dataset, _ = _build_adapter_with_transport([FakeResponse(payload)])
+
+        batch = adapter.query_records(dataset, Query(page=1, page_size=100))
+
+        assert len(batch.items) == 1
+
     def test_query_records_filters_passed(self) -> None:
         payload = _success_payload(items=[{"id": 1}], total_count=1, num_of_rows=100, page_no=1)
         adapter, dataset, transport = _build_adapter_with_transport([FakeResponse(payload)])

--- a/uv.lock
+++ b/uv.lock
@@ -462,7 +462,7 @@ wheels = [
 
 [[package]]
 name = "kpubdata"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Accept any zero-valued `resultCode` (e.g. `"00"`, `"000"`) as success in `DataGoAdapter._validate_envelope`
- Add regression tests covering both two-digit (`"00"`) and three-digit (`"000"`) success codes

## Why

The data.go.kr RTMS family (`apis.data.go.kr/1613000/...`) returns `<resultCode>000</resultCode>` on success, but the previous strict equality check (`if result_code != "00"`) raised `ProviderResponseError("OK")` for valid responses.

This made all 13 `datago.*` RTMS datasets (`apt_trade`, `apt_rent`, `sh_trade`, `sh_rent`, `rh_trade`, `rh_rent`, `offi_trade`, `offi_rent`, etc.) unusable end-to-end despite passing authentication, transport, and XML parsing.

## Repro before fix

```python
from kpubdata import Client
Client.from_env().dataset("datago.apt_trade").list(LAWD_CD="11680", DEAL_YMD="202503")
# kpubdata.exceptions.ProviderResponseError: OK
```

Raw HTTP 200 response (correctly parsed as XML by transport layer):

```xml
<response>
  <header><resultCode>000</resultCode><resultMsg>OK</resultMsg></header>
  <body><items><item>...real data...</item></items></body>
</response>
```

## Approach

Replace the strict equality check with `int(code) == 0`. Any zero-valued numeric variant (`"00"`, `"000"`, `"0000"`, etc.) is now treated as success; non-numeric codes still fall through to the existing error mapping in `_raise_for_result_code`.

A small helper `_is_success_code(code: str) -> bool` is introduced at module level for clarity and so error-mapping tests remain trivially auditable.

## Tests

```
tests/unit/providers/datago/test_adapter.py::TestDataGoAdapterQueryRecords::test_query_records_accepts_three_digit_success_code_000 PASSED
tests/unit/providers/datago/test_adapter.py::TestDataGoAdapterQueryRecords::test_query_records_accepts_two_digit_success_code_00 PASSED
```

Full unit suite: **273 passed, 1 skipped**. All existing error-code tests (`30`, `22`, `10`, `12`, `01`) still pass — non-zero numeric codes continue to map to their respective exceptions.

## Closes

Closes #129