### PR TITLE
feat(seoul): add Seoul Open Data Plaza provider with subway and bike datasets

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -76,6 +76,10 @@ for batch in dataset.list_all(lawd_code="11680", deal_ym="202503"):
 `list_all()` yields one `RecordBatch` per page and follows `next_page`
 automatically until pagination is exhausted.
 
+Dataset metadata may expose provider-specific pagination styles through
+`DatasetRef.query_support.pagination`, including `offset`, `cursor`, and
+index-window based `index` pagination.
+
 ### Schema
 
 ```python

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ KPubData가 지원하는 각 기관의 API 키를 발급받아 [환경 변수](h
 - **절차**: 회원가입 → 지방행정인허가 Open API(일반음식점/휴게음식점) 활용신청 → 승인 후 인증키 확인
 - **환경 변수**: `KPUBDATA_LOCALDATA_API_KEY`
 
+#### 서울 열린데이터광장 (data.seoul.go.kr) — `seoul`
+- **가입 URL**: [https://data.seoul.go.kr/](https://data.seoul.go.kr/)
+- **절차**: 회원가입 → 원하는 Open API 페이지에서 인증키 신청/확인 → 마이페이지에서 발급 키 확인
+- **참고**: 서울 Open API는 인증키를 쿼리스트링이 아니라 URL 경로 세그먼트로 전달합니다.
+- **환경 변수**: `KPUBDATA_SEOUL_API_KEY`
+
 #### 환경 변수 설정 예시
 ```bash
 # 공공데이터포털 (data.go.kr)
@@ -145,6 +151,9 @@ export KPUBDATA_LOFIN_API_KEY="your-lofin-api-key"
 
 # 지방행정인허가
 export KPUBDATA_LOCALDATA_API_KEY="your-localdata-service-key"
+
+# 서울 열린데이터광장
+export KPUBDATA_SEOUL_API_KEY="your-seoul-api-key"
 ```
 
 ### 2. 클라이언트 생성
@@ -162,6 +171,7 @@ client = Client(provider_keys={
     "kosis": "YOUR_KOSIS_API_KEY",
     "lofin": "YOUR_LOFIN_API_KEY",
     "localdata": "YOUR_DATA_GO_KR_API_KEY",
+    "seoul": "YOUR_SEOUL_API_KEY",
 })
 ```
 
@@ -344,6 +354,8 @@ print(df.head())
 | 공공데이터포털 (`datago`) | 한국관광공사 행사정보 (`tour_kor_festival`) | 지원 |
 | 공공데이터포털 (`datago`) | 서울교통공사 실시간 운임정보 (`metro_fare`) | 지원 |
 | 공공데이터포털 (`datago`) | 서울교통공사 최단경로 이동정보 (`metro_path`) | 지원 |
+| 서울 열린데이터광장 (`seoul`) | 지하철 실시간 도착정보 (`subway_realtime_arrival`) | 지원 |
+| 서울 열린데이터광장 (`seoul`) | 따릉이 월별 이용정보 (`bike_rent_month`) | 지원 |
 | 한국은행 ECOS (`bok`) | 기준금리 (`base_rate`) | 지원 |
 | 통계청 KOSIS (`kosis`) | 인구이동 (`population_migration`) | 지원 |
 | 지방재정365 (`lofin`) | 세출결산총괄 (`expenditure_budget`) | 지원 |

