### PR TITLE
fix(datago): support v2 envelope for bus_arrival (msgHeader/msgBody)

### DIFF
--- a/src/kpubdata/providers/datago/adapter.py
+++ b/src/kpubdata/providers/datago/adapter.py
@@ -147,7 +147,7 @@ class DataGoAdapter:
                 params[key] = str(value)
 
         payload = self._request_and_decode(url, params, dataset.id)
-        body, items = self._validate_envelope(payload, dataset.id)
+        body, items = self._validate_envelope(payload, dataset)
 
         total_count = coerce_int(body.get("totalCount"), 0)
         if (total_count and page * page_size < total_count) or (
@@ -293,7 +293,7 @@ class DataGoAdapter:
 
             payload = self._request_and_decode(url, request_params, dataset.id)
             if validate_envelope:
-                _ = self._validate_envelope(payload, dataset.id)
+                _ = self._validate_envelope(payload, dataset)
             return payload
 
         url = self._build_request_url(dataset, operation)
@@ -305,7 +305,7 @@ class DataGoAdapter:
                 request_params[key] = str(value)
 
         payload = self._request_and_decode(url, request_params, dataset.id)
-        _ = self._validate_envelope(payload, dataset.id)
+        _ = self._validate_envelope(payload, dataset)
         return payload
 
     @staticmethod
@@ -395,8 +395,9 @@ class DataGoAdapter:
         raise ParseError("Decoded payload is not an object", provider="datago")
 
     def _validate_envelope(
-        self, payload: dict[str, object], dataset_id: str = ""
+        self, payload: dict[str, object], dataset: DatasetRef | None = None
     ) -> tuple[dict[str, object], list[dict[str, object]]]:
+        dataset_id = dataset.id if dataset is not None else ""
         response_obj = payload.get("response")
         if not isinstance(response_obj, dict):
             logger.debug(
@@ -411,6 +412,14 @@ class DataGoAdapter:
 
         response_dict = cast(dict[str, object], response_obj)
 
+        envelope_style = dataset.raw_metadata.get("envelope_style") if dataset is not None else None
+        if envelope_style == "gyeonggi_msg":
+            return self._validate_gyeonggi_msg_envelope(response_dict, dataset_id)
+        return self._validate_standard_envelope(response_dict, dataset_id)
+
+    def _validate_standard_envelope(
+        self, response_dict: dict[str, object], dataset_id: str
+    ) -> tuple[dict[str, object], list[dict[str, object]]]:
         header_obj = response_dict.get("header")
         if not isinstance(header_obj, dict):
             raise ProviderResponseError(
@@ -445,6 +454,57 @@ class DataGoAdapter:
         )
         items = self._normalize_items(body_dict.get("items"))
         return body_dict, items
+
+    def _validate_gyeonggi_msg_envelope(
+        self, response_dict: dict[str, object], dataset_id: str
+    ) -> tuple[dict[str, object], list[dict[str, object]]]:
+        header_obj = response_dict.get("msgHeader")
+        if not isinstance(header_obj, dict):
+            raise ProviderResponseError(
+                "Malformed response envelope: missing msgHeader",
+                provider="datago",
+                dataset_id=dataset_id or None,
+            )
+
+        header_dict = cast(dict[str, object], header_obj)
+        result_code = self._coerce_result_code(header_dict.get("resultCode"), dataset_id)
+        result_msg_raw = header_dict.get("resultMessage")
+        result_msg = (
+            result_msg_raw if isinstance(result_msg_raw, str) else "Provider returned error"
+        )
+        logger.debug(
+            "data.go.kr result",
+            extra={"result_code": result_code, "result_msg": result_msg, "dataset_id": dataset_id},
+        )
+        if not _is_success_code(result_code):
+            self._raise_for_result_code(result_code, result_msg, dataset_id)
+
+        body_obj = response_dict.get("msgBody")
+        body_dict: dict[str, object] = (
+            cast(dict[str, object], body_obj) if isinstance(body_obj, dict) else {}
+        )
+        items_wrapper = self._extract_gyeonggi_msg_items_wrapper(body_dict)
+        items = self._normalize_items(items_wrapper)
+        return body_dict, items
+
+    def _coerce_result_code(self, result_code: object, dataset_id: str) -> str:
+        if isinstance(result_code, str):
+            return result_code
+        if isinstance(result_code, int):
+            return str(result_code)
+        raise ProviderResponseError(
+            "Malformed response envelope: missing resultCode",
+            provider="datago",
+            dataset_id=dataset_id or None,
+        )
+
+    def _extract_gyeonggi_msg_items_wrapper(self, body_dict: dict[str, object]) -> object:
+        list_values: list[object] = [
+            value for value in body_dict.values() if isinstance(value, list)
+        ]
+        if len(list_values) == 1:
+            return list_values[0]
+        return body_dict
 
     def _raise_for_result_code(self, code: str, msg: str, dataset_id: str) -> NoReturn:
         extra = {"dataset_id": dataset_id, "result_code": code, "result_msg": msg}

--- a/src/kpubdata/providers/datago/catalogue.json
+++ b/src/kpubdata/providers/datago/catalogue.json
@@ -49,6 +49,7 @@
     "name": "경기도 버스도착정보 조회서비스 (Bus Arrival)",
     "base_url": "http://apis.data.go.kr/6410000/busarrivalservice/v2",
     "default_operation": "getBusArrivalListv2",
+    "envelope_style": "gyeonggi_msg",
     "representation": "api_json",
     "service_key_param": "serviceKey",
     "format_param": "_type",

--- a/tests/fixtures/datago/bus_arrival_v2.json
+++ b/tests/fixtures/datago/bus_arrival_v2.json
@@ -1,0 +1,20 @@
+{
+  "response": {
+    "comMsgHeader": "",
+    "msgHeader": {
+      "queryTime": "2026-04-21 09:19:32.093",
+      "resultCode": 0,
+      "resultMessage": "정상적으로 처리되었습니다."
+    },
+    "msgBody": {
+      "busArrivalList": [
+        {
+          "flag": "PASS",
+          "routeId": 200000333,
+          "stationId": 228000704,
+          "staOrder": 3
+        }
+      ]
+    }
+  }
+}

--- a/tests/unit/providers/datago/test_fixtures.py
+++ b/tests/unit/providers/datago/test_fixtures.py
@@ -50,6 +50,31 @@ def _build_real_estate_adapter(
     return adapter, dataset
 
 
+def test_fixture_bus_arrival_v2_call_raw_returns_full_envelope() -> None:
+    adapter, dataset = _build_real_estate_adapter("bus_arrival_v2.json", "bus_arrival")
+    expected = load_json_fixture("bus_arrival_v2.json")
+
+    payload = adapter.call_raw(dataset, "getBusArrivalListv2", {"stationId": "228000704"})
+
+    assert payload == expected
+    payload_dict = cast(dict[str, object], payload)
+    response = payload_dict["response"]
+    assert isinstance(response, dict)
+    assert "msgHeader" in response
+    assert "msgBody" in response
+
+
+def test_fixture_bus_arrival_v2_list_normalizes_msg_body_list() -> None:
+    adapter, dataset = _build_real_estate_adapter("bus_arrival_v2.json", "bus_arrival")
+
+    batch = adapter.query_records(dataset, Query())
+
+    assert len(batch.items) == 1
+    assert batch.items[0]["routeId"] == 200000333
+    assert batch.items[0]["stationId"] == 228000704
+    assert batch.total_count is None
+
+
 def test_fixture_single_page(configured_adapter: AdapterFactory) -> None:
     adapter, dataset, _ = configured_adapter(["success_single_page.json"])
 


### PR DESCRIPTION
## Summary
- add dataset-level envelope dispatch so `datago.bus_arrival` can validate Gyeonggi-do `msgHeader`/`msgBody` responses without changing the standard datago envelope path
- coerce v2 `resultCode` values to strings, reuse existing provider error mapping, and normalize single list-valued `msgBody` payloads for `call_raw()`/`list()`
- add a sanitized `bus_arrival_v2` fixture plus unit coverage for raw calls and list normalization

## Validation
- uv sync --extra dev
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy src
- uv run pytest
- uv run python -m build