### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-23
+
+### Fixed
+- Source `__version__` from `importlib.metadata` instead of hardcoded string (#127)
+- Add 활용신청 (activation request) hint to datago 403 `AuthError` and document API key activation requirement (#128)
+- Add required parameters to metro integration tests (#140)
+
 ## [0.3.0] - 2026-04-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kpubdata"
-version = "0.3.0"
+version = "0.3.1"
 description = "Dialect-inspired Python access framework for Korean public data"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -462,7 +462,7 @@ wheels = [
 
 [[package]]
 name = "kpubdata"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bump version to 0.3.1
- Add CHANGELOG entry for three bug fixes since v0.3.0

### Included fixes
- #127: Source `__version__` from `importlib.metadata`
- #128: Add 활용신청 hint to datago 403 `AuthError` + document activation requirement
- #140: Add required parameters to metro integration tests

### Quality gates
- ✅ ruff check / format
- ✅ mypy
- ✅ pytest (705 passed, 1 skipped)
- ✅ python -m build (kpubdata-0.3.1)