### PR TITLE
fix(test): contract 테스트 provider_keys를 datago로 통합

### DIFF
--- a/tests/contract/test_localdata.py
+++ b/tests/contract/test_localdata.py
@@ -53,7 +53,7 @@ class _AdapterFactory(Protocol):
 
 def _build_adapter(fixture_names: list[str]) -> ProviderAdapter:
     transport = _FixtureTransport(fixture_names)
-    config = KPubDataConfig(provider_keys={"localdata": "test-key"})
+    config = KPubDataConfig(provider_keys={"datago": "test-key"})
     adapter_module = import_module("kpubdata.providers.localdata.adapter")
     adapter_class_obj = cast(object, adapter_module.LocaldataAdapter)
     if not isinstance(adapter_class_obj, type):

--- a/tests/contract/test_lofin.py
+++ b/tests/contract/test_lofin.py
@@ -54,7 +54,7 @@ class _AdapterFactory(Protocol):
 
 def _build_adapter(fixture_names: list[str]) -> ProviderAdapter:
     transport = _FixtureTransport(fixture_names)
-    config = KPubDataConfig(provider_keys={"lofin": "test-key"})
+    config = KPubDataConfig(provider_keys={"datago": "test-key"})
     adapter_module = import_module("kpubdata.providers.lofin.adapter")
     adapter_class_obj = cast(object, adapter_module.LofinAdapter)
     if not isinstance(adapter_class_obj, type):
@@ -94,7 +94,7 @@ class TestLofinAdapterContract(ProviderAdapterContract):
 
     def test_query_records_uses_lofin365_url_and_key_param(self) -> None:
         transport = _FixtureTransport(["success_single_page.json"])
-        config = KPubDataConfig(provider_keys={"lofin": "test-key"})
+        config = KPubDataConfig(provider_keys={"datago": "test-key"})
         adapter_module = import_module("kpubdata.providers.lofin.adapter")
         adapter_class_obj = cast(object, adapter_module.LofinAdapter)
         if not isinstance(adapter_class_obj, type):
@@ -114,7 +114,7 @@ class TestLofinAdapterContract(ProviderAdapterContract):
 
     def test_query_records_handles_top_level_auth_error(self) -> None:
         transport = _FixtureTransport(["error_auth.json"])
-        config = KPubDataConfig(provider_keys={"lofin": "invalid-key"})
+        config = KPubDataConfig(provider_keys={"datago": "invalid-key"})
         adapter_module = import_module("kpubdata.providers.lofin.adapter")
         adapter_class_obj = cast(object, adapter_module.LofinAdapter)
         if not isinstance(adapter_class_obj, type):
@@ -133,7 +133,7 @@ class TestLofinAdapterContract(ProviderAdapterContract):
 
     def test_query_records_fiacrv_dataset(self) -> None:
         transport = _FixtureTransport(["success_fiacrv.json"])
-        config = KPubDataConfig(provider_keys={"lofin": "test-key"})
+        config = KPubDataConfig(provider_keys={"datago": "test-key"})
         adapter_module = import_module("kpubdata.providers.lofin.adapter")
         adapter_class_obj = cast(object, adapter_module.LofinAdapter)
         if not isinstance(adapter_class_obj, type):

--- a/tests/contract/test_semas.py
+++ b/tests/contract/test_semas.py
@@ -52,7 +52,7 @@ class _AdapterFactory(Protocol):
 
 def _build_adapter(fixture_names: list[str]) -> ProviderAdapter:
     transport = _FixtureTransport(fixture_names)
-    config = KPubDataConfig(provider_keys={"semas": "test-key"})
+    config = KPubDataConfig(provider_keys={"datago": "test-key"})
     adapter_module = import_module("kpubdata.providers.semas.adapter")
     adapter_class_obj = cast(object, adapter_module.SemasAdapter)
     if not isinstance(adapter_class_obj, type):


### PR DESCRIPTION
## 연관 이슈

- #175 (v0.4.0 API 키 통합 후속)

## 변경 사항

PR #176에서 adapter의 `require_provider_key` 호출을 `"datago"`로 통합했으나, contract 테스트의 `KPubDataConfig(provider_keys={...})` fixture가 업데이트되지 않아 CI 실패.

- `test_localdata.py`: `{"localdata": "test-key"}` → `{"datago": "test-key"}`
- `test_lofin.py`: `{"lofin": "test-key"|"invalid-key"}` → `{"datago": ...}`
- `test_semas.py`: `{"semas": "test-key"}` → `{"datago": "test-key"}`

## 증거

730 passed, 73 deselected (0 failed)