### PR TITLE
fix: source __version__ from importlib.metadata (#127)

### DIFF
--- a/src/kpubdata/__init__.py
+++ b/src/kpubdata/__init__.py
@@ -49,4 +49,6 @@ __all__ = [
     "ProviderNotRegisteredError",
 ]
 
-__version__ = "0.2.3"
+from importlib.metadata import version as _pkg_version
+
+__version__: str = _pkg_version("kpubdata")

--- a/tests/unit/core/test_version.py
+++ b/tests/unit/core/test_version.py
@@ -1,0 +1,10 @@
+"""Regression test: kpubdata.__version__ must track package metadata."""
+
+from importlib.metadata import version
+
+import kpubdata
+
+
+def test_version_matches_metadata() -> None:
+    """Ensure __version__ equals importlib.metadata version (issue #127)."""
+    assert kpubdata.__version__ == version("kpubdata")


### PR DESCRIPTION
## Summary
- Replace hardcoded `__version__ = "0.2.3"` with `importlib.metadata.version("kpubdata")`
- Add regression test ensuring `__version__` always matches package metadata

Fixes #127