### PR TITLE
refactor: extract builtin provider registry to providers/manifest.py

### DIFF
--- a/src/kpubdata/client.py
+++ b/src/kpubdata/client.py
@@ -14,20 +14,13 @@ from kpubdata.config import KPubDataConfig
 from kpubdata.core.dataset import Dataset
 from kpubdata.core.protocol import ProviderAdapter
 from kpubdata.registry import ProviderRegistry
+from kpubdata.providers.manifest import BUILTIN_PROVIDERS
 from kpubdata.transport.cache import ResponseCache
 from kpubdata.transport.http import HttpTransport, TransportConfig, TransportRequirements
 
 logger = logging.getLogger("kpubdata.client")
 
-_BUILTIN_PROVIDERS: tuple[tuple[str, str, str], ...] = (
-    ("datago", "kpubdata.providers.datago", "DataGoAdapter"),
-    ("bok", "kpubdata.providers.bok", "BokAdapter"),
-    ("seoul", "kpubdata.providers.seoul", "SeoulAdapter"),
-    ("kosis", "kpubdata.providers.kosis", "KosisAdapter"),
-    ("lofin", "kpubdata.providers.lofin", "LofinAdapter"),
-    ("localdata", "kpubdata.providers.localdata.adapter", "LocaldataAdapter"),
-    ("semas", "kpubdata.providers.semas.adapter", "SemasAdapter"),
-)
+_BUILTIN_PROVIDERS = BUILTIN_PROVIDERS
 
 
 class Client:

--- a/src/kpubdata/providers/manifest.py
+++ b/src/kpubdata/providers/manifest.py
@@ -1,0 +1,22 @@
+"""Built-in provider manifest — single source of truth for provider discovery.
+
+Each entry maps a provider name to its module path and adapter class name.
+The ``Client`` lazily imports these modules on first access so that unused
+providers impose zero import cost.
+
+To add a new built-in provider, append an entry here.  No other file needs
+to change for basic registration.
+"""
+
+from __future__ import annotations
+
+#: (provider_name, module_path, adapter_class_name)
+BUILTIN_PROVIDERS: tuple[tuple[str, str, str], ...] = (
+    ("datago", "kpubdata.providers.datago", "DataGoAdapter"),
+    ("bok", "kpubdata.providers.bok", "BokAdapter"),
+    ("seoul", "kpubdata.providers.seoul", "SeoulAdapter"),
+    ("kosis", "kpubdata.providers.kosis", "KosisAdapter"),
+    ("lofin", "kpubdata.providers.lofin", "LofinAdapter"),
+    ("localdata", "kpubdata.providers.localdata.adapter", "LocaldataAdapter"),
+    ("semas", "kpubdata.providers.semas.adapter", "SemasAdapter"),
+)


### PR DESCRIPTION
## Summary
- `_BUILTIN_PROVIDERS` 하드코딩 튜플을 `providers/manifest.py`로 추출
- 새 provider 추가 시 manifest 한 곳만 수정하면 됨 (single source of truth)
- 향후 entry_points 기반 plugin discovery로 전환할 수 있는 seam 확보
- `client._BUILTIN_PROVIDERS` re-export 유지 → 기존 테스트 monkeypatch 호환

## Changes
- **New**: `src/kpubdata/providers/manifest.py` — `BUILTIN_PROVIDERS` 튜플
- **Modified**: `src/kpubdata/client.py` — manifest에서 import + re-export

## Verification
- 729 passed, 1 skipped
- mypy clean
- ruff clean