### PR TITLE
feat(datago): 인기 data.go.kr 6종(TourAPI 4 + 서울교통공사 2) 사전 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,12 @@ print(df.head())
 | 공공데이터포털 (`datago`) | 연립다세대 전월세 실거래가 (`rh_rent`) | 지원 |
 | 공공데이터포털 (`datago`) | 단독/다가구 매매 실거래가 (`sh_trade`) | 지원 |
 | 공공데이터포털 (`datago`) | 단독/다가구 전월세 실거래가 (`sh_rent`) | 지원 |
+| 공공데이터포털 (`datago`) | 한국관광공사 지역기반 관광정보 (`tour_kor_area`) | 지원 |
+| 공공데이터포털 (`datago`) | 한국관광공사 위치기반 관광정보 (`tour_kor_location`) | 지원 |
+| 공공데이터포털 (`datago`) | 한국관광공사 키워드 검색 (`tour_kor_keyword`) | 지원 |
+| 공공데이터포털 (`datago`) | 한국관광공사 행사정보 (`tour_kor_festival`) | 지원 |
+| 공공데이터포털 (`datago`) | 서울교통공사 실시간 운임정보 (`metro_fare`) | 지원 |
+| 공공데이터포털 (`datago`) | 서울교통공사 최단경로 이동정보 (`metro_path`) | 지원 |
 | 한국은행 ECOS (`bok`) | 기준금리 (`base_rate`) | 지원 |
 | 통계청 KOSIS (`kosis`) | 인구이동 (`population_migration`) | 지원 |
 | 지방재정365 (`lofin`) | 세출결산총괄 (`expenditure_budget`) | 지원 |

--- a/SUPPORTED_DATA.md
+++ b/SUPPORTED_DATA.md
@@ -35,6 +35,12 @@
 | 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `air_quality` | 대기오염정보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
 | 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `bus_arrival` | 경기도 버스도착정보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
 | 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `hospital_info` | 병원정보서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
