### PR TITLE
docs: realign roadmap around core/plugin/provider axes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,41 +1,95 @@
 # Roadmap — KPubData
 
-## v0.1
+> kpubdata는 **한국 공공데이터 접근 코어 프레임워크**에 집중합니다.
+> MCP, HTTP API 등 서비스 레이어는 본체에 포함하지 않으며, 필요 시 별도 레포(`kpubdata-mcp` 등)로 분리합니다.
+
+## 개발 3축
+
+| 축 | 설명 | 대표 이슈 |
+| :--- | :--- | :--- |
+| **Core** | 핵심 계약(contract), 스키마, 메타데이터, discovery 안정화 | #55, #57, #63 |
+| **Plugin Ecosystem** | entry-point plugin discovery, provider scaffolding 도구 | #112, #61 |
+| **Provider Adapters** | 기관별 어댑터 확장 (datago, localdata, semas, bok, ...) | #87-#94, #161-#168 |
+
+---
+
+## v0.1 ✅
 
 Foundation release.
 
 - finalize core contracts
 - implement transport skeleton
-- implement 3 distinct adapters
+- implement 3 distinct adapters (datago, bok, kosis)
 - support XML + JSON
 - support discovery + list + raw
 - ship docs and contract tests
 
-## v0.2
+## v0.2 ✅
 
 Stabilization and ergonomics.
 
 - dataset metadata enrichment
-- plugin loading
 - schema improvements
-- pandas adapter
-- more examples
+- pandas adapter (`to_pandas()`)
+- single-page pagination contract + `list_all()`
+- more examples and documentation
 
-## v0.3
+## v0.3 ✅
 
-Extensibility.
+Provider expansion.
 
-- thin MCP adapter
-- provider scaffolding tools
-- more provider coverage
-- more robust discovery
+- localdata provider: 195개 인허가 데이터셋
+- sgis provider: 행정구역 경계 GeoJSON
+- semas provider: 상가(상권)정보 17개 데이터셋
+- seoul provider: 지하철 실시간, 따릉이
+- lofin provider: 6개 재정 데이터셋
+- datago provider: 부동산 실거래가, 관광, 지하철 어댑터 추가
+
+## v0.4
+
+Core 안정화 + Plugin 생태계 + Provider 확장.
+
+### Core
+- dataset metadata enrichment (#55)
+- schema improvements (#57)
+- more robust discovery (#63)
+
+### Plugin Ecosystem
+- entry-point plugin discovery — 외부 provider 패키지 지원 (#112)
+- provider scaffolding tools (#61)
+
+### Provider Adapters
+- datago: 실시간 도로교통정보 (#87), 농수축산물 가격정보 (#88)
+- datago: 건축물대장 (#90), 사업자등록 상태조회 (#91)
+- datago: 의약품 안전사용정보 (#92), 지하철역별 승하차 인원 (#93)
+- datago: 기상청 중기예보 (#94)
+- datago: 워크넷 채용정보 (#161), 긴급재난문자 (#162), 채권시세정보 (#163)
+- datago: NEIS 급식식단정보 (#164), 식품이력추적 (#165), 전국체육시설 (#166)
+- datago: 문화시설 (#167), 환경소음 측정망 (#168)
+
+### Documentation & Testing
+- 실제 API 호출 기반 integration test 추가 (#80)
+- more examples and documentation (#59)
 
 ## v1.0 criteria
 
 - public API feels stable
-- adapter contract proven across multiple provider families
+- adapter contract proven across multiple provider families (7+ providers)
+- plugin discovery로 외부 provider 패키지 등록 가능
 - docs/examples sufficient for external users
 - breakage policy and versioning discipline established
+
+---
+
+## 본체에 포함하지 않는 것
+
+아래 항목은 kpubdata 코어에 넣지 않습니다. 필요 시 product family 별도 레포로 분리합니다.
+
+| 항목 | 분리 대상 레포 | 상태 |
+| :--- | :--- | :--- |
+| MCP adapter | `kpubdata-mcp` | 미생성 (필요 시 분리) |
+| HTTP/REST API 서비스 | `kpubdata-api` | 미생성 (필요 시 분리) |
+| LLM tool schema / agent helper | `kpubdata-mcp` | 미생성 (필요 시 분리) |
 
 ---
 


### PR DESCRIPTION
## Summary
- v0.3에서 thin MCP adapter 제거 → 향후 `kpubdata-mcp` 레포로 분리
- v0.1~v0.3 실제 완료 내용 반영
- v0.4를 3축(Core / Plugin Ecosystem / Provider Adapters)으로 재구성
- 본체에 포함하지 않는 항목 명시 (MCP, HTTP API, LLM helper)

Closes #60