--- a/SUPPORTED_DATA.md
+++ b/SUPPORTED_DATA.md
@@ -43,6 +43,8 @@
 | 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `metro_path` | 서울교통공사 최단경로 이동정보 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr/15143842](https://www.data.go.kr/data/15143842/openapi.do) | 서울교통공사 / `getShtrmPath` (필수 파라미터 `dptreStnNm`/`arvlStnNm` 등, 활용가이드 확인 필요, [#140](https://github.com/yeongseon/kpubdata/issues/140)) |
 | 지원 | 테스트 검증 | - | 지방행정인허가 (`localdata`) | `general_restaurant` | 일반음식점 인허가 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 행정안전부 제공, service_name 실API 검증 완료 (data.go.kr 이관) |
 | 지원 | 테스트 검증 | - | 지방행정인허가 (`localdata`) | `rest_cafe` | 휴게음식점 인허가 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 행정안전부 제공, service_name 실API 검증 완료 |
+| 지원 | 테스트 검증 | - | 서울 열린데이터광장 (`seoul`) | `subway_realtime_arrival` | 서울시 지하철 실시간 도착정보 | [서울 열린데이터광장](https://data.seoul.go.kr/) 인증키 | [data.seoul.go.kr](https://data.seoul.go.kr/) | 경로 기반 인증키 + 서비스별 top-level envelope |
+| 지원 | 테스트 검증 | - | 서울 열린데이터광장 (`seoul`) | `bike_rent_month` | 서울시 공공자전거 이용정보(월별) | [서울 열린데이터광장](https://data.seoul.go.kr/) 인증키 | [data.seoul.go.kr](https://data.seoul.go.kr/) | 경로 기반 인증키 + 인덱스 페이지네이션 |
 | 지원 | 실API 검증 | 2025-04-15 | 한국은행 ECOS (`bok`) | `base_rate` | 한국은행 기준금리 | [ECOS](https://ecos.bok.or.kr/api/) 인증키 | [ecos.bok.or.kr](https://ecos.bok.or.kr/api/) | |
 | 지원 | 실API 검증 | 2025-04-15 | 통계청 KOSIS (`kosis`) | `population_migration` | 시도별 이동자수 | [KOSIS](https://kosis.kr/openapi/index/index.jsp) 인증키 | [kosis.kr](https://kosis.kr/openapi/index/index.jsp) | |
 | 지원 | 실API 검증 | 2025-04-16 | 지방재정365 (`lofin`) | `expenditure_budget` | 세출결산총괄 | [지방재정365](https://www.lofin365.go.kr) 인증키 | [lofin365.go.kr](https://www.lofin365.go.kr) | API 코드: AJGCF |

--- a/docs/providers/seoul.md
+++ b/docs/providers/seoul.md
@@ -1,0 +1,133 @@
+# 서울 열린데이터광장 (seoul)
+
+## 개요
+
+서울 열린데이터광장은 서울시 교통·환경·행정 데이터를 Open API로 제공합니다. KPubData의 `seoul` provider는 서울 Open API의 경로 기반 인증키, 서비스별 top-level envelope, 시작/종료 인덱스 기반 페이지네이션을 그대로 존중하면서 `list()`와 `call_raw()`를 제공합니다.
+
+- KPubData provider 이름: `seoul`
+- 포털: <https://data.seoul.go.kr/>
+
+## 인증키 발급 및 환경 변수 설정
+
+1. [서울 열린데이터광장](https://data.seoul.go.kr/)에 가입합니다.
+2. 사용하려는 Open API 페이지에서 인증키를 신청하거나 발급 상태를 확인합니다.
+3. 마이페이지에서 인증키를 복사합니다.
+4. 환경 변수에 설정합니다.
+
+```bash
+export KPUBDATA_SEOUL_API_KEY="your-seoul-api-key"
+```
+
+`Client.from_env()`는 위 환경 변수를 자동으로 읽습니다.
+
+## 서울 Open API 호출 규칙
+
+- 인증키는 **쿼리 파라미터가 아니라 URL 경로 세그먼트**입니다.
+- 응답 형식은 `json`으로 고정합니다.
+- 페이지네이션은 `start_index` / `end_index` 기반입니다.
+- KPubData의 `list(page=..., page_size=...)`는 아래 규칙으로 변환됩니다.
+
+```text
+start_index = (page - 1) * page_size + 1
+end_index = page * page_size
+```
+
+- 최대 `page_size`는 `1000`입니다.
+
+### URL 패턴
+
+#### 1) 지하철 실시간 도착정보
+
+```text
+http://swopenAPI.seoul.go.kr/api/subway/{KEY}/json/realtimeStationArrival/{START_INDEX}/{END_INDEX}/{stationName}
+```
+
+#### 2) 따릉이 이용정보(월별)
+
+```text
+http://openapi.seoul.go.kr:8088/{KEY}/json/tbCycleRentUseMonthInfo/{START_INDEX}/{END_INDEX}/{RENT_NM}
+```
+
+## 지원 데이터셋
+
+### 1. `subway_realtime_arrival`
+
+- 서비스명: `realtimeStationArrival`
+- 필수 경로 파라미터: `stationName`
+- 예시 값: `"강남"`
+
+### 2. `bike_rent_month`
+
+- 서비스명: `tbCycleRentUseMonthInfo`
+- 필수 경로 파라미터: `RENT_NM`
+- 예시 값: `"202401"`
+
+## 에러 코드 매핑
+
+| 코드 | 의미 | KPubData 예외 |
+|---|---|---|
+| `INFO-000` | 정상 처리 | 예외 없음 |
+| `INFO-100` | 인증키 오류 | `AuthError` |
+| `INFO-200` | 데이터 없음 | 빈 `RecordBatch` 반환 |
+| `INFO-300` | 인증키 권한 없음 | `AuthError` |
+| `INFO-400` | HTTP/요청 오류 | `InvalidRequestError` |
+| `INFO-500` | 서버 오류 | `ProviderResponseError` |
+| `ERROR-300` | 필수값 누락 | `InvalidRequestError` |
+| `ERROR-301` | 서비스명 오류 | `InvalidRequestError` |
+| `ERROR-310` | 서비스 미존재 | `InvalidRequestError` |
+| `ERROR-336` | 페이지 인덱스 오류 | `InvalidRequestError` |
+| `ERROR-500` | 일반 서버 오류 | `ProviderResponseError` |
+| `ERROR-600` | 일반 서버 오류 | `ProviderResponseError` |
+| `ERROR-601` | 일반 서버 오류 | `ProviderResponseError` |
+
+알 수 없는 코드도 `ProviderResponseError`로 매핑합니다.
+
+## 사용 예제
+
+### 지하철 실시간 도착정보 `list()`
+
+```python
+from kpubdata import Client
+
+client = Client.from_env()
+ds = client.dataset("seoul.subway_realtime_arrival")
+
+result = ds.list(stationName="강남", page_size=5)
+
+for item in result.items:
+    print(item["statnNm"], item["arvlMsg2"], item["arvlMsg3"])
+```
+
+### 지하철 실시간 도착정보 `call_raw()`
+
+```python
+raw = ds.call_raw("realtimeStationArrival", stationName="강남", page_no=1, page_size=5)
+print(raw["realtimeStationArrival"]["RESULT"])
+```
+
+### 따릉이 월별 이용정보 `list()`
+
+```python
+from kpubdata import Client
+
+client = Client.from_env()
+ds = client.dataset("seoul.bike_rent_month")
+
+result = ds.list(RENT_NM="202401", page=1, page_size=10)
+
+for item in result.items:
+    print(item["RENT_NO"], item["RENT_USE_CNT"], item["MOVE_METER"])
+```
+
+### 따릉이 월별 이용정보 `call_raw()`
+
+```python
+raw = ds.call_raw("tbCycleRentUseMonthInfo", RENT_NM="202401", page_no=1, page_size=10)
+print(raw["tbCycleRentUseMonthInfo"]["list_total_count"])
+```
+
+## 참고
+
+- `list()`는 한 번에 한 페이지만 반환하며, 다음 페이지가 있으면 `RecordBatch.next_page`가 채워집니다.
+- 서울 Open API의 서비스명과 경로 파라미터 이름은 provider-specific semantics이므로 그대로 유지합니다.
+- 실API 검증은 서울 인증키 확보 후 후속 PR에서 `SUPPORTED_DATA.md`의 검증 상태를 갱신할 예정입니다.

--- a/src/kpubdata/client.py
+++ b/src/kpubdata/client.py
@@ -22,6 +22,7 @@ logger = logging.getLogger("kpubdata.client")
 _BUILTIN_PROVIDERS: tuple[tuple[str, str, str], ...] = (
     ("datago", "kpubdata.providers.datago", "DataGoAdapter"),
     ("bok", "kpubdata.providers.bok", "BokAdapter"),
+    ("seoul", "kpubdata.providers.seoul", "SeoulAdapter"),
     ("kosis", "kpubdata.providers.kosis", "KosisAdapter"),
     ("lofin", "kpubdata.providers.lofin", "LofinAdapter"),
     ("localdata", "kpubdata.providers.localdata.adapter", "LocaldataAdapter"),

--- a/src/kpubdata/core/capability.py
+++ b/src/kpubdata/core/capability.py
@@ -19,7 +19,7 @@ def _dataclass(
     frozen: bool = False,
 ) -> Callable[[type[_T]], type[_T]]:
     def _decorate(cls: type[_T]) -> type[_T]:
-        return _stdlib_dataclass(slots=slots, frozen=frozen)(cls)  # pyright: ignore[reportCallIssue]
+        return _stdlib_dataclass(slots=slots, frozen=frozen)(cls)
 
     return _decorate
 
@@ -38,6 +38,7 @@ class PaginationMode(str, Enum):
     """How a dataset supports pagination."""
 
     OFFSET = "offset"
+    INDEX = "index"
     CURSOR = "cursor"
     NONE = "none"
 

--- a/src/kpubdata/providers/seoul/__init__.py
+++ b/src/kpubdata/providers/seoul/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import SeoulAdapter
+
+__all__ = ["SeoulAdapter"]

--- a/src/kpubdata/providers/seoul/adapter.py
+++ b/src/kpubdata/providers/seoul/adapter.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import NoReturn, cast
+from urllib.parse import quote
+
+from kpubdata.config import KPubDataConfig
+from kpubdata.core.models import DatasetRef, Query, RecordBatch, SchemaDescriptor
+from kpubdata.exceptions import (
+    AuthError,
+    DatasetNotFoundError,
+    InvalidRequestError,
+    ParseError,
+    ProviderResponseError,
+)
+from kpubdata.providers._common import build_schema_from_metadata, coerce_int, load_catalogue
+from kpubdata.transport.decode import decode_json
+from kpubdata.transport.http import HttpTransport, TransportConfig
+
+_SUCCESS_CODE = "INFO-000"
+_EMPTY_CODE = "INFO-200"
+
+
+class SeoulAdapter:
+    def __init__(
+        self,
+        *,
+        config: KPubDataConfig | None = None,
+        transport: HttpTransport | None = None,
+        catalogue: Sequence[DatasetRef] | None = None,
+    ) -> None:
+        self._config: KPubDataConfig = config or KPubDataConfig()
+        transport_config = TransportConfig(
+            timeout=self._config.timeout,
+            max_retries=self._config.max_retries,
+        )
+        self._transport: HttpTransport = transport or HttpTransport(transport_config)
+
+        datasets = tuple(catalogue) if catalogue is not None else self._load_default_catalogue()
+        self._datasets: tuple[DatasetRef, ...] = datasets
+        self._datasets_by_key: dict[str, DatasetRef] = {
+            dataset.dataset_key: dataset for dataset in self._datasets
+        }
+
+    @property
+    def name(self) -> str:
+        return "seoul"
+
+    def list_datasets(self) -> list[DatasetRef]:
+        return list(self._datasets)
+
+    def search_datasets(self, text: str) -> list[DatasetRef]:
+        needle = text.casefold()
+        return [
+            dataset
+            for dataset in self._datasets
+            if needle in dataset.id.casefold() or needle in dataset.name.casefold()
+        ]
+
+    def get_dataset(self, dataset_key: str) -> DatasetRef:
+        dataset = self._datasets_by_key.get(dataset_key)
+        if dataset is not None:
+            return dataset
+
+        raise DatasetNotFoundError(
+            f"Dataset not found: seoul.{dataset_key}",
+            provider="seoul",
+            dataset_id=f"seoul.{dataset_key}",
+        )
+
+    def query_records(self, dataset: DatasetRef, query: Query) -> RecordBatch:
+        page_no = query.page or 1
+        page_size = query.page_size or 100
+        self._validate_pagination(page_no, page_size, dataset.id)
+
+        path_params = self._require_path_params(dataset, query.filters)
+        start_index = (page_no - 1) * page_size + 1
+        end_index = page_no * page_size
+        url = self._build_request_url(
+            dataset,
+            operation=None,
+            start_index=start_index,
+            end_index=end_index,
+            path_params=path_params,
+        )
+
+        payload = self._request_and_decode(url, dataset.id)
+        service_name = self._service_name(dataset, operation=None)
+        body, items = self._validate_envelope(payload, service_name, dataset.id)
+        total_count = coerce_int(body.get("list_total_count"), 0)
+        next_page = page_no + 1 if total_count > 0 and end_index < total_count else None
+
+        return RecordBatch(
+            items=items,
+            dataset=dataset,
+            total_count=total_count if total_count > 0 else None,
+            next_page=next_page,
+            raw=payload,
+        )
+
+    def get_schema(self, dataset: DatasetRef) -> SchemaDescriptor | None:
+        return build_schema_from_metadata(dataset)
+
+    def call_raw(self, dataset: DatasetRef, operation: str, params: dict[str, object]) -> object:
+        page_no = self._int_param(params, "page_no", 1)
+        page_size = self._int_param(params, "page_size", 100)
+        self._validate_pagination(page_no, page_size, dataset.id)
+
+        start_index = self._int_param(params, "start_index", 0)
+        end_index = self._int_param(params, "end_index", 0)
+        if start_index <= 0 or end_index <= 0:
+            start_index = (page_no - 1) * page_size + 1
+            end_index = page_no * page_size
+
+        path_params = self._require_path_params(dataset, params)
+        url = self._build_request_url(
+            dataset,
+            operation=operation,
+            start_index=start_index,
+            end_index=end_index,
+            path_params=path_params,
+        )
+        payload = self._request_and_decode(url, dataset.id)
+        _ = self._validate_envelope(
+            payload, self._service_name(dataset, operation=operation), dataset.id
+        )
+        return payload
+
+    def _validate_pagination(self, page_no: int, page_size: int, dataset_id: str) -> None:
+        if page_no < 1:
+            raise InvalidRequestError(
+                "Seoul API page_no must be >= 1",
+                provider="seoul",
+                dataset_id=dataset_id,
+            )
+        if page_size < 1:
+            raise InvalidRequestError(
+                "Seoul API page_size must be >= 1",
+                provider="seoul",
+                dataset_id=dataset_id,
+            )
+        if page_size > 1000:
+            raise InvalidRequestError(
+                "Seoul API page_size must be <= 1000",
+                provider="seoul",
+                dataset_id=dataset_id,
+            )
+
+    def _require_api_key(self) -> str:
+        return self._config.require_provider_key("seoul")
+
+    def _build_request_url(
+        self,
+        dataset: DatasetRef,
+        *,
+        operation: str | None,
+        start_index: int,
+        end_index: int,
+        path_params: Mapping[str, str],
+    ) -> str:
+        base_url = self._require_dataset_metadata(dataset, "base_url")
+        service_name = self._service_name(dataset, operation=operation)
+        path_suffix = "/".join(quote(value, safe="") for value in path_params.values())
+        return (
+            f"{base_url}/{self._require_api_key()}/json/{service_name}/"
+            f"{start_index}/{end_index}/{path_suffix}"
+        )
+
+    def _service_name(self, dataset: DatasetRef, operation: str | None) -> str:
+        if operation is not None and operation:
+            return operation
+        return self._require_dataset_metadata(dataset, "default_operation")
+
+    def _request_and_decode(self, url: str, dataset_id: str) -> dict[str, object]:
+        response = self._transport.request("GET", url, dataset_id=dataset_id, provider="seoul")
+
+        try:
+            decoded: object = decode_json(response.content)
+        except ParseError as exc:
+            exc.provider = "seoul"
+            raise
+
+        if isinstance(decoded, dict):
+            return cast(dict[str, object], decoded)
+        raise ParseError(
+            "Decoded payload is not an object", provider="seoul", dataset_id=dataset_id
+        )
+
+    def _validate_envelope(
+        self,
+        payload: dict[str, object],
+        service_name: str,
+        dataset_id: str,
+    ) -> tuple[dict[str, object], list[dict[str, object]]]:
+        body_obj = payload.get(service_name)
+        if not isinstance(body_obj, dict):
+            raise ProviderResponseError(
+                f"Malformed response envelope: missing {service_name}",
+                provider="seoul",
+                dataset_id=dataset_id,
+            )
+
+        body = cast(dict[str, object], body_obj)
+        result_obj = body.get("RESULT")
+        if not isinstance(result_obj, dict):
+            raise ProviderResponseError(
+                "Malformed response envelope: missing RESULT",
+                provider="seoul",
+                dataset_id=dataset_id,
+            )
+
+        result = cast(dict[str, object], result_obj)
+        code_raw = result.get("CODE")
+        message_raw = result.get("MESSAGE")
+        code = code_raw if isinstance(code_raw, str) else "ERROR-UNKNOWN"
+        message = message_raw if isinstance(message_raw, str) else "Provider returned error"
+
+        if code == _SUCCESS_CODE:
+            return body, self._normalize_rows(body.get("row"))
+        if code == _EMPTY_CODE:
+            return body, []
+
+        self._raise_for_result_code(code, message, dataset_id)
+
+    def _raise_for_result_code(self, code: str, message: str, dataset_id: str) -> NoReturn:
+        if code in {"INFO-100", "INFO-300"}:
+            raise AuthError(message, provider="seoul", provider_code=code, dataset_id=dataset_id)
+        if code in {"INFO-400", "ERROR-300", "ERROR-301", "ERROR-310", "ERROR-336"}:
+            raise InvalidRequestError(
+                message,
+                provider="seoul",
+                provider_code=code,
+                dataset_id=dataset_id,
+            )
+        if code in {"INFO-500", "ERROR-500", "ERROR-600", "ERROR-601"}:
+            raise ProviderResponseError(
+                message,
+                provider="seoul",
+                provider_code=code,
+                dataset_id=dataset_id,
+            )
+        raise ProviderResponseError(
+            message,
+            provider="seoul",
+            provider_code=code,
+            dataset_id=dataset_id,
+        )
+
+    def _require_path_params(
+        self,
+        dataset: DatasetRef,
+        params: Mapping[str, object],
+    ) -> dict[str, str]:
+        resolved: dict[str, str] = {}
+        for param_name in self._required_path_param_names(dataset):
+            value = params.get(param_name)
+            if isinstance(value, str) and value:
+                resolved[param_name] = value
+                continue
+            raise InvalidRequestError(
+                f"Seoul API requires path parameter '{param_name}'",
+                provider="seoul",
+                dataset_id=dataset.id,
+            )
+        return resolved
+
+    def _required_path_param_names(self, dataset: DatasetRef) -> tuple[str, ...]:
+        raw = dataset.raw_metadata.get("required_path_params")
+        if not isinstance(raw, list):
+            raise ProviderResponseError(
+                "Dataset metadata missing required_path_params",
+                provider="seoul",
+                dataset_id=dataset.id,
+            )
+
+        names: list[str] = []
+        for value in cast(list[object], raw):
+            if isinstance(value, str) and value:
+                names.append(value)
+        if not names:
+            raise ProviderResponseError(
+                "Dataset metadata missing required_path_params",
+                provider="seoul",
+                dataset_id=dataset.id,
+            )
+        return tuple(names)
+
+    def _require_dataset_metadata(self, dataset: DatasetRef, key: str) -> str:
+        value = dataset.raw_metadata.get(key)
+        if isinstance(value, str) and value:
+            return value
+        raise ProviderResponseError(
+            f"Dataset metadata missing {key}",
+            provider="seoul",
+            dataset_id=dataset.id,
+        )
+
+    def _normalize_rows(self, rows: object) -> list[dict[str, object]]:
+        if rows is None:
+            return []
+        if isinstance(rows, list):
+            row_items = cast(list[object], rows)
+            return [cast(dict[str, object], item) for item in row_items if isinstance(item, dict)]
+        if isinstance(rows, dict):
+            return [cast(dict[str, object], rows)]
+        return []
+
+    @staticmethod
+    def _int_param(params: Mapping[str, object], key: str, default: int) -> int:
+        coerced = coerce_int(params.get(key), default)
+        return coerced if coerced > 0 else default
+
+    @staticmethod
+    def _load_default_catalogue() -> tuple[DatasetRef, ...]:
+        return load_catalogue("kpubdata.providers.seoul", "seoul")
+
+
+__all__ = ["SeoulAdapter"]

--- a/src/kpubdata/providers/seoul/catalogue.json
+++ b/src/kpubdata/providers/seoul/catalogue.json
@@ -1,0 +1,24 @@
+[
+  {
+    "dataset_key": "subway_realtime_arrival",
+    "name": "서울시 지하철 실시간 도착정보 (Subway Realtime Arrival)",
+    "base_url": "http://swopenAPI.seoul.go.kr/api/subway",
+    "default_operation": "realtimeStationArrival",
+    "representation": "api_json",
+    "description": "Real-time subway arrival information for Seoul Metro stations",
+    "operations": ["list", "raw"],
+    "query_support": {"pagination": "index", "max_page_size": 1000},
+    "required_path_params": ["stationName"]
+  },
+  {
+    "dataset_key": "bike_rent_month",
+    "name": "서울시 공공자전거 이용정보 월별 (Ttareungi Monthly)",
+    "base_url": "http://openapi.seoul.go.kr:8088",
+    "default_operation": "tbCycleRentUseMonthInfo",
+    "representation": "api_json",
+    "description": "Seoul public bicycle (Ttareungi) monthly usage statistics",
+    "operations": ["list", "raw"],
+    "query_support": {"pagination": "index", "max_page_size": 1000},
+    "required_path_params": ["RENT_NM"]
+  }
+]

--- a/tests/contract/test_seoul.py
+++ b/tests/contract/test_seoul.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from typing import Protocol, cast
+
+import pytest
+
+from kpubdata.config import KPubDataConfig
+from kpubdata.core.models import DatasetRef, Query
+from kpubdata.core.protocol import ProviderAdapter
+from kpubdata.transport.http import HttpTransport
+from tests.contract.provider_adapter import ProviderAdapterContract
+
+
+def _fixture_path(name: str) -> Path:
+    return Path(__file__).resolve().parents[1] / "fixtures" / "seoul" / name
+
+
+def _load_fixture_bytes(name: str) -> bytes:
+    return _fixture_path(name).read_bytes()
+
+
+class _FakeResponse:
+    def __init__(self, data: bytes, content_type: str = "application/json") -> None:
+        self.headers: dict[str, str] = {"content-type": content_type}
+        self.content: bytes = data
+        self.text: str = data.decode("utf-8")
+
+
+class _FixtureTransport:
+    def __init__(self, fixture_names: list[str]) -> None:
+        self._responses: list[_FakeResponse] = [
+            _FakeResponse(_load_fixture_bytes(name)) for name in fixture_names
+        ]
+        self.calls: list[dict[str, object]] = []
+
+    def request(self, method: str, url: str, **kwargs: object) -> _FakeResponse:
+        self.calls.append({"method": method, "url": url, **kwargs})
+        if not self._responses:
+            raise AssertionError("No fixture responses remaining")
+        return self._responses.pop(0)
+
+
+class _AdapterFactory(Protocol):
+    def __call__(
+        self,
+        *,
+        config: KPubDataConfig | None = None,
+        transport: HttpTransport | None = None,
+    ) -> ProviderAdapter: ...
+
+
+def _build_adapter(fixture_names: list[str]) -> ProviderAdapter:
+    transport = _FixtureTransport(fixture_names)
+    config = KPubDataConfig(provider_keys={"seoul": "test-key"})
+    adapter_module = import_module("kpubdata.providers.seoul.adapter")
+    adapter_class_obj = cast(object, adapter_module.SeoulAdapter)
+    if not isinstance(adapter_class_obj, type):
+        raise AssertionError("SeoulAdapter is not a class")
+    adapter_class = cast(_AdapterFactory, adapter_class_obj)
+    return adapter_class(
+        config=config,
+        transport=cast(HttpTransport, cast(object, transport)),
+    )
+
+
+class TestSeoulAdapterContract(ProviderAdapterContract):
+    @pytest.fixture()
+    def adapter(self) -> ProviderAdapter:
+        return _build_adapter(["subway_realtime_arrival_success.json"] * 5)
+
+    @pytest.fixture()
+    def valid_dataset_key(self) -> str:
+        return "subway_realtime_arrival"
+
+    @pytest.fixture()
+    def invalid_dataset_key(self) -> str:
+        return "nonexistent_dataset_key_xyz"
+
+    @pytest.fixture()
+    def sample_dataset(self, adapter: ProviderAdapter) -> DatasetRef:
+        return adapter.get_dataset("subway_realtime_arrival")
+
+    @pytest.fixture()
+    def sample_query(self) -> Query:
+        return Query(filters={"stationName": "강남"})
+
+    @pytest.fixture()
+    def raw_operation(self) -> tuple[str, dict[str, object]]:
+        return ("realtimeStationArrival", {"stationName": "강남", "page_no": 1, "page_size": 5})

--- a/tests/fixtures/seoul/bike_rent_month_success.json
+++ b/tests/fixtures/seoul/bike_rent_month_success.json
@@ -1,0 +1,38 @@
+{
+  "tbCycleRentUseMonthInfo": {
+    "list_total_count": 24,
+    "RESULT": {
+      "CODE": "INFO-000",
+      "MESSAGE": "정상 처리되었습니다"
+    },
+    "row": [
+      {
+        "RENT_DATE": "20240101",
+        "RENT_ID": "ST-001",
+        "RENT_NM": "202401",
+        "RENT_NO": "1001",
+        "RENT_USE_CNT": "154",
+        "MOVE_TIME": "3421",
+        "MOVE_METER": "12543"
+      },
+      {
+        "RENT_DATE": "20240101",
+        "RENT_ID": "ST-002",
+        "RENT_NM": "202401",
+        "RENT_NO": "1002",
+        "RENT_USE_CNT": "203",
+        "MOVE_TIME": "4120",
+        "MOVE_METER": "14789"
+      },
+      {
+        "RENT_DATE": "20240101",
+        "RENT_ID": "ST-003",
+        "RENT_NM": "202401",
+        "RENT_NO": "1003",
+        "RENT_USE_CNT": "98",
+        "MOVE_TIME": "2150",
+        "MOVE_METER": "8540"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/seoul/empty_response.json
+++ b/tests/fixtures/seoul/empty_response.json
@@ -1,0 +1,10 @@
+{
+  "realtimeStationArrival": {
+    "list_total_count": 0,
+    "RESULT": {
+      "CODE": "INFO-200",
+      "MESSAGE": "해당하는 데이터가 없습니다"
+    },
+    "row": []
+  }
+}

--- a/tests/fixtures/seoul/error_auth.json
+++ b/tests/fixtures/seoul/error_auth.json
@@ -1,0 +1,10 @@
+{
+  "realtimeStationArrival": {
+    "list_total_count": 0,
+    "RESULT": {
+      "CODE": "INFO-100",
+      "MESSAGE": "인증키가 유효하지 않습니다."
+    },
+    "row": []
+  }
+}

--- a/tests/fixtures/seoul/subway_realtime_arrival_success.json
+++ b/tests/fixtures/seoul/subway_realtime_arrival_success.json
@@ -1,0 +1,55 @@
+{
+  "realtimeStationArrival": {
+    "list_total_count": 2,
+    "RESULT": {
+      "CODE": "INFO-000",
+      "MESSAGE": "정상 처리되었습니다"
+    },
+    "row": [
+      {
+        "subwayId": "1002",
+        "updnLine": "상행",
+        "trainLineNm": "2호선 성수행 - 강남방면",
+        "subwayHeading": "내선",
+        "statnFid": "1002000222",
+        "statnTid": "1002000220",
+        "statnId": "1002000221",
+        "statnNm": "강남",
+        "ordkey": "01000강남0",
+        "subwayList": "1002",
+        "statnList": "1002000222,1002000221,1002000220",
+        "btrainSttus": "일반",
+        "barvlDt": "45",
+        "btrainNo": "2345",
+        "bstatnId": "1002000222",
+        "bstatnNm": "역삼",
+        "recptnDt": "2026-04-21 10:15:30.0",
+        "arvlMsg2": "강남 도착",
+        "arvlMsg3": "역삼",
+        "arvlCd": "1"
+      },
+      {
+        "subwayId": "1002",
+        "updnLine": "하행",
+        "trainLineNm": "2호선 잠실행 - 강남방면",
+        "subwayHeading": "외선",
+        "statnFid": "1002000220",
+        "statnTid": "1002000222",
+        "statnId": "1002000221",
+        "statnNm": "강남",
+        "ordkey": "02000강남0",
+        "subwayList": "1002",
+        "statnList": "1002000220,1002000221,1002000222",
+        "btrainSttus": "급행",
+        "barvlDt": "120",
+        "btrainNo": "2711",
+        "bstatnId": "1002000220",
+        "bstatnNm": "교대",
+        "recptnDt": "2026-04-21 10:15:31.0",
+        "arvlMsg2": "전역 출발",
+        "arvlMsg3": "교대",
+        "arvlCd": "4"
+      }
+    ]
+  }
+}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -59,6 +59,14 @@ def require_localdata_key() -> str:
 
 
 @pytest.fixture(scope="session")
+def require_seoul_key() -> str:
+    key = os.getenv("KPUBDATA_SEOUL_API_KEY", "")
+    if not key:
+        pytest.skip("KPUBDATA_SEOUL_API_KEY not set")
+    return key
+
+
+@pytest.fixture(scope="session")
 def live_client() -> Client:
     if not any(
         os.getenv(name, "")
@@ -68,6 +76,7 @@ def live_client() -> Client:
             "KPUBDATA_KOSIS_API_KEY",
             "KPUBDATA_LOFIN_API_KEY",
             "KPUBDATA_LOCALDATA_API_KEY",
+            "KPUBDATA_SEOUL_API_KEY",
         )
     ):
         pytest.skip("No API keys set")

--- a/tests/integration/test_seoul_live.py
+++ b/tests/integration/test_seoul_live.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from kpubdata.client import Client
+
+
+def _three_months_ago_kst_yyyymm() -> str:
+    now = datetime.now(ZoneInfo("Asia/Seoul"))
+    year = now.year
+    month = now.month - 3
+    while month <= 0:
+        month += 12
+        year -= 1
+    return f"{year:04d}{month:02d}"
+
+
+@pytest.mark.integration
+def test_seoul_subway_realtime_arrival(require_seoul_key: None, live_client: Client) -> None:
+    _ = require_seoul_key
+    ds = live_client.dataset("seoul.subway_realtime_arrival")
+
+    result = ds.call_raw("realtimeStationArrival", stationName="강남", page_no=1, page_size=5)
+
+    assert isinstance(result, dict)
+    assert "realtimeStationArrival" in result
+
+
+@pytest.mark.integration
+def test_seoul_bike_rent_month(require_seoul_key: None, live_client: Client) -> None:
+    _ = require_seoul_key
+    ds = live_client.dataset("seoul.bike_rent_month")
+
+    result = ds.call_raw(
+        "tbCycleRentUseMonthInfo",
+        RENT_NM=_three_months_ago_kst_yyyymm(),
+        page_no=1,
+        page_size=5,
+    )
+
+    assert isinstance(result, dict)
+    assert "tbCycleRentUseMonthInfo" in result

--- a/tests/unit/providers/seoul/test_adapter.py
+++ b/tests/unit/providers/seoul/test_adapter.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from kpubdata.config import KPubDataConfig
+from kpubdata.core.models import Query
+from kpubdata.exceptions import AuthError, InvalidRequestError, ProviderResponseError
+from kpubdata.providers.seoul.adapter import SeoulAdapter
+from kpubdata.transport.http import HttpTransport
+
+
+def _fixture_path(name: str) -> Path:
+    return Path(__file__).resolve().parents[3] / "fixtures" / "seoul" / name
+
+
+def _load_fixture(name: str) -> dict[str, object]:
+    return cast(dict[str, object], json.loads(_fixture_path(name).read_text(encoding="utf-8")))
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.headers: dict[str, str] = {"content-type": "application/json"}
+        self.text: str = json.dumps(payload, ensure_ascii=False)
+        self.content: bytes = self.text.encode("utf-8")
+
+
+class FakeTransport:
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self._responses: list[FakeResponse] = list(responses)
+        self.calls: list[dict[str, object]] = []
+
+    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, **kwargs})
+        if not self._responses:
+            raise AssertionError("No fixture responses remaining")
+        return self._responses.pop(0)
+
+
+def _build_adapter(
+    responses: list[FakeResponse],
+    *,
+    config: KPubDataConfig | None = None,
+) -> tuple[SeoulAdapter, FakeTransport]:
+    transport = FakeTransport(responses)
+    adapter = SeoulAdapter(
+        config=config or KPubDataConfig(provider_keys={"seoul": "test-seoul-key"}),
+        transport=cast(HttpTransport, cast(object, transport)),
+    )
+    return adapter, transport
+
+
+def test_query_records_builds_subway_url_with_path_key() -> None:
+    adapter, transport = _build_adapter(
+        [FakeResponse(_load_fixture("subway_realtime_arrival_success.json"))]
+    )
+    dataset = adapter.get_dataset("subway_realtime_arrival")
+
+    _ = adapter.query_records(dataset, Query(filters={"stationName": "강남"}))
+
+    assert transport.calls[0]["url"] == (
+        "http://swopenAPI.seoul.go.kr/api/subway/test-seoul-key/json/"
+        "realtimeStationArrival/1/100/%EA%B0%95%EB%82%A8"
+    )
+
+
+def test_query_records_builds_bike_url_with_path_key() -> None:
+    adapter, transport = _build_adapter(
+        [FakeResponse(_load_fixture("bike_rent_month_success.json"))]
+    )
+    dataset = adapter.get_dataset("bike_rent_month")
+
+    _ = adapter.query_records(dataset, Query(filters={"RENT_NM": "202401"}, page_size=10))
+
+    assert transport.calls[0]["url"] == (
+        "http://openapi.seoul.go.kr:8088/test-seoul-key/json/tbCycleRentUseMonthInfo/1/10/202401"
+    )
+
+
+def test_query_records_parses_successful_envelope() -> None:
+    adapter, _ = _build_adapter(
+        [FakeResponse(_load_fixture("subway_realtime_arrival_success.json"))]
+    )
+    dataset = adapter.get_dataset("subway_realtime_arrival")
+
+    batch = adapter.query_records(
+        dataset, Query(filters={"stationName": "강남"}, page=1, page_size=2)
+    )
+
+    assert len(batch.items) == 2
+    assert batch.items[0]["statnNm"] == "강남"
+    assert batch.total_count == 2
+    assert batch.next_page is None
+
+
+def test_info_100_raises_auth_error() -> None:
+    adapter, _ = _build_adapter([FakeResponse(_load_fixture("error_auth.json"))])
+    dataset = adapter.get_dataset("subway_realtime_arrival")
+
+    with pytest.raises(AuthError) as exc_info:
+        _ = adapter.query_records(dataset, Query(filters={"stationName": "강남"}))
+
+    assert exc_info.value.provider_code == "INFO-100"
+
+
+def test_info_200_returns_empty_record_batch() -> None:
+    adapter, _ = _build_adapter([FakeResponse(_load_fixture("empty_response.json"))])
+    dataset = adapter.get_dataset("subway_realtime_arrival")
+
+    batch = adapter.query_records(dataset, Query(filters={"stationName": "강남"}))
+
+    assert batch.items == []
+    assert batch.total_count is None
+    assert batch.next_page is None
+
+
+def test_call_raw_returns_raw_payload() -> None:
+    payload = _load_fixture("bike_rent_month_success.json")
+    adapter, _ = _build_adapter([FakeResponse(payload)])
+    dataset = adapter.get_dataset("bike_rent_month")
+
+    raw = adapter.call_raw(
+        dataset,
+        "tbCycleRentUseMonthInfo",
+        {"RENT_NM": "202401", "page_no": 1, "page_size": 5},
+    )
+
+    assert raw == payload
+
+
+def test_pagination_uses_index_window_in_url() -> None:
+    adapter, transport = _build_adapter(
+        [FakeResponse(_load_fixture("bike_rent_month_success.json"))]
+    )
+    dataset = adapter.get_dataset("bike_rent_month")
+
+    _ = adapter.query_records(dataset, Query(filters={"RENT_NM": "202401"}, page=2, page_size=10))
+
+    assert "/11/20/202401" in cast(str, transport.calls[0]["url"])
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_exception"),
+    [
+        ("INFO-300", AuthError),
+        ("INFO-400", InvalidRequestError),
+        ("INFO-500", ProviderResponseError),
+        ("ERROR-300", InvalidRequestError),
+        ("ERROR-336", InvalidRequestError),
+        ("ERROR-600", ProviderResponseError),
+        ("UNKNOWN-999", ProviderResponseError),
+    ],
+)
+def test_error_code_mapping_table(code: str, expected_exception: type[Exception]) -> None:
+    payload: dict[str, object] = {
+        "realtimeStationArrival": {
+            "list_total_count": 0,
+            "RESULT": {"CODE": code, "MESSAGE": f"error: {code}"},
+            "row": [],
+        }
+    }
+    adapter, _ = _build_adapter([FakeResponse(payload)])
+    dataset = adapter.get_dataset("subway_realtime_arrival")
+
+    with pytest.raises(expected_exception) as exc_info:
+        _ = adapter.query_records(dataset, Query(filters={"stationName": "강남"}))
+
+    provider_error = exc_info.value
+    assert getattr(provider_error, "provider_code", None) == code
+
+
+def test_config_from_env_injects_seoul_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KPUBDATA_SEOUL_API_KEY", "env-seoul-key")
+    adapter, transport = _build_adapter(
+        [FakeResponse(_load_fixture("subway_realtime_arrival_success.json"))],
+        config=KPubDataConfig.from_env(),
+    )
+    dataset = adapter.get_dataset("subway_realtime_arrival")
+
+    _ = adapter.query_records(dataset, Query(filters={"stationName": "강남"}))
+
+    assert "/env-seoul-key/json/" in cast(str, transport.calls[0]["url"])
+
+
+def test_page_size_over_1000_raises_invalid_request() -> None:
+    adapter, _ = _build_adapter([])
+    dataset = adapter.get_dataset("bike_rent_month")
+
+    with pytest.raises(InvalidRequestError, match="page_size must be <= 1000"):
+        _ = adapter.query_records(dataset, Query(filters={"RENT_NM": "202401"}, page_size=1001))


### PR DESCRIPTION
## Summary
- 서울 열린데이터광장 `seoul` provider를 추가하고 `subway_realtime_arrival`, `bike_rent_month` 두 데이터셋을 카탈로그/클라이언트/문서에 등록했습니다.
- 서울 Open API의 경로 기반 인증키, 서비스별 top-level envelope, `INFO-*`/`ERROR-*` 결과 코드 매핑, start/end index 페이지네이션을 전용 adapter에 격리해 구현했습니다.
- fixture/unit/contract/live-gated integration 테스트와 `SUPPORTED_DATA.md`를 함께 추가했으며, 실API 검증 상태는 서울 인증키 확보 후 후속 PR에서 갱신할 예정입니다.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv run pytest`
- `uv run python -m build`