### PR TITLE
fix(datago): update bus_arrival to v2 endpoint

### DIFF
--- a/docs/providers/datago.md
+++ b/docs/providers/datago.md
@@ -176,7 +176,7 @@ raw = ds.call_raw("getCtprvnRltmMesureDnsty", sidoName="서울", numOfRows="5")
 
 ```python
 ds = client.dataset("datago.bus_arrival")
-raw = ds.call_raw("getBusArrivalList", stationId="200000078")
+raw = ds.call_raw("getBusArrivalListv2", stationId="200000078")
 ```
 
 ### hospital_info (병원정보서비스)

--- a/src/kpubdata/providers/datago/catalogue.json
+++ b/src/kpubdata/providers/datago/catalogue.json
@@ -47,8 +47,8 @@
   {
     "dataset_key": "bus_arrival",
     "name": "경기도 버스도착정보 조회서비스 (Bus Arrival)",
-    "base_url": "http://apis.data.go.kr/6410000/busarrivalservice",
-    "default_operation": "getBusArrivalList",
+    "base_url": "http://apis.data.go.kr/6410000/busarrivalservice/v2",
+    "default_operation": "getBusArrivalListv2",
     "representation": "api_json",
     "service_key_param": "serviceKey",
     "format_param": "_type",

--- a/tests/integration/test_datago_live.py
+++ b/tests/integration/test_datago_live.py
@@ -58,7 +58,7 @@ def test_datago_bus_arrival(
     _ = require_realestate_key
     ds = live_client.dataset("datago.bus_arrival")
 
-    result = ds.call_raw("getBusArrivalList", stationId="228000704", numOfRows="5")
+    result = ds.call_raw("getBusArrivalListv2", stationId="228000704", numOfRows="5")
 
     assert isinstance(result, dict)
     assert "response" in result


### PR DESCRIPTION
## Summary
- 경기도 버스도착정보 서비스가 v2로 업그레이드되며 기존 v1 endpoint (`getBusArrivalList`)가 404를 반환합니다.
- 카탈로그의 `base_url`과 `default_operation`을 v2(`/v2/getBusArrivalListv2`)로 갱신합니다.
- 라이브 통합 테스트와 provider 문서 예제도 함께 v2 호출로 갱신합니다.

## Why
이전 라이브 검증에서 `bus_arrival`만 HTTP 404로 실패했고, 원인이 활용신청이 아니라 endpoint 변경임을 data.go.kr OpenAPI 페이지(15080346)와 경기버스정보(gbis.go.kr) 개발가이드로 확인했습니다.

## Changes
- `src/kpubdata/providers/datago/catalogue.json`
  - `base_url`: `http://apis.data.go.kr/6410000/busarrivalservice` → `.../v2`
  - `default_operation`: `getBusArrivalList` → `getBusArrivalListv2`
- `tests/integration/test_datago_live.py`: `call_raw` operation을 v2로 갱신
- `docs/providers/datago.md`: 사용 예제 갱신

## Validation
- ruff check / ruff format --check / mypy: 통과
- pytest: 438 passed, 1 skipped (pandas optional)
- python -m build: 성공

라이브 재검증은 활용신청 승인 + 키 활성화 이후 별도 PR(SUPPORTED_DATA.md `실API 검증` 승격)에서 함께 확인합니다.