### PR TITLE
fix(localdata): catalogue 실API 검증 반영 + rest_cafe 추가 (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ KPubData가 지원하는 각 기관의 API 키를 발급받아 [환경 변수](h
 - **SSL 참고**: 서버의 TLS 설정 특성상, KPubData가 내부적으로 SSL 설정을 자동 조정합니다.
 - **환경 변수**: `KPUBDATA_LOFIN_API_KEY`
 
+#### 지방행정인허가 (data.go.kr) — `localdata`
+- **가입 URL**: [https://www.data.go.kr](https://www.data.go.kr)
+- **절차**: 회원가입 → 지방행정인허가 Open API(일반음식점/휴게음식점) 활용신청 → 승인 후 인증키 확인
+- **환경 변수**: `KPUBDATA_LOCALDATA_API_KEY`
+
 #### 환경 변수 설정 예시
 ```bash
 # 공공데이터포털 (data.go.kr)
@@ -137,6 +142,9 @@ export KPUBDATA_KOSIS_API_KEY="your-kosis-api-key"
 
 # 지방재정365
 export KPUBDATA_LOFIN_API_KEY="your-lofin-api-key"
+
+# 지방행정인허가
+export KPUBDATA_LOCALDATA_API_KEY="your-localdata-service-key"
 ```
 
 ### 2. 클라이언트 생성
@@ -153,6 +161,7 @@ client = Client(provider_keys={
     "bok": "YOUR_BOK_API_KEY",
     "kosis": "YOUR_KOSIS_API_KEY",
     "lofin": "YOUR_LOFIN_API_KEY",
+    "localdata": "YOUR_DATA_GO_KR_API_KEY",
 })
 ```
 
@@ -260,7 +269,18 @@ for item in result.items[:5]:
 # ...
 ```
 
-### 9. 전체 페이지 자동 조회 (list_all)
+### 9. 지방행정인허가 조회 (Localdata)
+
+```python
+# 지방행정인허가 (Localdata) - 일반음식점
+client = Client(provider_keys={"localdata": "YOUR_DATA_GO_KR_API_KEY"})
+ds = client.dataset("localdata.general_restaurant")
+result = ds.list(page_size=10)
+for item in result.items:
+    print(item["BPLC_NM"], item["ROAD_NM_ADDR"])
+```
+
+### 10. 전체 페이지 자동 조회 (list_all)
 
 대량의 데이터를 페이지 단위로 자동 순회하려면 `list_all()`을 사용합니다.
 
@@ -274,7 +294,7 @@ for batch in ds.list_all(fyr="2024"):
         print(item)
 ```
 
-### 10. pandas DataFrame 변환
+### 11. pandas DataFrame 변환
 
 조회 결과를 pandas DataFrame으로 변환하여 분석할 수 있습니다.
 

--- a/SUPPORTED_DATA.md
+++ b/SUPPORTED_DATA.md
@@ -35,10 +35,8 @@
 | 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `air_quality` | 대기오염정보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
 | 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `bus_arrival` | 경기도 버스도착정보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
 | 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `hospital_info` | 병원정보서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
-| 지원 | 테스트 검증 | - | 지방행정인허가 (`localdata`) | `general_restaurant` | 일반음식점 인허가 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 행정안전부 제공 (data.go.kr 이관), service_name 추정치 — 실API 검증 필요 |
-| 지원 | 테스트 검증 | - | 지방행정인허가 (`localdata`) | `coffee_shop` | 커피숍 인허가 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 행정안전부 제공 (data.go.kr 이관), service_name 추정치 — 실API 검증 필요 |
-| 지원 | 테스트 검증 | - | 지방행정인허가 (`localdata`) | `bakery` | 제과점 인허가 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 행정안전부 제공 (data.go.kr 이관), service_name 추정치 — 실API 검증 필요 |
-| 지원 | 테스트 검증 | - | 지방행정인허가 (`localdata`) | `retail_store` | 소매점 인허가 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 행정안전부 제공 (data.go.kr 이관), service_name 추정치 — 실API 검증 필요 |
+| 지원 | 테스트 검증 | - | 지방행정인허가 (`localdata`) | `general_restaurant` | 일반음식점 인허가 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 행정안전부 제공, service_name 실API 검증 완료 (data.go.kr 이관) |
+| 지원 | 테스트 검증 | - | 지방행정인허가 (`localdata`) | `rest_cafe` | 휴게음식점 인허가 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 행정안전부 제공, service_name 실API 검증 완료 |
 | 지원 | 실API 검증 | 2025-04-15 | 한국은행 ECOS (`bok`) | `base_rate` | 한국은행 기준금리 | [ECOS](https://ecos.bok.or.kr/api/) 인증키 | [ecos.bok.or.kr](https://ecos.bok.or.kr/api/) | |
 | 지원 | 실API 검증 | 2025-04-15 | 통계청 KOSIS (`kosis`) | `population_migration` | 시도별 이동자수 | [KOSIS](https://kosis.kr/openapi/index/index.jsp) 인증키 | [kosis.kr](https://kosis.kr/openapi/index/index.jsp) | |
 | 지원 | 실API 검증 | 2025-04-16 | 지방재정365 (`lofin`) | `expenditure_budget` | 세출결산총괄 | [지방재정365](https://www.lofin365.go.kr) 인증키 | [lofin365.go.kr](https://www.lofin365.go.kr) | API 코드: AJGCF |

--- a/src/kpubdata/providers/localdata/catalogue.json
+++ b/src/kpubdata/providers/localdata/catalogue.json
@@ -30,69 +30,9 @@
     ]
   },
   {
-    "dataset_key": "coffee_shop",
-    "name": "커피숍 인허가 (Coffee Shop Permits)",
-    "base_url": "http://apis.data.go.kr/1741000/coffee_shops",
-    "default_operation": "info",
-    "representation": "api_json",
-    "service_key_param": "serviceKey",
-    "format_param": "type",
-    "operations": ["list", "raw"],
-    "query_support": {
-      "pagination": "offset",
-      "max_page_size": 100
-    },
-    "fields": [
-      {"name": "OPN_SVC_ID", "title": "업종코드", "type": "string"},
-      {"name": "OPN_ATMY_GRP_CD", "title": "개방자치단체코드", "type": "string"},
-      {"name": "MGT_NO", "title": "관리번호", "type": "string"},
-      {"name": "LCPMT_YMD", "title": "인허가일자", "type": "string"},
-      {"name": "SALS_STTS_CD", "title": "영업상태코드", "type": "string"},
-      {"name": "SALS_STTS_NM", "title": "영업상태명", "type": "string"},
-      {"name": "CLSBIZ_YMD", "title": "폐업일자", "type": "string"},
-      {"name": "SITE_TEL", "title": "전화번호", "type": "string"},
-      {"name": "STTUS_ADDR", "title": "지번주소", "type": "string"},
-      {"name": "ROAD_NM_ADDR", "title": "도로명주소", "type": "string"},
-      {"name": "BPLC_NM", "title": "사업장명", "type": "string"},
-      {"name": "BSNTPE_NM", "title": "업태명", "type": "string"},
-      {"name": "X_CRDNT", "title": "X좌표(경도)", "type": "string"},
-      {"name": "Y_CRDNT", "title": "Y좌표(위도)", "type": "string"}
-    ]
-  },
-  {
-    "dataset_key": "bakery",
-    "name": "제과점 인허가 (Bakery Permits)",
-    "base_url": "http://apis.data.go.kr/1741000/bakeries",
-    "default_operation": "info",
-    "representation": "api_json",
-    "service_key_param": "serviceKey",
-    "format_param": "type",
-    "operations": ["list", "raw"],
-    "query_support": {
-      "pagination": "offset",
-      "max_page_size": 100
-    },
-    "fields": [
-      {"name": "OPN_SVC_ID", "title": "업종코드", "type": "string"},
-      {"name": "OPN_ATMY_GRP_CD", "title": "개방자치단체코드", "type": "string"},
-      {"name": "MGT_NO", "title": "관리번호", "type": "string"},
-      {"name": "LCPMT_YMD", "title": "인허가일자", "type": "string"},
-      {"name": "SALS_STTS_CD", "title": "영업상태코드", "type": "string"},
-      {"name": "SALS_STTS_NM", "title": "영업상태명", "type": "string"},
-      {"name": "CLSBIZ_YMD", "title": "폐업일자", "type": "string"},
-      {"name": "SITE_TEL", "title": "전화번호", "type": "string"},
-      {"name": "STTUS_ADDR", "title": "지번주소", "type": "string"},
-      {"name": "ROAD_NM_ADDR", "title": "도로명주소", "type": "string"},
-      {"name": "BPLC_NM", "title": "사업장명", "type": "string"},
-      {"name": "BSNTPE_NM", "title": "업태명", "type": "string"},
-      {"name": "X_CRDNT", "title": "X좌표(경도)", "type": "string"},
-      {"name": "Y_CRDNT", "title": "Y좌표(위도)", "type": "string"}
-    ]
-  },
-  {
-    "dataset_key": "retail_store",
-    "name": "소매점 인허가 (Retail Store Permits)",
-    "base_url": "http://apis.data.go.kr/1741000/retail_stores",
+    "dataset_key": "rest_cafe",
+    "name": "휴게음식점 인허가 (Rest Cafe Permits)",
+    "base_url": "http://apis.data.go.kr/1741000/rest_cafes",
     "default_operation": "info",
     "representation": "api_json",
     "service_key_param": "serviceKey",

--- a/tests/fixtures/localdata/rest_cafe_success.json
+++ b/tests/fixtures/localdata/rest_cafe_success.json
@@ -1,0 +1,63 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "00",
+      "resultMsg": "NORMAL SERVICE."
+    },
+    "body": {
+      "totalCount": 3,
+      "items": {
+        "item": [
+          {
+            "OPN_SVC_ID": "07_24_05_P",
+            "OPN_ATMY_GRP_CD": "3000000",
+            "MGT_NO": "3000000-101-2023-00010",
+            "LCPMT_YMD": "20230215",
+            "SALS_STTS_CD": "01",
+            "SALS_STTS_NM": "영업/정상",
+            "CLSBIZ_YMD": "",
+            "SITE_TEL": "042-555-1234",
+            "STTUS_ADDR": "대전광역시 중구 대흥동 200",
+            "ROAD_NM_ADDR": "대전광역시 중구 대종로 50",
+            "BPLC_NM": "카페모카",
+            "BSNTPE_NM": "커피숍",
+            "X_CRDNT": "127.4215",
+            "Y_CRDNT": "36.3285"
+          },
+          {
+            "OPN_SVC_ID": "07_24_05_P",
+            "OPN_ATMY_GRP_CD": "3000000",
+            "MGT_NO": "3000000-101-2023-00011",
+            "LCPMT_YMD": "20230610",
+            "SALS_STTS_CD": "01",
+            "SALS_STTS_NM": "영업/정상",
+            "CLSBIZ_YMD": "",
+            "SITE_TEL": "042-333-5678",
+            "STTUS_ADDR": "대전광역시 서구 탄방동 300",
+            "ROAD_NM_ADDR": "대전광역시 서구 둔산로 120",
+            "BPLC_NM": "달콤베이커리카페",
+            "BSNTPE_NM": "제과점영업",
+            "X_CRDNT": "127.3890",
+            "Y_CRDNT": "36.3510"
+          },
+          {
+            "OPN_SVC_ID": "07_24_05_P",
+            "OPN_ATMY_GRP_CD": "3000000",
+            "MGT_NO": "3000000-101-2023-00012",
+            "LCPMT_YMD": "20230901",
+            "SALS_STTS_CD": "01",
+            "SALS_STTS_NM": "영업/정상",
+            "CLSBIZ_YMD": "",
+            "SITE_TEL": "042-222-9999",
+            "STTUS_ADDR": "대전광역시 유성구 궁동 100",
+            "ROAD_NM_ADDR": "대전광역시 유성구 대학로 55",
+            "BPLC_NM": "유성라운지",
+            "BSNTPE_NM": "커피숍",
+            "X_CRDNT": "127.3500",
+            "Y_CRDNT": "36.3650"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -40,6 +40,14 @@ def require_lofin_key() -> str:
 
 
 @pytest.fixture(scope="session")
+def require_localdata_key() -> str:
+    key = os.getenv("KPUBDATA_LOCALDATA_API_KEY", "")
+    if not key:
+        pytest.skip("KPUBDATA_LOCALDATA_API_KEY not set")
+    return key
+
+
+@pytest.fixture(scope="session")
 def live_client() -> Client:
     if not any(
         os.getenv(name, "")
@@ -48,6 +56,7 @@ def live_client() -> Client:
             "KPUBDATA_BOK_API_KEY",
             "KPUBDATA_KOSIS_API_KEY",
             "KPUBDATA_LOFIN_API_KEY",
+            "KPUBDATA_LOCALDATA_API_KEY",
         )
     ):
         pytest.skip("No API keys set")

--- a/tests/integration/test_localdata_live.py
+++ b/tests/integration/test_localdata_live.py
@@ -1,0 +1,85 @@
+"""Localdata (data.go.kr) real API integration tests.
+
+Run with:
+    export KPUBDATA_LOCALDATA_API_KEY="your-key"
+    uv run pytest -m integration -k localdata -ra -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kpubdata.client import Client
+from kpubdata.core.models import RecordBatch
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_localdata_key")
+def test_general_restaurant_returns_record_batch(live_client: Client) -> None:
+    ds = live_client.dataset("localdata.general_restaurant")
+    result = ds.list(page_size=5)
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) > 0
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_localdata_key")
+def test_general_restaurant_raw_returns_envelope(live_client: Client) -> None:
+    ds = live_client.dataset("localdata.general_restaurant")
+    result = ds.call_raw("info", numOfRows="3")
+
+    assert isinstance(result, dict)
+    assert "response" in result
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_localdata_key")
+def test_rest_cafe_returns_record_batch(live_client: Client) -> None:
+    ds = live_client.dataset("localdata.rest_cafe")
+    result = ds.list(page_size=5)
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) > 0
+
+
+LOCALDATA_COMMON_KEYS = {"BPLC_NM", "SALS_STTS_NM", "ROAD_NM_ADDR", "STTUS_ADDR"}
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_localdata_key")
+def test_general_restaurant_has_required_fields(live_client: Client) -> None:
+    ds = live_client.dataset("localdata.general_restaurant")
+    result = ds.list(page_size=5)
+    item = result.items[0]
+
+    assert LOCALDATA_COMMON_KEYS.issubset(item.keys())
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_localdata_key")
+def test_general_restaurant_total_count(live_client: Client) -> None:
+    ds = live_client.dataset("localdata.general_restaurant")
+    result = ds.list(page_size=5)
+
+    assert result.total_count is not None
+    assert result.total_count > 0
+
+
+ALL_DATASETS = [
+    "localdata.general_restaurant",
+    "localdata.rest_cafe",
+]
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_localdata_key")
+@pytest.mark.parametrize("dataset_id", ALL_DATASETS)
+def test_all_datasets_return_data(live_client: Client, dataset_id: str) -> None:
+    ds = live_client.dataset(dataset_id)
+    result = ds.list(page_size=3)
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) > 0
+    assert result.total_count is not None
+    assert result.total_count > 0

--- a/tests/unit/providers/localdata/test_adapter.py
+++ b/tests/unit/providers/localdata/test_adapter.py
@@ -51,6 +51,18 @@ def _build_adapter_with_transport(
     return adapter, dataset, transport
 
 
+def _build_rest_cafe_adapter_with_transport(
+    responses: list[FakeResponse],
+) -> tuple[LocaldataAdapter, DatasetRef, FakeTransport]:
+    transport = FakeTransport(responses)
+    adapter = LocaldataAdapter(
+        config=KPubDataConfig(provider_keys={"localdata": "test-key"}),
+        transport=cast(HttpTransport, cast(object, transport)),
+    )
+    dataset = adapter.get_dataset("rest_cafe")
+    return adapter, dataset, transport
+
+
 def test_query_records_parses_success_fixture() -> None:
     payload = _load_fixture("general_restaurant_success.json")
     adapter, dataset, transport = _build_adapter_with_transport([FakeResponse(payload)])
@@ -112,3 +124,25 @@ def test_query_records_passes_local_code_filter() -> None:
     assert request_params["pageNo"] == "1"
     assert request_params["numOfRows"] == "100"
     assert request_params["localCode"] == "41135"
+
+
+def test_rest_cafe_query_records_parses_success_fixture() -> None:
+    payload = _load_fixture("rest_cafe_success.json")
+    adapter, dataset, _ = _build_rest_cafe_adapter_with_transport([FakeResponse(payload)])
+
+    batch = adapter.query_records(dataset, Query())
+
+    assert len(batch.items) == 3
+    assert batch.items[0]["BPLC_NM"] == "카페모카"
+
+
+def test_adapter_lists_two_datasets() -> None:
+    adapter = LocaldataAdapter(config=KPubDataConfig(provider_keys={"localdata": "test-key"}))
+
+    datasets = adapter.list_datasets()
+
+    assert len(datasets) == 2
+    assert [dataset.dataset_key for dataset in datasets] == [
+        "general_restaurant",
+        "rest_cafe",
+    ]


### PR DESCRIPTION
## Summary
- localdata 카탈로그를 실 API 검증 결과에 맞춰 `general_restaurant`/`rest_cafe` 2종만 유지하도록 정리했습니다.
- `rest_cafe` fixture, unit test, live integration test를 추가하고 integration conftest에 `KPUBDATA_LOCALDATA_API_KEY` 체크를 반영했습니다.
- README/SUPPORTED_DATA 문서를 최신 dataset 구성과 사용 예시에 맞게 업데이트했습니다.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv run pytest`
- `uv run python -m build`

Closes #137