### PR TITLE
feat(datago): datago.generic raw 비상구 추가 (미등록 엔드포인트 즉시 호출)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,16 @@ print(df.head())
 
 > 검증 수준 및 실API 최종 검증일 등 상세 정보는 [SUPPORTED_DATA.md](./SUPPORTED_DATA.md)를 참고하세요.
 
+### 비상구 (Escape Hatches)
+
+정규화된 데이터셋이 아닌, 미등록 endpoint를 즉시 호출할 수 있게 해주는 raw 비상구입니다. 정규화·페이지네이션·스키마 보장이 없으며 호출자가 원본 응답을 직접 처리해야 합니다.
+
+| Provider | 비상구 키 | 용도 |
+|---|---|---|
+| 공공데이터포털 (`datago`) | `datago.generic` | 카탈로그에 없는 임의의 data.go.kr API를 `call_raw(operation, _base_url=..., **params)`로 호출 |
+
+자세한 사용법은 [docs/providers/datago.md](./docs/providers/datago.md#generic-범용-엔드포인트)와 [SUPPORTED_DATA.md](./SUPPORTED_DATA.md#비상구--고급-기능-escape-hatches)를 참고하세요.
+
 ## 문서 가이드 (Document Guide)
 
 KPubData의 설계 철학과 사용 방법을 안내하는 문서 목록입니다.

--- a/SUPPORTED_DATA.md
+++ b/SUPPORTED_DATA.md
@@ -60,3 +60,13 @@
 4. **README 동기화**: `지원` 항목만 [README.md](./README.md)의 요약 표에 추가
 5. **명칭 규칙**: provider slug와 dataset id는 코드의 실제 이름과 정확히 일치시킬 것
 6. **PR 포함**: adapter 추가/상태 변경 PR에는 이 문서의 업데이트를 반드시 포함
+
+## 비상구 / 고급 기능 (Escape Hatches)
+
+정규화된 데이터셋은 아니지만, 미등록 endpoint를 즉시 호출할 수 있게 해주는 raw 비상구입니다. 정규화·페이지네이션·스키마·엔드포인트별 호환은 보장되지 않으며, 호출자가 원본 응답을 직접 처리해야 합니다.
+
+| Provider | 비상구 키 | 용도 | 제약 |
+|---|---|---|---|
+| 공공데이터포털 (`datago`) | `datago.generic` | 카탈로그에 없는 임의의 data.go.kr endpoint를 `call_raw(operation, _base_url=..., **params)`로 호출 | `list()` 미지원 · 표준 envelope 검증은 옵션 (`_envelope=False`) · 응답 정규화 없음 · `*.data.go.kr` 외 호스트는 경고 로그 |
+
+특정 endpoint가 반복 사용된다면 비상구를 확장하지 말고 정식 dataset으로 등록(`기여자를 위한 새 데이터셋 추가 가이드` 참고)하는 것을 권장합니다.

--- a/docs/providers/datago.md
+++ b/docs/providers/datago.md
@@ -332,6 +332,47 @@ ds = client.dataset("datago.sh_rent")
 result = ds.list(LAWD_CD="11110", DEAL_YMD="202401")
 ```
 
+### generic (범용 엔드포인트)
+
+KPubData에 정식 등록되지 않은 임의의 data.go.kr 엔드포인트를 호출할 수 있는 비상구입니다. 카탈로그가 없는 API를 즉시 사용해야 할 때 활용하세요.
+
+- 제공 기관: data.go.kr (모든 기관)
+- 호출 방식: `call_raw(operation, _base_url=..., **params)` 만 지원합니다. `list()`는 지원하지 않습니다.
+- 인증키(`serviceKey`)는 자동으로 주입됩니다.
+
+| 매직 파라미터 | 필수 | 기본값 | 설명 |
+|---|---|---|---|
+| `_base_url` | 필수 | — | 엔드포인트 베이스 URL (`/operation` 직전까지) |
+| `_envelope` | 선택 | `True` | 표준 `response.header.resultCode` 검증 여부. 비표준 응답이면 `False` |
+| `_service_key_param` | 선택 | `serviceKey` | 인증키 파라미터 이름 변경 |
+| `_format_param` | 선택 | `resultType` | 응답 포맷 파라미터 이름 변경 |
+
+```python
+ds = client.dataset("datago.generic")
+
+# 예: 동네예보 API를 generic으로 호출
+result = ds.call_raw(
+    "getVilageFcst",
+    _base_url="http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0",
+    base_date="20250401",
+    base_time="0500",
+    nx="55",
+    ny="127",
+)
+```
+
+```python
+# 비표준 envelope 응답을 받는 엔드포인트
+result = ds.call_raw(
+    "getCustomData",
+    _base_url="http://apis.data.go.kr/XXXXXXX/SomeService",
+    _envelope=False,
+    someParam="value",
+)
+```
+
+> 주의: generic은 정규화된 `RecordBatch`를 반환하지 않고 원본 응답(dict)을 그대로 돌려줍니다. 페이지네이션·필드 정규화·타입 변환은 호출자가 직접 처리해야 합니다. 자주 사용하는 데이터셋이라면 정식 카탈로그 등록(`기여자를 위한 새 데이터셋 추가 가이드` 참고)을 권장합니다.
+
 ## 공공데이터포털 API 특이사항
 
 - **응답 형식**: JSON과 XML을 모두 지원하는 경우가 많으나, KPubData는 내부적으로 JSON 형식을 우선 사용합니다.

--- a/src/kpubdata/providers/datago/adapter.py
+++ b/src/kpubdata/providers/datago/adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping, Sequence
 from typing import NoReturn, cast
+from urllib.parse import urlparse
 
 from kpubdata.config import KPubDataConfig
 from kpubdata.core.models import (
@@ -106,6 +107,13 @@ class DataGoAdapter:
     def query_records(self, dataset: DatasetRef, query: Query) -> RecordBatch:
         """Query records from a data.go.kr dataset."""
 
+        if self._is_generic(dataset):
+            raise InvalidRequestError(
+                "datago.generic does not support list(); use call_raw with _base_url instead",
+                provider="datago",
+                dataset_id=dataset.id,
+            )
+
         page = query.page or 1
         page_size = query.page_size or 100
         logger.debug(
@@ -160,7 +168,23 @@ class DataGoAdapter:
         return build_schema_from_metadata(dataset)
 
     def call_raw(self, dataset: DatasetRef, operation: str, params: dict[str, object]) -> object:
-        """Call provider-native data.go.kr API operation."""
+        """Call provider-native data.go.kr API operation.
+
+        ``datago.generic`` is a raw-only escape hatch for data.go.kr endpoints
+        that are not in the curated catalogue. It returns the raw decoded
+        response (dict) — no normalization, no pagination, no schema. Callers
+        must pass:
+          * ``_base_url`` (str, REQUIRED): endpoint base URL up to (but not
+            including) the operation name.
+          * ``_envelope`` (bool, default True): when True, validate the
+            standard ``response.header.resultCode`` envelope. Must be a real
+            bool — strings/ints are rejected.
+          * ``_service_key_param`` (str): override service-key param name.
+          * ``_format_param`` (str): override response-format param name.
+
+        A warning is logged if ``_base_url`` does not point to a
+        ``*.data.go.kr`` host. The call still proceeds — this is a soft check.
+        """
 
         logger.debug(
             "datago call_raw",
@@ -170,6 +194,81 @@ class DataGoAdapter:
                 "param_keys": sorted(params.keys()),
             },
         )
+
+        is_generic = self._is_generic(dataset)
+        if is_generic:
+            base_url_override = params.get("_base_url")
+            if not isinstance(base_url_override, str) or not base_url_override:
+                raise InvalidRequestError(
+                    "datago.generic requires '_base_url' to be passed in params",
+                    provider="datago",
+                    dataset_id=dataset.id,
+                )
+            envelope_flag = params.get("_envelope", True)
+            if not isinstance(envelope_flag, bool):
+                raise InvalidRequestError(
+                    "datago.generic '_envelope' must be a bool (True or False)",
+                    provider="datago",
+                    dataset_id=dataset.id,
+                )
+            validate_envelope = envelope_flag
+            service_key_param_override = params.get("_service_key_param")
+            format_param_override = params.get("_format_param")
+
+            host = urlparse(base_url_override).hostname or ""
+            if not host.endswith(".data.go.kr") and host != "data.go.kr":
+                logger.warning(
+                    "datago.generic called with non-data.go.kr host",
+                    extra={
+                        "dataset_id": dataset.id,
+                        "operation": operation,
+                        "base_url": base_url_override,
+                        "host": host,
+                    },
+                )
+
+            url = f"{base_url_override.rstrip('/')}/{operation}"
+            logger.debug(
+                "datago.generic dispatch",
+                extra={
+                    "dataset_id": dataset.id,
+                    "operation": operation,
+                    "base_url": base_url_override,
+                    "envelope": validate_envelope,
+                },
+            )
+            request_params = self._build_base_params(
+                dataset,
+                service_key_param_override=(
+                    service_key_param_override
+                    if isinstance(service_key_param_override, str)
+                    else None
+                ),
+                format_param_override=(
+                    format_param_override if isinstance(format_param_override, str) else None
+                ),
+            )
+            service_key_param = (
+                service_key_param_override
+                if isinstance(service_key_param_override, str) and service_key_param_override
+                else str(dataset.raw_metadata.get("service_key_param", "serviceKey"))
+            )
+            magic_keys = {
+                "_base_url",
+                "_envelope",
+                "_service_key_param",
+                "_format_param",
+            }
+            for key, value in params.items():
+                if key in magic_keys or key == service_key_param:
+                    continue
+                request_params[key] = str(value)
+
+            payload = self._request_and_decode(url, request_params)
+            if validate_envelope:
+                _ = self._validate_envelope(payload, dataset.id)
+            return payload
+
         url = self._build_request_url(dataset, operation)
         request_params = self._build_base_params(dataset)
 
@@ -181,6 +280,10 @@ class DataGoAdapter:
         payload = self._request_and_decode(url, request_params)
         _ = self._validate_envelope(payload, dataset.id)
         return payload
+
+    @staticmethod
+    def _is_generic(dataset: DatasetRef) -> bool:
+        return bool(dataset.raw_metadata.get("generic"))
 
     def _require_api_key(self) -> str:
         return self._config.require_provider_key("datago")
@@ -198,10 +301,24 @@ class DataGoAdapter:
             return f"{base_url_raw}/{selected_operation}"
         return base_url_raw
 
-    def _build_base_params(self, dataset: DatasetRef) -> dict[str, str]:
+    def _build_base_params(
+        self,
+        dataset: DatasetRef,
+        *,
+        service_key_param_override: str | None = None,
+        format_param_override: str | None = None,
+    ) -> dict[str, str]:
         api_key = self._require_api_key()
-        service_key_param_raw = dataset.raw_metadata.get("service_key_param", "serviceKey")
-        format_param_raw = dataset.raw_metadata.get("format_param", "resultType")
+        service_key_param_raw = (
+            service_key_param_override
+            if service_key_param_override
+            else dataset.raw_metadata.get("service_key_param", "serviceKey")
+        )
+        format_param_raw = (
+            format_param_override
+            if format_param_override
+            else dataset.raw_metadata.get("format_param", "resultType")
+        )
         service_key_param = (
             service_key_param_raw
             if isinstance(service_key_param_raw, str) and service_key_param_raw

--- a/src/kpubdata/providers/datago/catalogue.json
+++ b/src/kpubdata/providers/datago/catalogue.json
@@ -193,5 +193,15 @@
       "pagination": "offset",
       "max_page_size": 1000
     }
+  },
+  {
+    "dataset_key": "generic",
+    "name": "범용 data.go.kr 엔드포인트 (Generic Endpoint)",
+    "representation": "api_json",
+    "service_key_param": "serviceKey",
+    "format_param": "resultType",
+    "description": "Call any data.go.kr API endpoint by passing _base_url at call time. Only call_raw is supported; list() is not available because schema and pagination vary by endpoint.",
+    "operations": ["raw"],
+    "generic": true
   }
 ]

--- a/tests/unit/providers/datago/test_adapter.py
+++ b/tests/unit/providers/datago/test_adapter.py
@@ -427,7 +427,7 @@ class TestDataGoAdapterCatalogueOperations:
     def test_default_catalogue_has_operations(self) -> None:
         adapter = DataGoAdapter()
 
-        datasets = adapter.list_datasets()
+        datasets = [d for d in adapter.list_datasets() if not d.raw_metadata.get("generic")]
         assert datasets
         for dataset in datasets:
             assert Operation.LIST in dataset.operations
@@ -436,7 +436,7 @@ class TestDataGoAdapterCatalogueOperations:
     def test_default_catalogue_has_query_support(self) -> None:
         adapter = DataGoAdapter()
 
-        datasets = adapter.list_datasets()
+        datasets = [d for d in adapter.list_datasets() if not d.raw_metadata.get("generic")]
         assert datasets
         for dataset in datasets:
             assert dataset.query_support is not None

--- a/tests/unit/providers/datago/test_generic.py
+++ b/tests/unit/providers/datago/test_generic.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+from typing import cast
+
+import pytest
+
+from kpubdata.config import KPubDataConfig
+from kpubdata.exceptions import ConfigError, InvalidRequestError
+from kpubdata.providers.datago.adapter import DataGoAdapter
+from kpubdata.transport.http import HttpTransport
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, object], content_type: str = "application/json") -> None:
+        self.headers: dict[str, str] = {"content-type": content_type}
+        self.text: str = json.dumps(payload)
+        self.content: bytes = self.text.encode()
+
+
+class FakeTransport:
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self._responses: list[FakeResponse] = list(responses)
+        self.calls: list[dict[str, object]] = []
+
+    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, **kwargs})
+        return self._responses.pop(0)
+
+
+def _success_envelope() -> dict[str, object]:
+    return {
+        "response": {
+            "header": {"resultCode": "00", "resultMsg": "OK"},
+            "body": {"items": {"item": [{"x": "1"}]}, "totalCount": 1},
+        }
+    }
+
+
+def _build_adapter(responses: list[FakeResponse]) -> tuple[DataGoAdapter, FakeTransport]:
+    transport = FakeTransport(responses)
+    config = KPubDataConfig(provider_keys={"datago": "test-key"})
+    adapter = DataGoAdapter(
+        config=config,
+        transport=cast(HttpTransport, cast(object, transport)),
+    )
+    return adapter, transport
+
+
+class TestDataGoGenericDataset:
+    def test_generic_dataset_in_catalogue(self) -> None:
+        adapter = DataGoAdapter()
+
+        dataset = adapter.get_dataset("generic")
+
+        assert dataset.id == "datago.generic"
+        assert dataset.dataset_key == "generic"
+        assert dataset.raw_metadata.get("generic") is True
+
+    def test_call_raw_with_base_url_builds_url(self) -> None:
+        adapter, transport = _build_adapter([FakeResponse(_success_envelope())])
+        dataset = adapter.get_dataset("generic")
+
+        adapter.call_raw(
+            dataset,
+            "getVilageFcst",
+            {
+                "_base_url": "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0",
+                "base_date": "20250401",
+                "nx": "55",
+            },
+        )
+
+        call = transport.calls[0]
+        assert (
+            call["url"] == "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst"
+        )
+        params = cast(dict[str, str], call["params"])
+        assert params["serviceKey"] == "test-key"
+        assert params["base_date"] == "20250401"
+        assert params["nx"] == "55"
+        assert "_base_url" not in params
+
+    def test_call_raw_strips_trailing_slash_from_base_url(self) -> None:
+        adapter, transport = _build_adapter([FakeResponse(_success_envelope())])
+        dataset = adapter.get_dataset("generic")
+
+        adapter.call_raw(
+            dataset,
+            "getX",
+            {"_base_url": "http://apis.data.go.kr/foo/bar/"},
+        )
+
+        assert transport.calls[0]["url"] == "http://apis.data.go.kr/foo/bar/getX"
+
+    def test_call_raw_missing_base_url_raises(self) -> None:
+        adapter, _ = _build_adapter([])
+        dataset = adapter.get_dataset("generic")
+
+        with pytest.raises(InvalidRequestError, match="_base_url"):
+            adapter.call_raw(dataset, "getX", {})
+
+    def test_call_raw_envelope_skip_allows_non_standard_payload(self) -> None:
+        non_standard = {"items": [{"a": 1}]}
+        adapter, _ = _build_adapter([FakeResponse(non_standard)])
+        dataset = adapter.get_dataset("generic")
+
+        result = adapter.call_raw(
+            dataset,
+            "getX",
+            {
+                "_base_url": "http://apis.data.go.kr/foo/bar",
+                "_envelope": False,
+            },
+        )
+
+        assert result == non_standard
+
+    def test_call_raw_with_service_key_param_override(self) -> None:
+        adapter, transport = _build_adapter([FakeResponse(_success_envelope())])
+        dataset = adapter.get_dataset("generic")
+
+        adapter.call_raw(
+            dataset,
+            "getX",
+            {
+                "_base_url": "http://apis.data.go.kr/foo/bar",
+                "_service_key_param": "ServiceKey",
+            },
+        )
+
+        params = cast(dict[str, str], transport.calls[0]["params"])
+        assert params["ServiceKey"] == "test-key"
+        assert "serviceKey" not in params
+
+    def test_call_raw_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("KPUBDATA_DATAGO_API_KEY", raising=False)
+        transport = FakeTransport([])
+        adapter = DataGoAdapter(
+            config=KPubDataConfig(),
+            transport=cast(HttpTransport, cast(object, transport)),
+        )
+        dataset = adapter.get_dataset("generic")
+
+        with pytest.raises(ConfigError):
+            adapter.call_raw(
+                dataset,
+                "getX",
+                {"_base_url": "http://apis.data.go.kr/foo/bar"},
+            )
+
+    def test_list_on_generic_raises(self) -> None:
+        from kpubdata.core.models import Query
+
+        adapter, _ = _build_adapter([])
+        dataset = adapter.get_dataset("generic")
+
+        with pytest.raises(InvalidRequestError, match="generic"):
+            adapter.query_records(dataset, Query())
+
+    def test_envelope_must_be_bool(self) -> None:
+        adapter, _ = _build_adapter([FakeResponse(_success_envelope())])
+        dataset = adapter.get_dataset("generic")
+
+        with pytest.raises(InvalidRequestError, match="_envelope"):
+            adapter.call_raw(
+                dataset,
+                "getX",
+                {
+                    "_base_url": "http://apis.data.go.kr/foo/bar",
+                    "_envelope": "false",
+                },
+            )
+
+    def test_envelope_rejects_int(self) -> None:
+        adapter, _ = _build_adapter([FakeResponse(_success_envelope())])
+        dataset = adapter.get_dataset("generic")
+
+        with pytest.raises(InvalidRequestError, match="_envelope"):
+            adapter.call_raw(
+                dataset,
+                "getX",
+                {
+                    "_base_url": "http://apis.data.go.kr/foo/bar",
+                    "_envelope": 0,
+                },
+            )
+
+    def test_non_data_go_kr_host_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        adapter, _ = _build_adapter([FakeResponse(_success_envelope())])
+        dataset = adapter.get_dataset("generic")
+
+        with caplog.at_level(logging.WARNING, logger="kpubdata.provider.datago"):
+            adapter.call_raw(
+                dataset,
+                "getX",
+                {"_base_url": "http://example.com/foo"},
+            )
+
+        assert any("non-data.go.kr host" in record.message for record in caplog.records)
+
+    def test_data_go_kr_host_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        adapter, _ = _build_adapter([FakeResponse(_success_envelope())])
+        dataset = adapter.get_dataset("generic")
+
+        with caplog.at_level(logging.WARNING, logger="kpubdata.provider.datago"):
+            adapter.call_raw(
+                dataset,
+                "getX",
+                {"_base_url": "http://apis.data.go.kr/foo/bar"},
+            )
+
+        assert not any("non-data.go.kr" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

카탈로그에 등록되지 않은 임의의 data.go.kr API를 즉시 호출할 수 있는 raw 비상구 `datago.generic`를 추가합니다. Oracle 아키텍처 리뷰를 받아 권고사항(엄격한 `_envelope` 검증, 호스트 경고 로그, "지원 데이터셋" 분리 표기)을 반영했습니다.

## 사용 예

\`\`\`python
ds = client.dataset("datago.generic")

result = ds.call_raw(
    "getVilageFcst",
    _base_url="http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0",
    base_date="20250401", base_time="0500", nx="55", ny="127",
)
\`\`\`

매직 파라미터:
- `_base_url` (필수): endpoint base URL
- `_envelope` (bool, 기본 True): 표준 `response.header.resultCode` 검증 — 엄격 bool 검증 (문자열/int 거부)
- `_service_key_param`, `_format_param`: 파라미터 이름 override

## Oracle 검토 결과 반영

판정: **APPROVE_WITH_MINOR_TWEAKS**. 다음 권고사항을 적용했습니다.

1. ✅ 현재 shape 유지 (`client.dataset(\"datago.generic\").call_raw(...)`) — 새 top-level public API 추가 안 함
2. ✅ docstring/문서에서 "데이터셋"보다 "raw 비상구" 성격 강조
3. ✅ `_envelope`이 `bool`이 아니면 `InvalidRequestError` (이전엔 `bool(...)` 강제변환으로 `\"false\"`가 True가 됨)
4. ✅ `list()`는 `InvalidRequestError`로 명시적 거부
5. ✅ `*.data.go.kr` 외 호스트는 경고 로그 (블로킹은 안 함)
6. ✅ `SUPPORTED_DATA.md`/`README.md`에서 "지원 데이터셋" 표가 아닌 별도 "비상구 / 고급 기능" 섹션으로 분리

## Changes

- `src/kpubdata/providers/datago/catalogue.json`: `generic` 항목 추가 (`base_url` 없음, `\"generic\": true` 마커)
- `src/kpubdata/providers/datago/adapter.py`: generic dispatch 분기, 엄격한 `_envelope` 타입 체크, host 경고 로그
- `tests/unit/providers/datago/test_generic.py`: 12개 신규 unit 테스트
- `tests/unit/providers/datago/test_adapter.py`: 기존 카탈로그 일관성 테스트가 generic을 건너뛰도록 수정
- `docs/providers/datago.md`: \"generic (범용 엔드포인트)\" 섹션 추가
- `README.md`, `SUPPORTED_DATA.md`: 비상구 전용 섹션 신설

## Validation

- \`uv run ruff check .\` — passed
- \`uv run ruff format --check .\` — passed (80 files)
- \`uv run mypy src\` — passed (26 source files)
- \`uv run pytest -q\` — **385 passed**, 1 skipped, 58 deselected

## 비상구 정책

특정 endpoint가 반복 사용되면 generic을 확장하지 말고 정식 dataset으로 등록하는 것이 권장됩니다 (`docs/providers/datago.md` 기여자 가이드 참고).