### PR TITLE
feat(config): data.go.kr 프로바이더 API 키 통합 (datago)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kpubdata"
-version = "0.3.1"
+version = "0.4.0"
 description = "Dialect-inspired Python access framework for Korean public data"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/kpubdata/config.py
+++ b/src/kpubdata/config.py
@@ -4,6 +4,9 @@ Key lookup order for provider keys:
 1. Explicit `provider_keys` dict passed to constructor
 2. Environment variable: KPUBDATA_{PROVIDER}_API_KEY (uppercased)
 3. Environment variable: {PROVIDER}_API_KEY (uppercased, fallback)
+
+data.go.kr providers (localdata, lofin, semas) all use the "datago" key.
+Set KPUBDATA_DATAGO_API_KEY once for all data.go.kr-based providers.
 """
 
 from __future__ import annotations

--- a/src/kpubdata/providers/localdata/adapter.py
+++ b/src/kpubdata/providers/localdata/adapter.py
@@ -160,7 +160,7 @@ class LocaldataAdapter:
         return payload
 
     def _require_api_key(self) -> str:
-        return self._config.require_provider_key("localdata")
+        return self._config.require_provider_key("datago")
 
     def _build_request_url(self, dataset: DatasetRef, operation: str | None = None) -> str:
         base_url_raw = dataset.raw_metadata.get("base_url")

--- a/src/kpubdata/providers/lofin/adapter.py
+++ b/src/kpubdata/providers/lofin/adapter.py
@@ -164,7 +164,7 @@ class LofinAdapter:
         return payload
 
     def _require_api_key(self) -> str:
-        return self._config.require_provider_key("lofin")
+        return self._config.require_provider_key("datago")
 
     def _build_request_url(
         self,

--- a/src/kpubdata/providers/semas/adapter.py
+++ b/src/kpubdata/providers/semas/adapter.py
@@ -164,7 +164,7 @@ class SemasAdapter:
         return payload
 
     def _require_api_key(self) -> str:
-        return self._config.require_provider_key("semas")
+        return self._config.require_provider_key("datago")
 
     def _build_request_url(self, dataset: DatasetRef, operation: str | None = None) -> str:
         base_url_raw = dataset.raw_metadata.get("base_url")

--- a/tests/unit/providers/localdata/test_adapter.py
+++ b/tests/unit/providers/localdata/test_adapter.py
@@ -48,7 +48,7 @@ def _build_adapter_with_transport(
 ) -> tuple[LocaldataAdapter, DatasetRef, FakeTransport]:
     transport = FakeTransport(responses)
     adapter = LocaldataAdapter(
-        config=KPubDataConfig(provider_keys={"localdata": "test-key"}),
+        config=KPubDataConfig(provider_keys={"datago": "test-key"}),
         transport=cast(HttpTransport, cast(object, transport)),
     )
     dataset = adapter.get_dataset("general_restaurant")
@@ -61,7 +61,7 @@ def _build_dataset_adapter_with_transport(
 ) -> tuple[LocaldataAdapter, DatasetRef, FakeTransport]:
     transport = FakeTransport(responses)
     adapter = LocaldataAdapter(
-        config=KPubDataConfig(provider_keys={"localdata": "test-key"}),
+        config=KPubDataConfig(provider_keys={"datago": "test-key"}),
         transport=cast(HttpTransport, cast(object, transport)),
     )
     dataset = adapter.get_dataset(dataset_key)
@@ -165,7 +165,7 @@ def test_rest_cafe_query_records_parses_success_fixture() -> None:
 
 
 def test_adapter_lists_all_datasets() -> None:
-    adapter = LocaldataAdapter(config=KPubDataConfig(provider_keys={"localdata": "test-key"}))
+    adapter = LocaldataAdapter(config=KPubDataConfig(provider_keys={"datago": "test-key"}))
 
     datasets = adapter.list_datasets()
 

--- a/tests/unit/providers/lofin/test_lofin_adapter.py
+++ b/tests/unit/providers/lofin/test_lofin_adapter.py
@@ -50,7 +50,7 @@ def _build_adapter_with_transport(
 ) -> tuple[LofinAdapter, DatasetRef, FakeTransport]:
     transport = FakeTransport(responses)
     adapter = LofinAdapter(
-        config=KPubDataConfig(provider_keys={"lofin": "test-key"}),
+        config=KPubDataConfig(provider_keys={"datago": "test-key"}),
         transport=cast(HttpTransport, cast(object, transport)),
     )
     dataset = adapter.get_dataset("expenditure_budget")

--- a/tests/unit/providers/semas/test_adapter.py
+++ b/tests/unit/providers/semas/test_adapter.py
@@ -47,7 +47,7 @@ def _build_adapter_with_transport(
 ) -> tuple[SemasAdapter, DatasetRef, FakeTransport]:
     transport = FakeTransport(responses)
     adapter = SemasAdapter(
-        config=KPubDataConfig(provider_keys={"semas": "test-key"}),
+        config=KPubDataConfig(provider_keys={"datago": "test-key"}),
         transport=cast(HttpTransport, cast(object, transport)),
     )
     dataset = adapter.get_dataset(dataset_key)
@@ -166,7 +166,7 @@ def test_query_records_raises_invalid_request_error() -> None:
 
 
 def test_adapter_lists_all_datasets() -> None:
-    adapter = SemasAdapter(config=KPubDataConfig(provider_keys={"semas": "test-key"}))
+    adapter = SemasAdapter(config=KPubDataConfig(provider_keys={"datago": "test-key"}))
 
     datasets = adapter.list_datasets()
 
@@ -193,7 +193,7 @@ def test_adapter_lists_all_datasets() -> None:
 
 
 def test_get_schema_returns_catalogue_schema() -> None:
-    adapter = SemasAdapter(config=KPubDataConfig(provider_keys={"semas": "test-key"}))
+    adapter = SemasAdapter(config=KPubDataConfig(provider_keys={"datago": "test-key"}))
     dataset = adapter.get_dataset("store_one")
 
     schema = adapter.get_schema(dataset)


### PR DESCRIPTION
## 연관 이슈

- #175

## 변경 사항

data.go.kr 기반 프로바이더(localdata, lofin, semas)가 각각 별도 API 키를 요구하던 구조를 `datago` 단일 키로 통합합니다.

- `localdata`, `lofin`, `semas` adapter: `require_provider_key("localdata"|"lofin"|"semas")` → `require_provider_key("datago")`
- `config.py` docstring에 통합 정책 기록
- `pyproject.toml` 버전: `0.3.1` → `0.4.0` (breaking: 환경변수명 변경)
- 관련 단위 테스트 fixture 전수 수정

## 증거

- 594 unit tests passed (0 failed)
- 변경 파일 8개, 모두 기계적 치환 (adapter 3 + test 3 + config docstring + version)

## 재현 방법

```bash
cd /data/GitHub/kpubdata
git checkout feat/unify-datago-api-key
python -m pytest tests/ -q
```

## Breaking Change

환경변수 이름 변경:
- `KPUBDATA_LOCALDATA_API_KEY` → `KPUBDATA_DATAGO_API_KEY`
- `KPUBDATA_LOFIN_API_KEY` → `KPUBDATA_DATAGO_API_KEY`
- `KPUBDATA_SEMAS_API_KEY` → `KPUBDATA_DATAGO_API_KEY`

downstream(changup-hallae) 후속 PR에서 `.env`, `docker-compose.yml`, `config.py` 일괄 rename 예정.