### PR TITLE
feat(logging): add debug logs to failure paths in adapters and transport

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -12,6 +12,7 @@ KPubData는 파이썬 표준 [`logging`](https://docs.python.org/3/library/loggi
 | `kpubdata.registry` | `registry.py` | 어댑터 등록(즉시/지연), 조회 성공·실패, 지연 어댑터 인스턴스화 |
 | `kpubdata.catalog` | `catalog.py` | 데이터셋 목록·검색·해석(resolve) 호출과 결과 건수 |
 | `kpubdata.dataset` | `core/dataset.py` | `list()`, `list_all()`, `call_raw()`, `schema()` 호출 흐름 |
+| `kpubdata.config` | `config.py` | Provider API 키 조회 실패 등 설정 검증 |
 | `kpubdata.transport` | `transport/http.py`, `transport/retry.py` | HTTP 요청/응답, 재시도, 상태 코드, `Retry-After` 처리 |
 | `kpubdata.transport.decode` | `transport/decode.py` | JSON/XML 디코딩 실패 컨텍스트, 미인식 content-type |
 | `kpubdata.provider.datago` | `providers/datago/adapter.py` | datago 요청 진입, `resultCode` 검증 |
@@ -64,11 +65,22 @@ logging.getLogger("kpubdata.provider.datago").setLevel(logging.DEBUG)
 | `kpubdata.registry` | `provider`, `adapter_type` |
 | `kpubdata.catalog` | `provider`, `provider_filter`, `text`, `dataset_id`, `count` |
 | `kpubdata.dataset` | `dataset_id`, `provider`, `page`, `page_size`, `cursor`, `filter_keys`, `item_count`, `total_count`, `next_page`, `next_cursor`, `iteration`, `iterations`, `operation`, `param_keys` |
-| `kpubdata.transport` | `method`, `url`, `attempt`, `max_retries`, `status_code`, `params`, `content_type`, `content_length`, `preview`, `delay_seconds`, `exception_type` |
+| `kpubdata.config` | `provider` |
+| `kpubdata.transport` | `method`, `url`, `attempt`, `max_retries`, `status_code`, `params`, `content_type`, `content_length`, `preview`, `delay_seconds`, `exception_type`, `dataset_id`, `provider` |
 | `kpubdata.transport.decode` | `byte_length`, `char_length`, `preview`, `line`, `column`, `root_type`, `content_type`, `exception_type` |
-| `kpubdata.provider.*` | `dataset_id`, `page`, `page_size`, `operation`, `param_keys`, `result_code`, `result_msg` (datago) |
+| `kpubdata.provider.*` | `dataset_id`, `provider`, `page`, `page_size`, `total_count`, `result_code`, `result_msg`, `code`, `message`, `operation` |
 
 JSON 포맷터와 결합하면 곧바로 관측(observability) 파이프라인에 연결할 수 있습니다.
+
+## 실패 경로 디버깅 (Debugging failure paths)
+
+라이브 API 재현 시 원인 파악을 쉽게 하기 위해, 주요 실패 경로는 이제 예외를 던지기 **직전**에 DEBUG 로그를 남깁니다.
+
+- `DatasetNotFoundError`, `InvalidRequestError`, `ParseError`
+- Provider별 envelope/API 오류 (`result_code`/`result_msg`, `code`/`message`)
+- 정상 envelope 이지만 `items=[]` 인 빈 결과 응답
+
+이 로그들은 `dataset_id`를 공통으로 포함하며, 가능한 경우 `provider`, `page`, `page_size`, `total_count` 같은 상관관계 키를 함께 기록합니다. `kpubdata.transport`도 선택적으로 `dataset_id`/`provider`를 받아 HTTP 요청 시작·성공·재시도·오류 로그에 같은 컨텍스트를 첨부하므로, 어댑터 실패와 실제 HTTP 호출을 한 흐름으로 추적할 수 있습니다.
 
 ```python
 import json

--- a/src/kpubdata/config.py
+++ b/src/kpubdata/config.py
@@ -8,6 +8,7 @@ Key lookup order for provider keys:
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from dataclasses import dataclass, field
@@ -16,6 +17,7 @@ from typing import Any
 from kpubdata.exceptions import ConfigError
 
 _ENV_KEY_PATTERN = re.compile(r"^KPUBDATA_([A-Z0-9_]+)_API_KEY$")
+logger = logging.getLogger("kpubdata.config")
 
 
 @dataclass
@@ -65,6 +67,7 @@ class KPubDataConfig:
         key = self.get_provider_key(provider)
         if key is not None:
             return key
+        logger.debug("Missing provider API key", extra={"provider": provider})
         raise ConfigError(f"Missing provider API key for '{provider}'")
 
     @classmethod

--- a/src/kpubdata/core/dataset.py
+++ b/src/kpubdata/core/dataset.py
@@ -72,6 +72,14 @@ class Dataset:
         """
 
         if Operation.LIST not in self._ref.operations:
+            logger.debug(
+                "Dataset does not support LIST",
+                extra={
+                    "dataset_id": self._ref.id,
+                    "provider": self._ref.provider,
+                    "operation": "list",
+                },
+            )
             raise UnsupportedCapabilityError(
                 f"Dataset does not support list: {self._ref.id}",
                 provider=self._ref.provider,

--- a/src/kpubdata/providers/bok/adapter.py
+++ b/src/kpubdata/providers/bok/adapter.py
@@ -68,6 +68,10 @@ class BokAdapter:
         if dataset is not None:
             return dataset
 
+        logger.debug(
+            "BOK dataset not found",
+            extra={"dataset_id": f"bok.{dataset_key}", "provider": "bok"},
+        )
         raise DatasetNotFoundError(
             f"Dataset not found: bok.{dataset_key}",
             provider="bok",
@@ -93,6 +97,10 @@ class BokAdapter:
         )
 
         if start_date is None or end_date is None:
+            logger.debug(
+                "BOK ECOS invalid query: missing start/end date",
+                extra={"dataset_id": dataset.id},
+            )
             raise InvalidRequestError(
                 "BOK ECOS queries require start_date and end_date",
                 provider="bok",
@@ -111,7 +119,7 @@ class BokAdapter:
             end_date=end_date,
         )
 
-        payload = self._request_and_decode(url)
+        payload = self._request_and_decode(url, dataset.id)
         body, items = self._validate_envelope(payload, dataset.id)
 
         total_count = coerce_int(body.get("list_total_count"), 0)
@@ -121,6 +129,17 @@ class BokAdapter:
             computed_next = page + 1
         else:
             computed_next = None
+
+        if not items:
+            logger.debug(
+                "BOK envelope: zero items",
+                extra={
+                    "dataset_id": dataset.id,
+                    "page": page,
+                    "page_size": page_size,
+                    "total_count": total_count,
+                },
+            )
 
         return RecordBatch(
             items=items,
@@ -143,8 +162,8 @@ class BokAdapter:
             },
         )
         frequency = self._string_param(params, "frequency") or "M"
-        start_date = self._require_param(params, "start_date")
-        end_date = self._require_param(params, "end_date")
+        start_date = self._require_param(params, "start_date", dataset.id)
+        end_date = self._require_param(params, "end_date", dataset.id)
         start_index = self._int_param(params, "start_index", 1)
         end_index = self._int_param(params, "end_index", 10)
 
@@ -157,7 +176,7 @@ class BokAdapter:
             start_date=start_date,
             end_date=end_date,
         )
-        payload = self._request_and_decode(url)
+        payload = self._request_and_decode(url, dataset.id)
         _ = self._validate_envelope(payload, dataset.id)
         return payload
 
@@ -177,6 +196,10 @@ class BokAdapter:
     ) -> str:
         base_url_raw = dataset.raw_metadata.get("base_url")
         if not isinstance(base_url_raw, str) or not base_url_raw:
+            logger.debug(
+                "BOK ECOS dataset metadata missing base_url",
+                extra={"dataset_id": dataset.id},
+            )
             raise ProviderResponseError(
                 "Dataset metadata missing base_url",
                 provider="bok",
@@ -185,6 +208,10 @@ class BokAdapter:
 
         selected_operation = operation or dataset.raw_metadata.get("default_operation")
         if not isinstance(selected_operation, str) or not selected_operation:
+            logger.debug(
+                "BOK ECOS dataset metadata missing default_operation",
+                extra={"dataset_id": dataset.id},
+            )
             raise ProviderResponseError(
                 "Dataset metadata missing default_operation",
                 provider="bok",
@@ -199,18 +226,20 @@ class BokAdapter:
             f"{start_index}/{end_index}/{stat_code}/{frequency}/{start_date}/{end_date}/{item_code1}"
         )
 
-    def _request_and_decode(self, url: str) -> dict[str, object]:
-        response = self._transport.request("GET", url)
+    def _request_and_decode(self, url: str, dataset_id: str) -> dict[str, object]:
+        response = self._transport.request("GET", url, dataset_id=dataset_id, provider="bok")
 
         try:
             decoded_obj: object = decode_json(response.content)
         except ParseError as exc:
             exc.provider = "bok"
+            logger.debug("BOK ECOS response parsing failed", extra={"dataset_id": dataset_id})
             raise
 
         if isinstance(decoded_obj, dict):
             return cast(dict[str, object], decoded_obj)
 
+        logger.debug("BOK ECOS decoded payload invalid type", extra={"dataset_id": dataset_id})
         raise ParseError("Decoded payload is not an object", provider="bok")
 
     def _validate_envelope(
@@ -319,11 +348,17 @@ class BokAdapter:
         return None
 
     @classmethod
-    def _require_param(cls, params: Mapping[str, object], key: str) -> str:
+    def _require_param(cls, params: Mapping[str, object], key: str, dataset_id: str) -> str:
         value = cls._string_param(params, key)
         if value is not None:
             return value
-        raise InvalidRequestError(f"BOK ECOS raw calls require {key}", provider="bok")
+        logger.debug(
+            "BOK ECOS raw call missing required parameter",
+            extra={"dataset_id": dataset_id},
+        )
+        raise InvalidRequestError(
+            f"BOK ECOS raw calls require {key}", provider="bok", dataset_id=dataset_id
+        )
 
     @classmethod
     def _int_param(cls, params: Mapping[str, object], key: str, default: int) -> int:

--- a/src/kpubdata/providers/datago/adapter.py
+++ b/src/kpubdata/providers/datago/adapter.py
@@ -98,6 +98,10 @@ class DataGoAdapter:
         if dataset is not None:
             return dataset
 
+        logger.debug(
+            "Datago dataset not found",
+            extra={"dataset_id": f"datago.{dataset_key}", "provider": "datago"},
+        )
         raise DatasetNotFoundError(
             f"Dataset not found: datago.{dataset_key}",
             provider="datago",
@@ -108,6 +112,10 @@ class DataGoAdapter:
         """Query records from a data.go.kr dataset."""
 
         if self._is_generic(dataset):
+            logger.debug(
+                "Datago list called with unsupported operation (generic)",
+                extra={"dataset_id": dataset.id},
+            )
             raise InvalidRequestError(
                 "datago.generic does not support list(); use call_raw with _base_url instead",
                 provider="datago",
@@ -138,7 +146,7 @@ class DataGoAdapter:
                 value: object = raw_value
                 params[key] = str(value)
 
-        payload = self._request_and_decode(url, params)
+        payload = self._request_and_decode(url, params, dataset.id)
         body, items = self._validate_envelope(payload, dataset.id)
 
         total_count = coerce_int(body.get("totalCount"), 0)
@@ -148,6 +156,17 @@ class DataGoAdapter:
             computed_next = page + 1
         else:
             computed_next = None
+
+        if not items:
+            logger.debug(
+                "Datago envelope: zero items",
+                extra={
+                    "dataset_id": dataset.id,
+                    "page": page,
+                    "page_size": page_size,
+                    "total_count": total_count,
+                },
+            )
 
         return RecordBatch(
             items=items,
@@ -199,6 +218,10 @@ class DataGoAdapter:
         if is_generic:
             base_url_override = params.get("_base_url")
             if not isinstance(base_url_override, str) or not base_url_override:
+                logger.debug(
+                    "Datago.generic missing _base_url in call_raw params",
+                    extra={"dataset_id": dataset.id},
+                )
                 raise InvalidRequestError(
                     "datago.generic requires '_base_url' to be passed in params",
                     provider="datago",
@@ -206,6 +229,10 @@ class DataGoAdapter:
                 )
             envelope_flag = params.get("_envelope", True)
             if not isinstance(envelope_flag, bool):
+                logger.debug(
+                    "Datago.generic '_envelope' must be a bool",
+                    extra={"dataset_id": dataset.id},
+                )
                 raise InvalidRequestError(
                     "datago.generic '_envelope' must be a bool (True or False)",
                     provider="datago",
@@ -264,7 +291,7 @@ class DataGoAdapter:
                     continue
                 request_params[key] = str(value)
 
-            payload = self._request_and_decode(url, request_params)
+            payload = self._request_and_decode(url, request_params, dataset.id)
             if validate_envelope:
                 _ = self._validate_envelope(payload, dataset.id)
             return payload
@@ -277,7 +304,7 @@ class DataGoAdapter:
             if key != service_key_param:
                 request_params[key] = str(value)
 
-        payload = self._request_and_decode(url, request_params)
+        payload = self._request_and_decode(url, request_params, dataset.id)
         _ = self._validate_envelope(payload, dataset.id)
         return payload
 
@@ -331,9 +358,17 @@ class DataGoAdapter:
         )
         return {service_key_param: api_key, format_param: "json"}
 
-    def _request_and_decode(self, url: str, params: Mapping[str, object]) -> dict[str, object]:
+    def _request_and_decode(
+        self, url: str, params: Mapping[str, object], dataset_id: str = ""
+    ) -> dict[str, object]:
         string_params = {key: str(value) for key, value in params.items()}
-        response = self._transport.request("GET", url, params=string_params)
+        response = self._transport.request(
+            "GET",
+            url,
+            params=string_params,
+            dataset_id=dataset_id,
+            provider="datago",
+        )
 
         try:
             content_type = detect_content_type(response)
@@ -345,6 +380,7 @@ class DataGoAdapter:
                 decoded = decode_json(response.content)
         except ParseError as exc:
             exc.provider = "datago"
+            logger.debug("Datago response parsing failed", extra={"dataset_id": dataset_id})
             raise
         except ImportError as exc:
             raise ParseError("Failed to parse data.go.kr response", provider="datago") from exc
@@ -352,6 +388,10 @@ class DataGoAdapter:
         if isinstance(decoded, dict):
             return cast(dict[str, object], decoded)
 
+        logger.debug(
+            "Datago decoded payload invalid type",
+            extra={"dataset_id": dataset_id},
+        )
         raise ParseError("Decoded payload is not an object", provider="datago")
 
     def _validate_envelope(
@@ -359,6 +399,10 @@ class DataGoAdapter:
     ) -> tuple[dict[str, object], list[dict[str, object]]]:
         response_obj = payload.get("response")
         if not isinstance(response_obj, dict):
+            logger.debug(
+                "Datago envelope missing response/body",
+                extra={"dataset_id": dataset_id},
+            )
             raise ProviderResponseError(
                 "Malformed response envelope: missing response",
                 provider="datago",
@@ -403,13 +447,18 @@ class DataGoAdapter:
         return body_dict, items
 
     def _raise_for_result_code(self, code: str, msg: str, dataset_id: str) -> NoReturn:
+        extra = {"dataset_id": dataset_id, "result_code": code, "result_msg": msg}
         if code in {"30", "31", "20", "32"}:
+            logger.debug("Datago API envelope error", extra=extra)
             raise AuthError(msg, provider="datago", provider_code=code)
         if code == "22":
+            logger.debug("Datago API envelope error", extra=extra)
             raise RateLimitError(msg, provider="datago", provider_code=code, retryable=False)
         if code == "10":
+            logger.debug("Datago API envelope error", extra=extra)
             raise InvalidRequestError(msg, provider="datago", provider_code=code)
         if code == "12":
+            logger.debug("Datago API envelope error", extra=extra)
             raise DatasetNotFoundError(
                 msg,
                 provider="datago",
@@ -417,7 +466,9 @@ class DataGoAdapter:
                 dataset_id=dataset_id,
             )
         if code in {"01", "02"}:
+            logger.debug("Datago API envelope error", extra=extra)
             raise ServiceUnavailableError(msg, provider="datago", provider_code=code)
+        logger.debug("Datago API envelope error", extra=extra)
         raise ProviderResponseError(msg, provider="datago", provider_code=code)
 
     def _normalize_items(self, items_wrapper: object) -> list[dict[str, object]]:

--- a/src/kpubdata/providers/kosis/adapter.py
+++ b/src/kpubdata/providers/kosis/adapter.py
@@ -67,6 +67,10 @@ class KosisAdapter:
         if dataset is not None:
             return dataset
 
+        logger.debug(
+            "KOSIS dataset not found",
+            extra={"dataset_id": f"kosis.{dataset_key}", "provider": "kosis"},
+        )
         raise DatasetNotFoundError(
             f"Dataset not found: kosis.{dataset_key}",
             provider="kosis",
@@ -87,8 +91,19 @@ class KosisAdapter:
             },
         )
         url = self._build_request_url(dataset, query)
-        payload = self._request_and_decode(url)
+        payload = self._request_and_decode(url, dataset.id)
         items = self._extract_items(payload, dataset.id)
+
+        if not items:
+            logger.debug(
+                "KOSIS envelope: zero items",
+                extra={
+                    "dataset_id": dataset.id,
+                    "page": query.page,
+                    "page_size": _page_size,
+                    "total_count": len(items),
+                },
+            )
 
         return RecordBatch(
             items=items,
@@ -111,7 +126,7 @@ class KosisAdapter:
             },
         )
         url = self._build_raw_url(dataset, operation, params)
-        payload = self._request_and_decode(url)
+        payload = self._request_and_decode(url, dataset.id)
         if isinstance(payload, dict):
             self._raise_for_error_payload(cast(dict[str, object], payload), dataset.id)
         return payload
@@ -123,6 +138,9 @@ class KosisAdapter:
         start_date = query.start_date
         end_date = query.end_date
         if not isinstance(start_date, str) or not start_date:
+            logger.debug(
+                "KOSIS invalid query: missing start_date", extra={"dataset_id": dataset.id}
+            )
             raise InvalidRequestError(
                 "KOSIS queries require start_date",
                 provider="kosis",
@@ -187,13 +205,14 @@ class KosisAdapter:
         query_string = urlencode(params)
         return f"{base_url}?{query_string}"
 
-    def _request_and_decode(self, url: str) -> object:
-        response = self._transport.request("GET", url)
+    def _request_and_decode(self, url: str, dataset_id: str) -> object:
+        response = self._transport.request("GET", url, dataset_id=dataset_id, provider="kosis")
 
         try:
             decoded: object = decode_json(response.content)
         except ParseError as exc:
             exc.provider = "kosis"
+            logger.debug("KOSIS response parsing failed", extra={"dataset_id": dataset_id})
             raise
 
         if isinstance(decoded, list):
@@ -201,6 +220,7 @@ class KosisAdapter:
         if isinstance(decoded, dict):
             return cast(dict[str, object], decoded)
 
+        logger.debug("KOSIS response parsing failed", extra={"dataset_id": dataset_id})
         raise ParseError("Decoded payload is neither an object nor an array", provider="kosis")
 
     def _extract_items(self, payload: object, dataset_id: str) -> list[dict[str, object]]:
@@ -208,6 +228,10 @@ class KosisAdapter:
             self._raise_for_error_payload(cast(dict[str, object], payload), dataset_id)
 
         if not isinstance(payload, list):
+            logger.debug(
+                "KOSIS envelope malformed: expected array payload",
+                extra={"dataset_id": dataset_id},
+            )
             raise ProviderResponseError(
                 "Malformed KOSIS response: expected array payload",
                 provider="kosis",
@@ -224,8 +248,8 @@ class KosisAdapter:
         message = message_raw if isinstance(message_raw, str) else "KOSIS returned an error"
 
         logger.debug(
-            "KOSIS error response",
-            extra={"provider_code": code, "message": message, "dataset_id": dataset_id},
+            "KOSIS API envelope error",
+            extra={"dataset_id": dataset_id, "code": code, "message": message},
         )
 
         if code == "30":

--- a/src/kpubdata/providers/localdata/adapter.py
+++ b/src/kpubdata/providers/localdata/adapter.py
@@ -70,6 +70,10 @@ class LocaldataAdapter:
         if dataset is not None:
             return dataset
 
+        logger.debug(
+            "Localdata dataset not found",
+            extra={"dataset_id": f"localdata.{dataset_key}", "provider": "localdata"},
+        )
         raise DatasetNotFoundError(
             f"Dataset not found: localdata.{dataset_key}",
             provider="localdata",
@@ -101,7 +105,7 @@ class LocaldataAdapter:
                 value: object = raw_value
                 params[key] = str(value)
 
-        payload = self._request_and_decode(url, params)
+        payload = self._request_and_decode(url, params, dataset.id)
 
         body, items = self._validate_envelope(payload, dataset.id)
         total_count = coerce_int(body.get("totalCount"), 0)
@@ -111,6 +115,17 @@ class LocaldataAdapter:
             computed_next = page + 1
         else:
             computed_next = None
+
+        if not items:
+            logger.debug(
+                "Localdata envelope: zero items",
+                extra={
+                    "dataset_id": dataset.id,
+                    "page": page,
+                    "page_size": page_size,
+                    "total_count": total_count,
+                },
+            )
 
         return RecordBatch(
             items=items,
@@ -140,7 +155,7 @@ class LocaldataAdapter:
             if key != service_key_param:
                 request_params[key] = str(value)
 
-        payload = self._request_and_decode(url, request_params)
+        payload = self._request_and_decode(url, request_params, dataset.id)
         _ = self._validate_envelope(payload, dataset.id)
         return payload
 
@@ -150,6 +165,10 @@ class LocaldataAdapter:
     def _build_request_url(self, dataset: DatasetRef, operation: str | None = None) -> str:
         base_url_raw = dataset.raw_metadata.get("base_url")
         if not isinstance(base_url_raw, str) or not base_url_raw:
+            logger.debug(
+                "Localdata dataset metadata missing base_url",
+                extra={"dataset_id": dataset.id},
+            )
             raise ProviderResponseError(
                 "Dataset metadata missing base_url",
                 provider="localdata",
@@ -175,9 +194,17 @@ class LocaldataAdapter:
         )
         return {service_key_param: api_key, format_param: "json"}
 
-    def _request_and_decode(self, url: str, params: Mapping[str, object]) -> dict[str, object]:
+    def _request_and_decode(
+        self, url: str, params: Mapping[str, object], dataset_id: str
+    ) -> dict[str, object]:
         string_params = {key: str(value) for key, value in params.items()}
-        response = self._transport.request("GET", url, params=string_params)
+        response = self._transport.request(
+            "GET",
+            url,
+            params=string_params,
+            dataset_id=dataset_id,
+            provider="localdata",
+        )
 
         try:
             content_type = detect_content_type(response)
@@ -189,6 +216,7 @@ class LocaldataAdapter:
                 decoded = decode_json(response.content)
         except ParseError as exc:
             exc.provider = "localdata"
+            logger.debug("Localdata response parsing failed", extra={"dataset_id": dataset_id})
             raise
         except ImportError as exc:
             raise ParseError("Failed to parse localdata response", provider="localdata") from exc
@@ -196,6 +224,7 @@ class LocaldataAdapter:
         if isinstance(decoded, dict):
             return cast(dict[str, object], decoded)
 
+        logger.debug("Localdata decoded payload invalid type", extra={"dataset_id": dataset_id})
         raise ParseError("Decoded payload is not an object", provider="localdata")
 
     def _validate_envelope(

--- a/src/kpubdata/providers/lofin/adapter.py
+++ b/src/kpubdata/providers/lofin/adapter.py
@@ -83,6 +83,10 @@ class LofinAdapter:
         if dataset is not None:
             return dataset
 
+        logger.debug(
+            "LOFIN dataset not found",
+            extra={"dataset_id": f"lofin.{dataset_key}", "provider": "lofin"},
+        )
         raise DatasetNotFoundError(
             f"Dataset not found: lofin.{dataset_key}",
             provider="lofin",
@@ -116,6 +120,17 @@ class LofinAdapter:
             computed_next = page + 1
         else:
             computed_next = None
+
+        if not items:
+            logger.debug(
+                "LOFIN envelope: zero items",
+                extra={
+                    "dataset_id": dataset.id,
+                    "page": page,
+                    "page_size": page_size,
+                    "total_count": total_count,
+                },
+            )
 
         return RecordBatch(
             items=items,
@@ -161,6 +176,10 @@ class LofinAdapter:
     ) -> str:
         base_url_raw = dataset.raw_metadata.get("base_url")
         if not isinstance(base_url_raw, str) or not base_url_raw:
+            logger.debug(
+                "LOFIN dataset metadata missing base_url",
+                extra={"dataset_id": dataset.id},
+            )
             raise ProviderResponseError(
                 "Dataset metadata missing base_url",
                 provider="lofin",
@@ -181,11 +200,12 @@ class LofinAdapter:
         return url
 
     def _request_and_decode(self, url: str, dataset_id: str = "") -> dict[str, object]:
-        response = self._transport.request("GET", url)
+        response = self._transport.request("GET", url, dataset_id=dataset_id, provider="lofin")
 
         try:
             decoded_obj: object = decode_json(response.content)
         except ValueError as exc:
+            logger.debug("LOFIN response parsing failed", extra={"dataset_id": dataset_id})
             raise ParseError("Failed to parse LOFIN response", provider="lofin") from exc
 
         if isinstance(decoded_obj, dict):
@@ -193,6 +213,7 @@ class LofinAdapter:
             self._raise_for_top_level_result(payload, dataset_id)
             return payload
 
+        logger.debug("LOFIN decoded payload invalid type", extra={"dataset_id": dataset_id})
         raise ParseError("Decoded payload is not an object", provider="lofin")
 
     def _validate_envelope(

--- a/src/kpubdata/transport/http.py
+++ b/src/kpubdata/transport/http.py
@@ -158,6 +158,8 @@ class HttpTransport:
         headers: dict[str, str] | None = None,
         content: bytes | None = None,
         json_body: object = None,
+        dataset_id: str | None = None,
+        provider: str | None = None,
     ) -> httpx.Response:
         """Execute HTTP request with retry logic.
 
@@ -178,6 +180,7 @@ class HttpTransport:
         total_attempts = self._config.max_retries + 1
         for attempt in range(1, total_attempts + 1):
             retry_delay: float | None = None
+            request_context = _request_context(dataset_id=dataset_id, provider=provider)
             try:
                 logger.debug(
                     "HTTP request start",
@@ -186,6 +189,7 @@ class HttpTransport:
                         "url": url,
                         "attempt": attempt,
                         "max_retries": self._config.max_retries,
+                        **request_context,
                     },
                 )
 
@@ -196,6 +200,7 @@ class HttpTransport:
                             "method": method,
                             "url": url,
                             "params": _sanitize_params(params),
+                            **request_context,
                         },
                     )
 
@@ -216,6 +221,7 @@ class HttpTransport:
                         "url": url,
                         "status_code": response.status_code,
                         "attempt": attempt,
+                        **request_context,
                     },
                 )
 
@@ -227,6 +233,7 @@ class HttpTransport:
                             "content_type": response.headers.get("content-type", ""),
                             "content_length": len(response.content),
                             "preview": _response_preview(response),
+                            **request_context,
                         },
                     )
                 return response
@@ -239,6 +246,7 @@ class HttpTransport:
                         "url": url,
                         "attempt": attempt,
                         "exception_type": type(exc).__name__,
+                        **request_context,
                     },
                 )
                 if attempt >= total_attempts:
@@ -255,6 +263,7 @@ class HttpTransport:
                         "url": url,
                         "attempt": attempt,
                         "status_code": status_code,
+                        **request_context,
                     },
                 )
                 if not _is_retryable_status(status_code) or attempt >= total_attempts:
@@ -274,6 +283,7 @@ class HttpTransport:
                         "url": url,
                         "attempt": attempt,
                         "exception_type": type(exc).__name__,
+                        **request_context,
                     },
                 )
                 if attempt >= total_attempts:
@@ -293,6 +303,7 @@ class HttpTransport:
                     "url": url,
                     "attempt": attempt,
                     "delay_seconds": delay,
+                    **request_context,
                 },
             )
             time.sleep(delay)
@@ -303,6 +314,15 @@ class HttpTransport:
 
 def _is_retryable_status(status_code: int) -> bool:
     return status_code == 429 or 500 <= status_code <= 599
+
+
+def _request_context(*, dataset_id: str | None, provider: str | None) -> dict[str, str]:
+    context: dict[str, str] = {}
+    if dataset_id is not None:
+        context["dataset_id"] = dataset_id
+    if provider is not None:
+        context["provider"] = provider
+    return context
 
 
 def _merge_headers(

--- a/tests/unit/providers/bok/test_bok_adapter.py
+++ b/tests/unit/providers/bok/test_bok_adapter.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import cast
+
+import pytest
 
 from kpubdata.config import KPubDataConfig
 from kpubdata.core.models import DatasetRef, Query
+from kpubdata.exceptions import InvalidRequestError
 from kpubdata.providers.bok.adapter import BokAdapter
 from kpubdata.transport.http import HttpTransport
 
@@ -84,3 +88,38 @@ def test_query_records_uses_heuristic_next_page_without_total_count() -> None:
 
     assert batch.total_count is None
     assert batch.next_page == 2
+
+
+def test_query_records_missing_dates_logs_debug(caplog: pytest.LogCaptureFixture) -> None:
+    adapter, dataset, _ = _build_adapter_with_transport([])
+
+    caplog.set_level(logging.DEBUG, logger="kpubdata.provider.bok")
+    with pytest.raises(InvalidRequestError, match="start_date and end_date"):
+        adapter.query_records(dataset, Query())
+
+    record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "BOK ECOS invalid query: missing start/end date"
+    )
+    assert record.__dict__["dataset_id"] == dataset.id
+
+
+def test_query_records_zero_items_logs_debug(caplog: pytest.LogCaptureFixture) -> None:
+    payload = _success_payload(items=[], total_count=0)
+    adapter, dataset, _ = _build_adapter_with_transport([FakeResponse(payload)])
+
+    caplog.set_level(logging.DEBUG, logger="kpubdata.provider.bok")
+    batch = adapter.query_records(
+        dataset,
+        Query(page=1, page_size=10, start_date="202401", end_date="202403"),
+    )
+
+    assert batch.items == []
+    record = next(
+        record for record in caplog.records if record.getMessage() == "BOK envelope: zero items"
+    )
+    assert record.__dict__["dataset_id"] == dataset.id
+    assert record.__dict__["page"] == 1
+    assert record.__dict__["page_size"] == 10
+    assert record.__dict__["total_count"] == 0

--- a/tests/unit/providers/datago/test_adapter.py
+++ b/tests/unit/providers/datago/test_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from types import MappingProxyType
 from typing import Protocol, cast
 
@@ -32,7 +33,7 @@ REAL_ESTATE_DATASET_KEYS = [
 
 
 class FakeResponse:
-    def __init__(self, payload: dict[str, object], content_type: str = "application/json") -> None:
+    def __init__(self, payload: object, content_type: str = "application/json") -> None:
         self.headers: dict[str, str] = {"content-type": content_type}
         self.text: str = json.dumps(payload)
         self.content: bytes = self.text.encode()
@@ -291,6 +292,23 @@ class TestDataGoAdapterQueryRecords:
 
         assert batch.items == []
         assert batch.total_count is None
+
+    def test_query_records_empty_items_logs_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        payload = _success_payload(items=None, total_count=0, num_of_rows=100, page_no=1)
+        adapter, dataset, _ = _build_adapter_with_transport([FakeResponse(payload)])
+
+        caplog.set_level(logging.DEBUG, logger="kpubdata.provider.datago")
+        _ = adapter.query_records(dataset, Query())
+
+        record = next(
+            record
+            for record in caplog.records
+            if record.getMessage() == "Datago envelope: zero items"
+        )
+        assert record.__dict__["dataset_id"] == dataset.id
+        assert record.__dict__["page"] == 1
+        assert record.__dict__["page_size"] == 100
+        assert record.__dict__["total_count"] == 0
 
     def test_query_records_string_numerics(self) -> None:
         payload = _success_payload(

--- a/tests/unit/providers/datago/test_generic.py
+++ b/tests/unit/providers/datago/test_generic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import cast
 
 import pytest
@@ -12,7 +13,7 @@ from kpubdata.transport.http import HttpTransport
 
 
 class FakeResponse:
-    def __init__(self, payload: dict[str, object], content_type: str = "application/json") -> None:
+    def __init__(self, payload: object, content_type: str = "application/json") -> None:
         self.headers: dict[str, str] = {"content-type": content_type}
         self.text: str = json.dumps(payload)
         self.content: bytes = self.text.encode()
@@ -99,6 +100,21 @@ class TestDataGoGenericDataset:
 
         with pytest.raises(InvalidRequestError, match="_base_url"):
             adapter.call_raw(dataset, "getX", {})
+
+    def test_call_raw_missing_base_url_logs_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        adapter, _ = _build_adapter([])
+        dataset = adapter.get_dataset("generic")
+
+        caplog.set_level(logging.DEBUG, logger="kpubdata.provider.datago")
+        with pytest.raises(InvalidRequestError, match="_base_url"):
+            adapter.call_raw(dataset, "getX", {})
+
+        record = next(
+            record
+            for record in caplog.records
+            if record.getMessage() == "Datago.generic missing _base_url in call_raw params"
+        )
+        assert record.__dict__["dataset_id"] == dataset.id
 
     def test_call_raw_envelope_skip_allows_non_standard_payload(self) -> None:
         non_standard = {"items": [{"a": 1}]}

--- a/tests/unit/providers/kosis/test_adapter.py
+++ b/tests/unit/providers/kosis/test_adapter.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import cast
+
+import pytest
+
+from kpubdata.config import KPubDataConfig
+from kpubdata.core.models import DatasetRef, Query
+from kpubdata.exceptions import InvalidRequestError
+from kpubdata.providers.kosis.adapter import KosisAdapter
+from kpubdata.transport.http import HttpTransport
+
+
+class FakeResponse:
+    def __init__(self, payload: object) -> None:
+        self.headers: dict[str, str] = {"content-type": "application/json"}
+        self.text: str = json.dumps(payload)
+        self.content: bytes = self.text.encode()
+
+
+class FakeTransport:
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self._responses: list[FakeResponse] = list(responses)
+        self.calls: list[dict[str, object]] = []
+
+    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, **kwargs})
+        return self._responses.pop(0)
+
+
+def _build_adapter_with_transport(
+    responses: list[FakeResponse],
+) -> tuple[KosisAdapter, DatasetRef, FakeTransport]:
+    transport = FakeTransport(responses)
+    adapter = KosisAdapter(
+        config=KPubDataConfig(provider_keys={"kosis": "test-key"}),
+        transport=cast(HttpTransport, cast(object, transport)),
+    )
+    dataset = adapter.get_dataset("population_migration")
+    return adapter, dataset, transport
+
+
+def test_query_records_missing_start_date_logs_debug(caplog: pytest.LogCaptureFixture) -> None:
+    adapter, dataset, _ = _build_adapter_with_transport([])
+
+    caplog.set_level(logging.DEBUG, logger="kpubdata.provider.kosis")
+    with pytest.raises(InvalidRequestError, match="start_date"):
+        adapter.query_records(dataset, Query(end_date="202401"))
+
+    record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "KOSIS invalid query: missing start_date"
+    )
+    assert record.__dict__["dataset_id"] == dataset.id
+
+
+def test_query_records_zero_items_logs_debug(caplog: pytest.LogCaptureFixture) -> None:
+    adapter, dataset, _ = _build_adapter_with_transport([FakeResponse([])])
+
+    caplog.set_level(logging.DEBUG, logger="kpubdata.provider.kosis")
+    batch = adapter.query_records(dataset, Query(start_date="202401", end_date="202401"))
+
+    assert batch.items == []
+    record = next(
+        record for record in caplog.records if record.getMessage() == "KOSIS envelope: zero items"
+    )
+    assert record.__dict__["dataset_id"] == dataset.id
+    assert record.__dict__["page"] is None
+    assert record.__dict__["page_size"] == 100
+    assert record.__dict__["total_count"] == 0

--- a/tests/unit/providers/localdata/test_adapter.py
+++ b/tests/unit/providers/localdata/test_adapter.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
+from types import MappingProxyType
 from typing import cast
+
+import pytest
 
 from kpubdata.config import KPubDataConfig
 from kpubdata.core.models import DatasetRef, Query
-from kpubdata.exceptions import AuthError
+from kpubdata.exceptions import AuthError, ProviderResponseError
 from kpubdata.providers.localdata.adapter import LocaldataAdapter
 from kpubdata.transport.http import HttpTransport
 
@@ -101,6 +105,27 @@ def test_query_records_handles_empty_response() -> None:
     assert batch.next_page is None
 
 
+def test_query_records_handles_empty_response_logs_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    payload = _load_fixture("empty_response.json")
+    adapter, dataset, _ = _build_adapter_with_transport([FakeResponse(payload)])
+
+    caplog.set_level(logging.DEBUG, logger="kpubdata.provider.localdata")
+    batch = adapter.query_records(dataset, Query())
+
+    assert batch.items == []
+    record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "Localdata envelope: zero items"
+    )
+    assert record.__dict__["dataset_id"] == dataset.id
+    assert record.__dict__["page"] == 1
+    assert record.__dict__["page_size"] == 100
+    assert record.__dict__["total_count"] == 0
+
+
 def test_query_records_sets_next_page_with_total_count() -> None:
     payload = _load_fixture("general_restaurant_success.json")
     adapter, dataset, _ = _build_adapter_with_transport([FakeResponse(payload)])
@@ -146,3 +171,30 @@ def test_adapter_lists_two_datasets() -> None:
         "general_restaurant",
         "rest_cafe",
     ]
+
+
+def test_build_request_url_missing_base_url_logs_debug(caplog: pytest.LogCaptureFixture) -> None:
+    adapter, dataset, _ = _build_adapter_with_transport([])
+    dataset = DatasetRef(
+        id=dataset.id,
+        provider=dataset.provider,
+        dataset_key=dataset.dataset_key,
+        name=dataset.name,
+        representation=dataset.representation,
+        operations=dataset.operations,
+        raw_metadata=MappingProxyType(
+            {k: v for k, v in dataset.raw_metadata.items() if k != "base_url"}
+        ),
+        query_support=dataset.query_support,
+    )
+
+    caplog.set_level(logging.DEBUG, logger="kpubdata.provider.localdata")
+    with pytest.raises(ProviderResponseError, match="base_url"):
+        adapter.query_records(dataset, Query())
+
+    record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "Localdata dataset metadata missing base_url"
+    )
+    assert record.__dict__["dataset_id"] == dataset.id

--- a/tests/unit/providers/lofin/test_lofin_adapter.py
+++ b/tests/unit/providers/lofin/test_lofin_adapter.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import json
+import logging
+from types import MappingProxyType
 from typing import cast
+
+import pytest
 
 from kpubdata.config import KPubDataConfig
 from kpubdata.core.models import DatasetRef, Query
+from kpubdata.exceptions import ProviderResponseError
 from kpubdata.providers.lofin.adapter import LofinAdapter
 from kpubdata.transport.http import HttpTransport
 
@@ -83,6 +88,50 @@ def test_query_records_uses_heuristic_next_page_without_total_count() -> None:
 
     assert batch.total_count is None
     assert batch.next_page == 2
+
+
+def test_build_request_url_missing_base_url_logs_debug(caplog: pytest.LogCaptureFixture) -> None:
+    adapter, dataset, _ = _build_adapter_with_transport([])
+    dataset = DatasetRef(
+        id=dataset.id,
+        provider=dataset.provider,
+        dataset_key=dataset.dataset_key,
+        name=dataset.name,
+        representation=dataset.representation,
+        operations=dataset.operations,
+        raw_metadata=MappingProxyType(
+            {k: v for k, v in dataset.raw_metadata.items() if k != "base_url"}
+        ),
+        query_support=dataset.query_support,
+    )
+
+    caplog.set_level(logging.DEBUG, logger="kpubdata.provider.lofin")
+    with pytest.raises(ProviderResponseError, match="base_url"):
+        adapter.query_records(dataset, Query())
+
+    record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "LOFIN dataset metadata missing base_url"
+    )
+    assert record.__dict__["dataset_id"] == dataset.id
+
+
+def test_query_records_zero_items_logs_debug(caplog: pytest.LogCaptureFixture) -> None:
+    payload = _success_payload(items=[], total_count=0)
+    adapter, dataset, _ = _build_adapter_with_transport([FakeResponse(payload)])
+
+    caplog.set_level(logging.DEBUG, logger="kpubdata.provider.lofin")
+    batch = adapter.query_records(dataset, Query(page=1, page_size=10))
+
+    assert batch.items == []
+    record = next(
+        record for record in caplog.records if record.getMessage() == "LOFIN envelope: zero items"
+    )
+    assert record.__dict__["dataset_id"] == dataset.id
+    assert record.__dict__["page"] == 1
+    assert record.__dict__["page_size"] == 10
+    assert record.__dict__["total_count"] == 0
 
 
 def test_transport_requirements_includes_ssl_context_factory() -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -16,11 +16,15 @@ class TestKPubDataConfig:
         cfg = KPubDataConfig(provider_keys={"datago": "mykey"})
         assert cfg.get_provider_key("datago") == "mykey"
 
-    def test_missing_key_returns_none(self) -> None:
+    def test_missing_key_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("KPUBDATA_DATAGO_API_KEY", raising=False)
+        monkeypatch.delenv("DATAGO_API_KEY", raising=False)
         cfg = KPubDataConfig()
         assert cfg.get_provider_key("datago") is None
 
-    def test_require_key_raises(self) -> None:
+    def test_require_key_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("KPUBDATA_DATAGO_API_KEY", raising=False)
+        monkeypatch.delenv("DATAGO_API_KEY", raising=False)
         cfg = KPubDataConfig()
         with pytest.raises(ConfigError, match="Missing provider API key"):
             cfg.require_provider_key("datago")

--- a/tests/unit/test_failure_path_logging.py
+++ b/tests/unit/test_failure_path_logging.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from kpubdata.catalog import Catalog
+from kpubdata.config import KPubDataConfig
+from kpubdata.core.dataset import Dataset
+from kpubdata.core.models import DatasetRef, Query, RecordBatch, SchemaDescriptor
+from kpubdata.core.representation import Representation
+from kpubdata.exceptions import ConfigError, DatasetNotFoundError, UnsupportedCapabilityError
+from kpubdata.registry import ProviderRegistry
+
+
+class _FakeAdapter:
+    name = "fake"
+
+    def list_datasets(self) -> list[DatasetRef]:
+        return []
+
+    def search_datasets(self, text: str) -> list[DatasetRef]:
+        _ = text
+        return []
+
+    def get_dataset(self, dataset_key: str) -> DatasetRef:
+        raise DatasetNotFoundError(
+            f"Dataset not found: fake.{dataset_key}",
+            provider="fake",
+            dataset_id=f"fake.{dataset_key}",
+        )
+
+    def query_records(self, dataset: DatasetRef, query: Query) -> RecordBatch:
+        _ = dataset, query
+        raise AssertionError("query_records should not be called")
+
+    def get_schema(self, dataset: DatasetRef) -> SchemaDescriptor | None:
+        _ = dataset
+        return None
+
+    def call_raw(self, dataset: DatasetRef, operation: str, params: dict[str, object]) -> object:
+        _ = dataset, operation, params
+        return None
+
+
+def test_catalog_resolve_failure_logs_debug(caplog: pytest.LogCaptureFixture) -> None:
+    registry = ProviderRegistry()
+    registry.register(_FakeAdapter())
+    catalog = Catalog(registry)
+
+    caplog.set_level(logging.DEBUG, logger="kpubdata.catalog")
+    with pytest.raises(DatasetNotFoundError):
+        _ = catalog.resolve("fake.nope")
+
+    record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "Catalog resolve failed: dataset not found"
+    )
+    assert record.__dict__["dataset_id"] == "fake.nope"
+    assert record.__dict__["provider"] == "fake"
+
+
+def test_dataset_list_unsupported_logs_debug(caplog: pytest.LogCaptureFixture) -> None:
+    dataset = Dataset(
+        ref=DatasetRef(
+            id="fake.raw_only",
+            provider="fake",
+            dataset_key="raw_only",
+            name="Raw Only",
+            operations=frozenset(),
+            representation=Representation.API_JSON,
+        ),
+        adapter=_FakeAdapter(),
+    )
+
+    caplog.set_level(logging.DEBUG, logger="kpubdata.dataset")
+    with pytest.raises(UnsupportedCapabilityError):
+        _ = dataset.list()
+
+    record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "Dataset does not support LIST"
+    )
+    assert record.__dict__["dataset_id"] == "fake.raw_only"
+    assert record.__dict__["provider"] == "fake"
+    assert record.__dict__["operation"] == "list"
+
+
+def test_missing_provider_key_logs_debug(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KPUBDATA_DATAGO_API_KEY", raising=False)
+    monkeypatch.delenv("DATAGO_API_KEY", raising=False)
+    cfg = KPubDataConfig()
+
+    caplog.set_level(logging.DEBUG, logger="kpubdata.config")
+    with pytest.raises(ConfigError):
+        cfg.require_provider_key("datago")
+
+    record = next(
+        record for record in caplog.records if record.getMessage() == "Missing provider API key"
+    )
+    assert record.__dict__["provider"] == "datago"

--- a/tests/unit/transport/test_logging.py
+++ b/tests/unit/transport/test_logging.py
@@ -120,3 +120,26 @@ def test_debug_gating_skips_sanitization_and_preview_helpers() -> None:
         patch("kpubdata.transport.http.httpx.Client.request", return_value=response),
     ):
         _ = transport.request("GET", "https://example.test/resource", params={"serviceKey": "x"})
+
+
+def test_request_logs_include_dataset_context(caplog: pytest.LogCaptureFixture) -> None:
+    transport = HttpTransport(TransportConfig(max_retries=0))
+    response = _response_with_content(b'{"ok": true}', "application/json")
+    caplog.set_level(logging.DEBUG, logger="kpubdata.transport")
+
+    with patch("kpubdata.transport.http.httpx.Client.request", return_value=response):
+        _ = transport.request(
+            "GET",
+            "https://example.test/resource",
+            dataset_id="datago.village_fcst",
+            provider="datago",
+        )
+
+    for message in {
+        "HTTP request start",
+        "HTTP request success",
+        "HTTP response preview",
+    }:
+        record = next(record for record in caplog.records if record.getMessage() == message)
+        assert record.__dict__["dataset_id"] == "datago.village_fcst"
+        assert record.__dict__["provider"] == "datago"


### PR DESCRIPTION
## 배경
- 라이브 API 검증 과정에서 #139, #140 계열 실패를 추적할 때 정상 경로 로그만으로는 실패 직전 컨텍스트가 부족했습니다.
- 이번 PR은 공개 동작을 바꾸지 않고 DEBUG 로그만 보강해, 어댑터 실패와 HTTP 호출을 같은 흐름으로 상관분석할 수 있게 합니다.

## 변경 사항
- 5개 provider adapter와 core/config 경로에 예외 발생 직전 DEBUG 로그를 추가했습니다.
- envelope 성공 + `items=[]` 인 분기에도 zero-items DEBUG 로그를 추가했습니다.
- `HttpTransport.request()`가 선택적 `dataset_id`/`provider` 컨텍스트를 받아 모든 HTTP DEBUG 로그에 함께 남기도록 확장했습니다.
- caplog 기반 단위 테스트를 추가/보강해 새 로그 메시지와 `extra` 키를 검증했습니다.
- `docs/logging.md`에 새로운 `extra` 키와 실패 경로 디버깅 패턴을 문서화했습니다.

## 추가된 주요 컨텍스트 키
- provider logs: `dataset_id`, `provider`, `page`, `page_size`, `total_count`, `result_code`, `result_msg`, `code`, `message`, `operation`
- transport logs: `dataset_id`, `provider`

## 검증
- `uv sync --extra dev`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv run pytest`
- `uv run python -m build`

## 비고
- 스킵한 empty-result 분기 없음
- 예외 타입, 제어 흐름, 공개 API 동작은 변경하지 않았습니다.