### PR TITLE
[ #128 ] data.go.kr 활용신청 requirement 문서화 및 403 메시지 개선

### DIFF
--- a/docs/providers/datago.md
+++ b/docs/providers/datago.md
@@ -35,7 +35,7 @@
 
 ### 3단계: 승인 대기
 
-- **자동 승인**: 기상청, 한국환경공단 등 대부분의 API는 신청 즉시 자동 승인됩니다.
+- **자동 승인**: 대부분의 API는 활용신청 후 약 1~5분 안에 자동 승인됩니다.
 - **심의 승인**: 국토교통부 아파트매매 실거래가 등 일부 API는 담당 기관의 심의 후 승인까지 1~2일이 소요될 수 있습니다.
 
 ### 4단계: 인증키 확인
@@ -52,16 +52,22 @@
 export KPUBDATA_DATAGO_API_KEY="발급받은-일반-인증키"
 ```
 
-### 6단계: 키 활성화 대기
+## API별 활용신청(활성화) requirement
 
-**중요: API 키는 발급 직후 바로 사용할 수 없습니다.**
+data.go.kr은 **계정용 공통 인증키 1개만 있으면 끝나는 구조가 아닙니다.** 호출하려는 Open API마다 상세 페이지에서 별도로 **활용신청**을 해야 합니다.
 
-- 발급 후 **1~2시간**의 활성화 대기 시간이 필요합니다.
-- 이 시간 동안 공공데이터포털 시스템이 각 API 제공기관의 서버와 인증키를 동기화합니다.
-- 동기화 완료 전에는 `SERVICE_KEY_IS_NOT_REGISTERED_ERROR` 또는 `401 Unauthorized` 에러가 발생합니다.
-- 동기화 시간은 제공기관에 따라 다를 수 있으며, 드물게 2시간 이상 걸리는 경우도 있습니다.
+- 같은 `KPUBDATA_DATAGO_API_KEY`를 쓰더라도 API별 활성화 상태는 서로 다를 수 있습니다.
+- 활용신청 후 대부분의 API는 약 **1~5분 안에 자동 승인/활성화**됩니다.
+- 활성화 전에는 KPubData 호출이 **HTTP 403**으로 실패할 수 있습니다.
+- 이 경우 해당 데이터셋의 data.go.kr 상세 페이지로 가서 **"활용신청"** 버튼을 눌렀는지 먼저 확인하세요.
 
-### 7단계: 활성화 확인
+예시:
+
+- `datago.village_fcst`를 쓰려면 단기예보 API 페이지에서 활용신청 필요
+- `datago.air_quality`를 쓰려면 대기오염정보 API 페이지에서 활용신청 필요
+- 둘은 같은 포털/같은 키를 써도 **각각 따로** 활성화해야 함
+
+### 6단계: 활성화 확인
 
 키가 활성화되었는지 확인하려면 다음과 같이 테스트합니다:
 
@@ -70,7 +76,7 @@ export KPUBDATA_DATAGO_API_KEY="발급받은-일반-인증키"
 curl "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=YOUR_KEY&dataType=json&numOfRows=1&pageNo=1&base_date=20250401&base_time=0500&nx=55&ny=127"
 ```
 
-정상 응답이 오면 활성화가 완료된 것입니다. `SERVICE_KEY_IS_NOT_REGISTERED_ERROR` 에러가 나오면 조금 더 기다려야 합니다.
+정상 응답이 오면 활성화가 완료된 것입니다. `403 Forbidden`, `SERVICE_KEY_IS_NOT_REGISTERED_ERROR`, 또는 인증 관련 오류가 나오면 활용신청 여부와 승인 대기 시간을 다시 확인하세요.
 
 ## KPubData에서 신청해야 할 API 목록
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -117,6 +117,12 @@ ProviderResponseError: BOK ECOS returned error
 ```
 → 날짜를 `"20240101"` 대신 `"202401"` (YYYYMM) 형식으로 입력했는지 확인하세요.
 
+### "data.go.kr에서 403이 나옵니다"
+```
+AuthError: data.go.kr returned 403...
+```
+→ data.go.kr은 공통 인증키만으로는 부족하고 **API별 활용신청**이 필요합니다. 사용하려는 API 상세 페이지에서 "활용신청"을 눌렀는지 확인하세요. 대부분 1~5분 안에 자동 승인되지만 일부 API는 더 오래 걸릴 수 있습니다.
+
 ## Step 7: 다른 데이터도 조회해보기
 
 ### 사용 가능한 전체 데이터셋 목록 보기
@@ -145,6 +151,8 @@ kosis.population_migration — 시도별 이동자수 (Population Migration)
 ### 다른 Provider 사용하려면
 - 공공데이터포털(datago): [datago API 키 발급 가이드](./providers/datago.md)
 - 통계청 KOSIS: [KOSIS API 키 발급 가이드](./providers/kosis.md)
+
+> 참고: `datago`는 인증키 발급 후에도 **데이터셋별 활용신청**이 필요합니다. 활용신청 전에는 403이 발생할 수 있습니다.
 
 ## Step 8: 전체 페이지 자동 조회
 

--- a/src/kpubdata/providers/datago/adapter.py
+++ b/src/kpubdata/providers/datago/adapter.py
@@ -7,6 +7,8 @@ from collections.abc import Mapping, Sequence
 from typing import NoReturn, cast
 from urllib.parse import urlparse
 
+import httpx
+
 from kpubdata.config import KPubDataConfig
 from kpubdata.core.models import (
     DatasetRef,
@@ -22,12 +24,19 @@ from kpubdata.exceptions import (
     ProviderResponseError,
     RateLimitError,
     ServiceUnavailableError,
+    TransportError,
 )
 from kpubdata.providers._common import build_schema_from_metadata, coerce_int, load_catalogue
 from kpubdata.transport.decode import decode_json, decode_xml, detect_content_type
 from kpubdata.transport.http import HttpTransport, TransportConfig
 
 logger = logging.getLogger("kpubdata.provider.datago")
+
+_DATAGO_403_HINT = (
+    "data.go.kr returned 403. This usually means the specific API has not been activated "
+    "(활용신청) for your key. Visit the dataset's page on https://www.data.go.kr and "
+    "click '활용신청'. Approval is usually automatic and becomes active within a few minutes."
+)
 
 
 def _is_success_code(code: str) -> bool:
@@ -362,13 +371,23 @@ class DataGoAdapter:
         self, url: str, params: Mapping[str, object], dataset_id: str = ""
     ) -> dict[str, object]:
         string_params = {key: str(value) for key, value in params.items()}
-        response = self._transport.request(
-            "GET",
-            url,
-            params=string_params,
-            dataset_id=dataset_id,
-            provider="datago",
-        )
+        try:
+            response = self._transport.request(
+                "GET",
+                url,
+                params=string_params,
+                dataset_id=dataset_id,
+                provider="datago",
+            )
+        except TransportError as exc:
+            if self._is_http_403(exc):
+                raise AuthError(
+                    _DATAGO_403_HINT,
+                    provider="datago",
+                    dataset_id=dataset_id or None,
+                    status_code=403,
+                ) from exc
+            raise
 
         try:
             content_type = detect_content_type(response)
@@ -393,6 +412,11 @@ class DataGoAdapter:
             extra={"dataset_id": dataset_id},
         )
         raise ParseError("Decoded payload is not an object", provider="datago")
+
+    @staticmethod
+    def _is_http_403(exc: TransportError) -> bool:
+        cause = exc.__cause__
+        return isinstance(cause, httpx.HTTPStatusError) and cause.response.status_code == 403
 
     def _validate_envelope(
         self, payload: dict[str, object], dataset: DatasetRef | None = None

--- a/tests/unit/providers/datago/test_adapter.py
+++ b/tests/unit/providers/datago/test_adapter.py
@@ -5,6 +5,7 @@ import logging
 from types import MappingProxyType
 from typing import Protocol, cast
 
+import httpx
 import pytest
 
 from kpubdata.config import KPubDataConfig
@@ -17,6 +18,7 @@ from kpubdata.exceptions import (
     InvalidRequestError,
     RateLimitError,
     ServiceUnavailableError,
+    TransportError,
 )
 from kpubdata.providers.datago.adapter import DataGoAdapter
 from kpubdata.transport.http import HttpTransport
@@ -352,6 +354,36 @@ class TestDataGoAdapterQueryRecords:
 
         with pytest.raises(ServiceUnavailableError):
             _ = adapter.query_records(dataset, Query())
+
+    def test_query_records_http_403_wraps_with_activation_hint(self) -> None:
+        request = httpx.Request("GET", "https://apis.data.go.kr/test")
+        response = httpx.Response(403, request=request)
+        status_error = httpx.HTTPStatusError(
+            "Client error '403 Forbidden' for url 'https://apis.data.go.kr/test'",
+            request=request,
+            response=response,
+        )
+
+        class ForbiddenTransport:
+            def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+                del method, url, kwargs
+                raise TransportError(
+                    "HTTP status error 403 for GET https://apis.data.go.kr/test"
+                ) from status_error
+
+        adapter = DataGoAdapter(
+            config=KPubDataConfig(provider_keys={"datago": "test-key"}),
+            transport=cast(HttpTransport, cast(object, ForbiddenTransport())),
+        )
+        dataset = adapter.get_dataset("village_fcst")
+
+        with pytest.raises(AuthError) as excinfo:
+            _ = adapter.query_records(dataset, Query())
+
+        assert "활용신청" in str(excinfo.value)
+        assert "https://www.data.go.kr" in str(excinfo.value)
+        assert excinfo.value.status_code == 403
+        assert excinfo.value.dataset_id == dataset.id
 
     def test_query_records_accepts_three_digit_success_code_000(self) -> None:
         payload = {


### PR DESCRIPTION
## Summary
- datago adapter now wraps HTTP 403 responses with an AuthError that explains the per-API 활용신청 requirement on data.go.kr
- added unit coverage for the datago-specific 403 guidance and documented the activation flow in the datago provider guide and quickstart
- ran full quality gates: ruff, format check, mypy, pytest, and build

## Testing
- uv sync --extra dev
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy src
- uv run pytest
- uv run python -m build