+| 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `tour_kor_area` | 한국관광공사 지역기반 관광정보 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr/15101578](https://www.data.go.kr/data/15101578/openapi.do) | TourAPI KorService2 / `areaBasedList2` |
+| 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `tour_kor_location` | 한국관광공사 위치기반 관광정보 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr/15101578](https://www.data.go.kr/data/15101578/openapi.do) | TourAPI KorService2 / `locationBasedList2` |
+| 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `tour_kor_keyword` | 한국관광공사 키워드 검색 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr/15101578](https://www.data.go.kr/data/15101578/openapi.do) | TourAPI KorService2 / `searchKeyword2` |
+| 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `tour_kor_festival` | 한국관광공사 행사정보 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr/15101578](https://www.data.go.kr/data/15101578/openapi.do) | TourAPI KorService2 / `searchFestival2` |
+| 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `metro_fare` | 서울교통공사 실시간 운임정보 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr/15143846](https://www.data.go.kr/data/15143846/openapi.do) | 서울교통공사 / `getRltmFare2` |
+| 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `metro_path` | 서울교통공사 최단경로 이동정보 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr/15143842](https://www.data.go.kr/data/15143842/openapi.do) | 서울교통공사 / `getShtrmPath` |
 | 지원 | 테스트 검증 | - | 지방행정인허가 (`localdata`) | `general_restaurant` | 일반음식점 인허가 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 행정안전부 제공, service_name 실API 검증 완료 (data.go.kr 이관) |
 | 지원 | 테스트 검증 | - | 지방행정인허가 (`localdata`) | `rest_cafe` | 휴게음식점 인허가 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 행정안전부 제공, service_name 실API 검증 완료 |
 | 지원 | 실API 검증 | 2025-04-15 | 한국은행 ECOS (`bok`) | `base_rate` | 한국은행 기준금리 | [ECOS](https://ecos.bok.or.kr/api/) 인증키 | [ecos.bok.or.kr](https://ecos.bok.or.kr/api/) | |

--- a/docs/providers/datago.md
+++ b/docs/providers/datago.md
@@ -74,7 +74,7 @@ curl "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?ser
 
 ## KPubData에서 신청해야 할 API 목록
 
-현재 KPubData가 지원하는 datago 데이터셋을 모두 사용하려면, 아래 13개 API를 각각 활용신청해야 합니다.
+현재 KPubData가 지원하는 datago 데이터셋을 모두 사용하려면, 아래 19개 API를 각각 활용신청해야 합니다.
 
 | # | data.go.kr 검색어 | 제공기관 | 승인 방식 |
 |---|---|---|---|
@@ -91,6 +91,14 @@ curl "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?ser
 | 11 | `연립다세대 전월세 실거래자료 조회 서비스` | 국토교통부 | 자동 승인 |
 | 12 | `단독/다가구 매매 실거래 조회 서비스` | 국토교통부 | 자동 승인 |
 | 13 | `단독/다가구 전월세 자료 조회 서비스` | 국토교통부 | 자동 승인 |
+| 14 | `한국관광공사_국문 관광정보 서비스_GW` ([15101578](https://www.data.go.kr/data/15101578/openapi.do)) | 한국관광공사 | 자동 승인 (개발) / 심의 승인 (운영) |
+| 15 | `한국관광공사_국문 관광정보 서비스_GW` (위 신청 1건으로 `tour_kor_location` 포함) | 한국관광공사 | 14번과 동일 신청 |
+| 16 | `한국관광공사_국문 관광정보 서비스_GW` (위 신청 1건으로 `tour_kor_keyword` 포함) | 한국관광공사 | 14번과 동일 신청 |
+| 17 | `한국관광공사_국문 관광정보 서비스_GW` (위 신청 1건으로 `tour_kor_festival` 포함) | 한국관광공사 | 14번과 동일 신청 |
+| 18 | `서울교통공사_실시간운임정보` ([15143846](https://www.data.go.kr/data/15143846/openapi.do)) | 서울교통공사 | 자동 승인 |
+| 19 | `서울교통공사_최단경로이동정보` ([15143842](https://www.data.go.kr/data/15143842/openapi.do)) | 서울교통공사 | 자동 승인 |
+
+> 💡 14~17은 모두 동일한 한국관광공사 TourAPI(KorService2) 단일 활용신청으로 한꺼번에 발급됩니다 — 활용신청은 1건이지만 4개 endpoint(`areaBasedList2`, `locationBasedList2`, `searchKeyword2`, `searchFestival2`)가 KPubData에서 별도 dataset_key로 노출됩니다.
 
 ## 지원 데이터셋
 
@@ -372,6 +380,144 @@ result = ds.call_raw(
 ```
 
 > 주의: generic은 정규화된 `RecordBatch`를 반환하지 않고 원본 응답(dict)을 그대로 돌려줍니다. 페이지네이션·필드 정규화·타입 변환은 호출자가 직접 처리해야 합니다. 자주 사용하는 데이터셋이라면 정식 카탈로그 등록(`기여자를 위한 새 데이터셋 추가 가이드` 참고)을 권장합니다.
+
+### tour_kor_area (한국관광공사 지역기반 관광정보)
+
+한국관광공사 TourAPI(KorService2)의 `areaBasedList2` 엔드포인트로, 지역코드 기준 관광지 목록을 조회합니다.
+
+- 제공 기관: 한국관광공사
+- 데이터 ID: [15101578](https://www.data.go.kr/data/15101578/openapi.do)
+- 주요 파라미터: `MobileOS`, `MobileApp` (필수), `areaCode`, `contentTypeId`, `numOfRows`, `pageNo`
+
+| 파라미터 | 필수 | 설명 | 예시 |
+|---|---|---|---|
+| MobileOS | 필수 | OS 구분 | "ETC" |
+| MobileApp | 필수 | 앱 이름 | "kpubdata" |
+| areaCode | 선택 | 지역 코드 | "1" (서울) |
+| contentTypeId | 선택 | 관광 타입 ID | "12" (관광지) |
+| numOfRows | 선택 | 한 페이지 결과 수 | "10" |
+| pageNo | 선택 | 페이지 번호 | "1" |
+
+```python
+ds = client.dataset("datago.tour_kor_area")
+raw = ds.call_raw(
+    "areaBasedList2",
+    MobileOS="ETC",
+    MobileApp="kpubdata",
+    numOfRows="5",
+    pageNo="1",
+    areaCode="1",
+)
+```
+
+### tour_kor_location (한국관광공사 위치기반 관광정보)
+
+위경도 좌표와 반경을 기준으로 주변 관광 정보를 조회합니다 (`locationBasedList2`).
+
+- 제공 기관: 한국관광공사
+- 데이터 ID: [15101578](https://www.data.go.kr/data/15101578/openapi.do)
+- 주요 파라미터: `MobileOS`, `MobileApp`, `mapX`, `mapY`, `radius`
+
+| 파라미터 | 필수 | 설명 | 예시 |
+|---|---|---|---|
+| MobileOS | 필수 | OS 구분 | "ETC" |
+| MobileApp | 필수 | 앱 이름 | "kpubdata" |
+| mapX | 필수 | 경도 (WGS84) | "126.9784" |
+| mapY | 필수 | 위도 (WGS84) | "37.5665" |
+| radius | 필수 | 반경 (m, 최대 20000) | "1000" |
+
+```python
+ds = client.dataset("datago.tour_kor_location")
+raw = ds.call_raw(
+    "locationBasedList2",
+    MobileOS="ETC",
+    MobileApp="kpubdata",
+    mapX="126.9784",
+    mapY="37.5665",
+    radius="1000",
+    numOfRows="5",
+    pageNo="1",
+)
+```
+
+### tour_kor_keyword (한국관광공사 키워드 검색)
+
+키워드로 관광 정보를 검색합니다 (`searchKeyword2`).
+
+- 제공 기관: 한국관광공사
+- 데이터 ID: [15101578](https://www.data.go.kr/data/15101578/openapi.do)
+- 주요 파라미터: `MobileOS`, `MobileApp`, `keyword`
+
+| 파라미터 | 필수 | 설명 | 예시 |
+|---|---|---|---|
+| MobileOS | 필수 | OS 구분 | "ETC" |
+| MobileApp | 필수 | 앱 이름 | "kpubdata" |
+| keyword | 필수 | 검색 키워드 | "경복궁" |
+
+```python
+ds = client.dataset("datago.tour_kor_keyword")
+raw = ds.call_raw(
+    "searchKeyword2",
+    MobileOS="ETC",
+    MobileApp="kpubdata",
+    keyword="경복궁",
+    numOfRows="5",
+    pageNo="1",
+)
+```
+
+### tour_kor_festival (한국관광공사 행사정보)
+
+날짜 범위 기준으로 행사·축제 정보를 조회합니다 (`searchFestival2`).
+
+- 제공 기관: 한국관광공사
+- 데이터 ID: [15101578](https://www.data.go.kr/data/15101578/openapi.do)
+- 주요 파라미터: `MobileOS`, `MobileApp`, `eventStartDate`
+
+| 파라미터 | 필수 | 설명 | 예시 |
+|---|---|---|---|
+| MobileOS | 필수 | OS 구분 | "ETC" |
+| MobileApp | 필수 | 앱 이름 | "kpubdata" |
+| eventStartDate | 필수 | 행사 시작일 (YYYYMMDD) | "20250101" |
+| eventEndDate | 선택 | 행사 종료일 (YYYYMMDD) | "20251231" |
+
+```python
+ds = client.dataset("datago.tour_kor_festival")
+raw = ds.call_raw(
+    "searchFestival2",
+    MobileOS="ETC",
+    MobileApp="kpubdata",
+    eventStartDate="20250101",
+    numOfRows="5",
+    pageNo="1",
+)
+```
+
+### metro_fare (서울교통공사 실시간 운임정보)
+
+서울교통공사의 출발역-도착역 간 실시간 운임 정보를 조회합니다 (`getRltmFare2`).
+
+- 제공 기관: 서울교통공사
+- 데이터 ID: [15143846](https://www.data.go.kr/data/15143846/openapi.do)
+- 주요 파라미터: `numOfRows`, `pageNo`
+
+```python
+ds = client.dataset("datago.metro_fare")
+raw = ds.call_raw("getRltmFare2", numOfRows="5", pageNo="1")
+```
+
+### metro_path (서울교통공사 최단경로 이동정보)
+
+두 지하철역 간 최단 경로(환승·소요시간 등)를 조회합니다 (`getShtrmPath`).
+
+- 제공 기관: 서울교통공사
+- 데이터 ID: [15143842](https://www.data.go.kr/data/15143842/openapi.do)
+- 주요 파라미터: `numOfRows`, `pageNo`
+
+```python
+ds = client.dataset("datago.metro_path")
+raw = ds.call_raw("getShtrmPath", numOfRows="5", pageNo="1")
+```
 
 ## 공공데이터포털 API 특이사항
 

--- a/src/kpubdata/providers/datago/catalogue.json
+++ b/src/kpubdata/providers/datago/catalogue.json
@@ -203,5 +203,95 @@
     "description": "Call any data.go.kr API endpoint by passing _base_url at call time. Only call_raw is supported; list() is not available because schema and pagination vary by endpoint.",
     "operations": ["raw"],
     "generic": true
+  },
+  {
+    "dataset_key": "tour_kor_area",
+    "name": "한국관광공사 지역기반 관광정보 (TourAPI Area-Based List)",
+    "base_url": "http://apis.data.go.kr/B551011/KorService2",
+    "default_operation": "areaBasedList2",
+    "representation": "api_json",
+    "service_key_param": "serviceKey",
+    "format_param": "_type",
+    "description": "KTO Korean tourism information by region (TourAPI KorService2)",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000
+    }
+  },
+  {
+    "dataset_key": "tour_kor_location",
+    "name": "한국관광공사 위치기반 관광정보 (TourAPI Location-Based List)",
+    "base_url": "http://apis.data.go.kr/B551011/KorService2",
+    "default_operation": "locationBasedList2",
+    "representation": "api_json",
+    "service_key_param": "serviceKey",
+    "format_param": "_type",
+    "description": "KTO Korean tourism information by latitude/longitude (TourAPI KorService2)",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000
+    }
+  },
+  {
+    "dataset_key": "tour_kor_keyword",
+    "name": "한국관광공사 키워드 검색 (TourAPI Keyword Search)",
+    "base_url": "http://apis.data.go.kr/B551011/KorService2",
+    "default_operation": "searchKeyword2",
+    "representation": "api_json",
+    "service_key_param": "serviceKey",
+    "format_param": "_type",
+    "description": "KTO Korean tourism keyword search (TourAPI KorService2)",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000
+    }
+  },
+  {
+    "dataset_key": "tour_kor_festival",
+    "name": "한국관광공사 행사정보 (TourAPI Festival Search)",
+    "base_url": "http://apis.data.go.kr/B551011/KorService2",
+    "default_operation": "searchFestival2",
+    "representation": "api_json",
+    "service_key_param": "serviceKey",
+    "format_param": "_type",
+    "description": "KTO Korean tourism festival/event search by date (TourAPI KorService2)",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000
+    }
+  },
+  {
+    "dataset_key": "metro_fare",
+    "name": "서울교통공사 실시간 운임정보 (Seoul Metro Real-time Fare)",
+    "base_url": "http://apis.data.go.kr/B553766/fare2",
+    "default_operation": "getRltmFare2",
+    "representation": "api_json",
+    "service_key_param": "serviceKey",
+    "format_param": "_type",
+    "description": "Seoul Metro real-time fare information by station pair",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000
+    }
+  },
+  {
+    "dataset_key": "metro_path",
+    "name": "서울교통공사 최단경로 이동정보 (Seoul Metro Shortest Path)",
+    "base_url": "http://apis.data.go.kr/B553766/path",
+    "default_operation": "getShtrmPath",
+    "representation": "api_json",
+    "service_key_param": "serviceKey",
+    "format_param": "_type",
+    "description": "Seoul Metro shortest path between two subway stations",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000
+    }
   }
 ]

--- a/tests/fixtures/datago/success_metro_fare.json
+++ b/tests/fixtures/datago/success_metro_fare.json
@@ -1,0 +1,31 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "0000",
+      "resultMsg": "OK"
+    },
+    "body": {
+      "items": {
+        "item": [
+          {
+            "startStation": "150",
+            "endStation": "201",
+            "fareCash": 1400,
+            "fareCard": 1370,
+            "fareTransfer": 0
+          },
+          {
+            "startStation": "150",
+            "endStation": "202",
+            "fareCash": 1500,
+            "fareCard": 1470,
+            "fareTransfer": 0
+          }
+        ]
+      },
+      "numOfRows": 10,
+      "pageNo": 1,
+      "totalCount": 2
+    }
+  }
+}

--- a/tests/fixtures/datago/success_metro_path.json
+++ b/tests/fixtures/datago/success_metro_path.json
@@ -1,0 +1,38 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "0000",
+      "resultMsg": "OK"
+    },
+    "body": {
+      "items": {
+        "item": [
+          {
+            "seq": 1,
+            "stationCode": "150",
+            "stationName": "서울역",
+            "lineNum": "1",
+            "transferYn": "N"
+          },
+          {
+            "seq": 2,
+            "stationCode": "151",
+            "stationName": "시청",
+            "lineNum": "1",
+            "transferYn": "N"
+          },
+          {
+            "seq": 3,
+            "stationCode": "201",
+            "stationName": "시청",
+            "lineNum": "2",
+            "transferYn": "Y"
+          }
+        ]
+      },
+      "numOfRows": 10,
+      "pageNo": 1,
+      "totalCount": 3
+    }
+  }
+}

--- a/tests/fixtures/datago/success_tour_kor_area.json
+++ b/tests/fixtures/datago/success_tour_kor_area.json
@@ -1,0 +1,39 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "0000",
+      "resultMsg": "OK"
+    },
+    "body": {
+      "items": {
+        "item": [
+          {
+            "addr1": "서울특별시 종로구 사직로 161",
+            "areacode": "1",
+            "contentid": "264337",
+            "contenttypeid": "14",
+            "firstimage": "http://tong.visitkorea.or.kr/cms/resource/77/2741177_image2_1.jpg",
+            "mapx": "126.9769930325",
+            "mapy": "37.5797664925",
+            "title": "경복궁",
+            "sigungucode": "23"
+          },
+          {
+            "addr1": "서울특별시 중구 세종대로 99",
+            "areacode": "1",
+            "contentid": "264336",
+            "contenttypeid": "14",
+            "firstimage": "",
+            "mapx": "126.9774102330",
+            "mapy": "37.5660250785",
+            "title": "덕수궁",
+            "sigungucode": "24"
+          }
+        ]
+      },
+      "numOfRows": 10,
+      "pageNo": 1,
+      "totalCount": 2
+    }
+  }
+}

--- a/tests/fixtures/datago/success_tour_kor_festival.json
+++ b/tests/fixtures/datago/success_tour_kor_festival.json
@@ -1,0 +1,37 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "0000",
+      "resultMsg": "OK"
+    },
+    "body": {
+      "items": {
+        "item": [
+          {
+            "addr1": "서울특별시 중구 을지로 281",
+            "contentid": "2784665",
+            "contenttypeid": "15",
+            "eventstartdate": "20250401",
+            "eventenddate": "20250430",
+            "title": "서울 봄꽃 축제",
+            "mapx": "127.0092",
+            "mapy": "37.5665"
+          },
+          {
+            "addr1": "부산광역시 해운대구",
+            "contentid": "2784666",
+            "contenttypeid": "15",
+            "eventstartdate": "20250410",
+            "eventenddate": "20250420",
+            "title": "해운대 모래축제",
+            "mapx": "129.1604",
+            "mapy": "35.1587"
+          }
+        ]
+      },
+      "numOfRows": 10,
+      "pageNo": 1,
+      "totalCount": 2
+    }
+  }
+}

--- a/tests/fixtures/datago/success_tour_kor_keyword.json
+++ b/tests/fixtures/datago/success_tour_kor_keyword.json
@@ -1,0 +1,33 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "0000",
+      "resultMsg": "OK"
+    },
+    "body": {
+      "items": {
+        "item": [
+          {
+            "addr1": "서울특별시 종로구 종로 99",
+            "contentid": "126508",
+            "contenttypeid": "14",
+            "title": "종로 한옥마을",
+            "mapx": "126.9885",
+            "mapy": "37.5826"
+          },
+          {
+            "addr1": "서울특별시 종로구 자하문로",
+            "contentid": "126509",
+            "contenttypeid": "12",
+            "title": "북촌 한옥마을",
+            "mapx": "126.9849",
+            "mapy": "37.5826"
+          }
+        ]
+      },
+      "numOfRows": 10,
+      "pageNo": 1,
+      "totalCount": 2
+    }
+  }
+}

--- a/tests/fixtures/datago/success_tour_kor_location.json
+++ b/tests/fixtures/datago/success_tour_kor_location.json
@@ -1,0 +1,35 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "0000",
+      "resultMsg": "OK"
+    },
+    "body": {
+      "items": {
+        "item": [
+          {
+            "addr1": "서울특별시 중구 을지로 281",
+            "contentid": "127947",
+            "contenttypeid": "14",
+            "dist": "523.5",
+            "mapx": "127.0091751069",
+            "mapy": "37.5664729927",
+            "title": "동대문디자인플라자(DDP)"
+          },
+          {
+            "addr1": "서울특별시 중구 동호로 249",
+            "contentid": "126508",
+            "contenttypeid": "14",
+            "dist": "812.4",
+            "mapx": "127.0050019520",
+            "mapy": "37.5639088906",
+            "title": "장충체육관"
+          }
+        ]
+      },
+      "numOfRows": 10,
+      "pageNo": 1,
+      "totalCount": 2
+    }
+  }
+}

--- a/tests/integration/test_datago_live.py
+++ b/tests/integration/test_datago_live.py
@@ -149,3 +149,99 @@ def test_datago_sh_rent(require_datago_key: None, live_client: Client) -> None:
 
     assert isinstance(result, RecordBatch)
     assert isinstance(result.items, list)
+
+
+@pytest.mark.integration
+def test_datago_tour_kor_area(require_datago_key: None, live_client: Client) -> None:
+    _ = require_datago_key
+    ds = live_client.dataset("datago.tour_kor_area")
+
+    result = ds.call_raw(
+        "areaBasedList2",
+        MobileOS="ETC",
+        MobileApp="kpubdata",
+        numOfRows="5",
+        pageNo="1",
+        areaCode="1",
+    )
+
+    assert isinstance(result, dict)
+    assert "response" in result
+
+
+@pytest.mark.integration
+def test_datago_tour_kor_location(require_datago_key: None, live_client: Client) -> None:
+    _ = require_datago_key
+    ds = live_client.dataset("datago.tour_kor_location")
+
+    result = ds.call_raw(
+        "locationBasedList2",
+        MobileOS="ETC",
+        MobileApp="kpubdata",
+        numOfRows="5",
+        pageNo="1",
+        mapX="126.9784",
+        mapY="37.5665",
+        radius="1000",
+    )
+
+    assert isinstance(result, dict)
+    assert "response" in result
+
+
+@pytest.mark.integration
+def test_datago_tour_kor_keyword(require_datago_key: None, live_client: Client) -> None:
+    _ = require_datago_key
+    ds = live_client.dataset("datago.tour_kor_keyword")
+
+    result = ds.call_raw(
+        "searchKeyword2",
+        MobileOS="ETC",
+        MobileApp="kpubdata",
+        numOfRows="5",
+        pageNo="1",
+        keyword="경복궁",
+    )
+
+    assert isinstance(result, dict)
+    assert "response" in result
+
+
+@pytest.mark.integration
+def test_datago_tour_kor_festival(require_datago_key: None, live_client: Client) -> None:
+    _ = require_datago_key
+    ds = live_client.dataset("datago.tour_kor_festival")
+
+    result = ds.call_raw(
+        "searchFestival2",
+        MobileOS="ETC",
+        MobileApp="kpubdata",
+        numOfRows="5",
+        pageNo="1",
+        eventStartDate="20250101",
+    )
+
+    assert isinstance(result, dict)
+    assert "response" in result
+
+
+@pytest.mark.integration
+def test_datago_metro_fare(require_datago_key: None, live_client: Client) -> None:
+    _ = require_datago_key
+    ds = live_client.dataset("datago.metro_fare")
+
+    result = ds.call_raw("getRltmFare2", numOfRows="5", pageNo="1")
+
+    assert isinstance(result, dict)
+    assert "response" in result
+
+
+@pytest.mark.integration
+def test_datago_metro_path(require_datago_key: None, live_client: Client) -> None:
+    _ = require_datago_key
+    ds = live_client.dataset("datago.metro_path")
+
+    result = ds.call_raw("getShtrmPath", numOfRows="5", pageNo="1")
+
+    assert isinstance(result, dict)
+    assert "response" in result

--- a/tests/unit/providers/datago/test_fixtures.py
+++ b/tests/unit/providers/datago/test_fixtures.py
@@ -238,3 +238,74 @@ def test_fixture_sh_rent_parses() -> None:
     assert "deposit" in batch.items[0]
     assert "monthlyRent" in batch.items[0]
     assert batch.total_count == 2
+
+
+def test_fixture_tour_kor_area_parses() -> None:
+    adapter, dataset = _build_real_estate_adapter("success_tour_kor_area.json", "tour_kor_area")
+
+    batch = adapter.query_records(dataset, Query())
+
+    assert len(batch.items) == 2
+    assert batch.items[0]["title"] == "경복궁"
+    assert "contentid" in batch.items[0]
+    assert batch.total_count == 2
+
+
+def test_fixture_tour_kor_location_parses() -> None:
+    adapter, dataset = _build_real_estate_adapter(
+        "success_tour_kor_location.json", "tour_kor_location"
+    )
+
+    batch = adapter.query_records(dataset, Query())
+
+    assert len(batch.items) == 2
+    assert "dist" in batch.items[0]
+    assert batch.total_count == 2
+
+
+def test_fixture_tour_kor_keyword_parses() -> None:
+    adapter, dataset = _build_real_estate_adapter(
+        "success_tour_kor_keyword.json", "tour_kor_keyword"
+    )
+
+    batch = adapter.query_records(dataset, Query())
+
+    assert len(batch.items) == 2
+    assert "title" in batch.items[0]
+    assert batch.total_count == 2
+
+
+def test_fixture_tour_kor_festival_parses() -> None:
+    adapter, dataset = _build_real_estate_adapter(
+        "success_tour_kor_festival.json", "tour_kor_festival"
+    )
+
+    batch = adapter.query_records(dataset, Query())
+
+    assert len(batch.items) == 2
+    assert "eventstartdate" in batch.items[0]
+    assert "eventenddate" in batch.items[0]
+    assert batch.total_count == 2
+
+
+def test_fixture_metro_fare_parses() -> None:
+    adapter, dataset = _build_real_estate_adapter("success_metro_fare.json", "metro_fare")
+
+    batch = adapter.query_records(dataset, Query())
+
+    assert len(batch.items) == 2
+    assert "startStation" in batch.items[0]
+    assert "endStation" in batch.items[0]
+    assert "fareCard" in batch.items[0]
+    assert batch.total_count == 2
+
+
+def test_fixture_metro_path_parses() -> None:
+    adapter, dataset = _build_real_estate_adapter("success_metro_path.json", "metro_path")
+
+    batch = adapter.query_records(dataset, Query())
+
+    assert len(batch.items) == 3
+    assert batch.items[0]["stationName"] == "서울역"
+    assert "lineNum" in batch.items[0]
+    assert batch.total_count == 3


### PR DESCRIPTION
## 요약

data.go.kr 활용신청 통계 기준 인기 API 중 datago provider 계약에 적합한 6종을 카탈로그에 사전 등록합니다.

| dataset_key | 출처 | data.go.kr ID |
|---|---|---|
| `tour_kor_area` | 한국관광공사 TourAPI `areaBasedList2` | 15101578 |
| `tour_kor_location` | TourAPI `locationBasedList2` | 15101578 |
| `tour_kor_keyword` | TourAPI `searchKeyword2` | 15101578 |
| `tour_kor_festival` | TourAPI `searchFestival2` | 15101578 |
| `metro_fare` | 서울교통공사 실시간 운임 `getRltmFare2` | 15143846 |
| `metro_path` | 서울교통공사 최단경로 `getShtrmPath` | 15143842 |

> TourAPI 4종은 동일한 단일 활용신청(15101578 KorService2)으로 한 번에 발급되므로, 사용자 입장에서 신청은 총 **3건**(TourAPI + 운임 + 최단경로)이면 됩니다.

## 변경 사항

- `src/kpubdata/providers/datago/catalogue.json`에 6개 항목 추가 (모두 `list+raw` operation, offset pagination)
- `tests/fixtures/datago/success_*.json` 6개 신규 fixture (data.go.kr REST 표준 envelope)
- `tests/unit/providers/datago/test_fixtures.py`에 fixture parse 테스트 6개 추가
- `tests/contract/test_datago.py` — 카탈로그 일관성 contract 자동 적용
- `tests/integration/test_datago_live.py`에 라이브 smoke 테스트 6개 추가 (`KPUBDATA_DATAGO_API_KEY`로 게이팅)
- `SUPPORTED_DATA.md` / `README.md` / `docs/providers/datago.md` 문서 동기화

## 후보 선정 과정

1. librarian으로 data.go.kr 인기 API 조사
2. 결과 정제: 표준데이터(CSV/XLS) 및 LINK 타입(data.seoul.go.kr 호스팅) 제외
3. **제외 사유**:
   - 서울 지하철 실시간 위치/도착 (15058569, 15125683): API 유형이 LINK → `data.seoul.go.kr`로 리다이렉트, datago provider 계약 밖. 별도 `seoul` provider 필요
   - 전국주차장정보표준데이터 (15012896): 표준데이터(CSV/XLS 다운로드 중심), OpenAPI 미제공
4. 최종 6개는 모두 `apis.data.go.kr/...` REST 엔드포인트로 검증됨

## 검증 결과

- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `uv run mypy src` ✅ (no issues)
- `uv run pytest -q` ✅ 379 passed, 1 skipped (pandas 미설치)
- `uv run python -m build` ✅ kpubdata-0.2.3 빌드 성공

라이브 검증은 **머지 후 사용자 협조로 활용신청 → 발급 → smoke 테스트 실행**으로 진행 예정입니다. 그 시점에 `SUPPORTED_DATA.md`의 검증 컬럼을 `테스트 검증` → `실API 검증`으로 갱신하는 별도 PR이 따라옵니다.

## 후속 작업 (별도 issue/PR 권장)

- 서울 지하철 실시간 정보(인기 1·2위) 지원을 위한 신규 `seoul` provider 설계
- 활용신청 자동화: 사용자 브라우저 로그인 후 playwright로 3건 일괄 신청