### PR TITLE
feat(datago): add building registry datasets (Closes #179)

### DIFF
--- a/SUPPORTED_DATA.md
+++ b/SUPPORTED_DATA.md
@@ -35,6 +35,10 @@
 | 지원 | 실API 검증 | 2026-04-21 | 공공데이터포털 (`datago`) | `air_quality` | 대기오염정보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
 | 지원 | 실API 검증 | 2026-04-21 | 공공데이터포털 (`datago`) | `bus_arrival` | 경기도 버스도착정보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 경기도 v2 endpoint (`getBusArrivalListv2`) + 자체 envelope (`msgHeader`/`msgBody`) |
 | 지원 | 실API 검증 | 2026-04-21 | 공공데이터포털 (`datago`) | `hospital_info` | 병원정보서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
+| 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `building_title` | 건축물대장 표제부 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 건축물대장정보 서비스 v2 / `getBrTitleInfo` |
+| 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `building_recap_title` | 건축물대장 총괄표제부 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 건축물대장정보 서비스 v2 / `getBrRecapTitleInfo` |
+| 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `building_floor` | 건축물대장 층별개요 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 건축물대장정보 서비스 v2 / `getBrFlrOulnInfo` |
+| 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `building_area` | 건축물대장 전유공용면적 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 건축물대장정보 서비스 v2 / `getBrExposPubuseAreaInfo` |
 | 지원 | 실API 검증 | 2026-04-20 | 공공데이터포털 (`datago`) | `tour_kor_area` | 한국관광공사 지역기반 관광정보 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr/15101578](https://www.data.go.kr/data/15101578/openapi.do) | TourAPI KorService2 / `areaBasedList2` |
 | 지원 | 실API 검증 | 2026-04-20 | 공공데이터포털 (`datago`) | `tour_kor_location` | 한국관광공사 위치기반 관광정보 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr/15101578](https://www.data.go.kr/data/15101578/openapi.do) | TourAPI KorService2 / `locationBasedList2` |
 | 지원 | 실API 검증 | 2026-04-20 | 공공데이터포털 (`datago`) | `tour_kor_keyword` | 한국관광공사 키워드 검색 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr/15101578](https://www.data.go.kr/data/15101578/openapi.do) | TourAPI KorService2 / `searchKeyword2` |

--- a/plans/issue-179-building-registry.md
+++ b/plans/issue-179-building-registry.md
@@ -1,0 +1,37 @@
+# Building Registry Plan (Issue #179)
+
+## Scope
+- 기존 `datago` provider 카탈로그에 건축물대장 정보 서비스 v2 기반 데이터셋 4종을 추가한다.
+- 각 데이터셋(`building_title`, `building_recap_title`, `building_floor`, `building_area`)에 대해 fixture와 fixture 기반 unit test를 추가한다.
+- 지원 상태 문서 `SUPPORTED_DATA.md`를 동일 PR에서 갱신한다.
+- 기존 generic `DataGoAdapter`를 그대로 사용하고 provider-specific parsing 로직은 추가하지 않는다.
+
+## Touched modules
+- 구현
+  - `src/kpubdata/providers/datago/catalogue.json`
+- 테스트/fixture
+  - `tests/fixtures/datago/success_building_title.json`
+  - `tests/fixtures/datago/success_building_recap_title.json`
+  - `tests/fixtures/datago/success_building_floor.json`
+  - `tests/fixtures/datago/success_building_area.json`
+  - `tests/unit/providers/datago/test_fixtures.py`
+- 문서
+  - `SUPPORTED_DATA.md`
+
+## Risks
+- 건축물대장 API의 JSON 지원이 환경별로 다를 수 있어 fixture는 표준 datago envelope 기준으로 유지해야 한다.
+- 기존 카탈로그 정렬/형식을 깨뜨리면 unrelated dataset discovery 테스트에 영향이 갈 수 있다.
+- `SUPPORTED_DATA.md` 상태/검증 정의와 실제 테스트 수준이 어긋나지 않도록 `테스트 검증`으로만 표기해야 한다.
+
+## Validation steps
+1. 정적 검증
+   - `uv run ruff check .`
+   - `uv run ruff format --check .`
+   - `uv run mypy src`
+2. 테스트
+   - `uv run pytest -x -q`
+3. 패키징/추가 게이트
+   - `uv run python -m build`
+4. 완료 확인
+   - 새 데이터셋 4종이 `client.datasets.list()`에 노출되는 카탈로그 메타데이터 구조를 유지하는지 확인
+   - fixture test에서 `RecordBatch.items`와 `total_count`가 기대대로 파싱되는지 확인

--- a/src/kpubdata/providers/datago/catalogue.json
+++ b/src/kpubdata/providers/datago/catalogue.json
@@ -76,6 +76,66 @@
     }
   },
   {
+    "dataset_key": "building_title",
+    "name": "건축물대장 표제부 (Building Title Info)",
+    "base_url": "http://apis.data.go.kr/1613000/BldRgstService_v2",
+    "default_operation": "getBrTitleInfo",
+    "representation": "api_json",
+    "service_key_param": "serviceKey",
+    "format_param": "_type",
+    "description": "MOLIT building registry title info from building ledger",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000
+    }
+  },
+  {
+    "dataset_key": "building_recap_title",
+    "name": "건축물대장 총괄표제부 (Building Recap Title Info)",
+    "base_url": "http://apis.data.go.kr/1613000/BldRgstService_v2",
+    "default_operation": "getBrRecapTitleInfo",
+    "representation": "api_json",
+    "service_key_param": "serviceKey",
+    "format_param": "_type",
+    "description": "MOLIT building registry recap title info from building ledger",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000
+    }
+  },
+  {
+    "dataset_key": "building_floor",
+    "name": "건축물대장 층별개요 (Building Floor Outline)",
+    "base_url": "http://apis.data.go.kr/1613000/BldRgstService_v2",
+    "default_operation": "getBrFlrOulnInfo",
+    "representation": "api_json",
+    "service_key_param": "serviceKey",
+    "format_param": "_type",
+    "description": "MOLIT building registry floor outline info from building ledger",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000
+    }
+  },
+  {
+    "dataset_key": "building_area",
+    "name": "건축물대장 전유공용면적 (Building Area Info)",
+    "base_url": "http://apis.data.go.kr/1613000/BldRgstService_v2",
+    "default_operation": "getBrExposPubuseAreaInfo",
+    "representation": "api_json",
+    "service_key_param": "serviceKey",
+    "format_param": "_type",
+    "description": "MOLIT building registry exclusive/common area info from building ledger",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000
+    }
+  },
+  {
     "dataset_key": "apt_trade",
     "name": "아파트매매 실거래자료 (Apartment Trade)",
     "base_url": "http://apis.data.go.kr/1613000/RTMSDataSvcAptTradeDev",

--- a/tests/fixtures/datago/success_building_area.json
+++ b/tests/fixtures/datago/success_building_area.json
@@ -1,0 +1,29 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "00",
+      "resultMsg": "NORMAL SERVICE."
+    },
+    "body": {
+      "items": {
+        "item": [
+          {
+            "hoNm": "101호",
+            "flrNo": "1",
+            "area": "84.97",
+            "exposPubuseGbCdNm": "전유면적"
+          },
+          {
+            "hoNm": "공용복도",
+            "flrNo": "1",
+            "area": "32.14",
+            "exposPubuseGbCdNm": "공용면적"
+          }
+        ]
+      },
+      "numOfRows": 10,
+      "pageNo": 1,
+      "totalCount": 2
+    }
+  }
+}

--- a/tests/fixtures/datago/success_building_floor.json
+++ b/tests/fixtures/datago/success_building_floor.json
@@ -1,0 +1,31 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "00",
+      "resultMsg": "NORMAL SERVICE."
+    },
+    "body": {
+      "items": {
+        "item": [
+          {
+            "flrNo": "1",
+            "flrNoNm": "1층",
+            "area": "845.12",
+            "flrGbCdNm": "지상",
+            "mainPurpsCdNm": "근린생활시설"
+          },
+          {
+            "flrNo": "-1",
+            "flrNoNm": "지하1층",
+            "area": "1203.45",
+            "flrGbCdNm": "지하",
+            "mainPurpsCdNm": "주차장"
+          }
+        ]
+      },
+      "numOfRows": 10,
+      "pageNo": 1,
+      "totalCount": 2
+    }
+  }
+}

--- a/tests/fixtures/datago/success_building_recap_title.json
+++ b/tests/fixtures/datago/success_building_recap_title.json
@@ -1,0 +1,37 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "00",
+      "resultMsg": "NORMAL SERVICE."
+    },
+    "body": {
+      "items": {
+        "item": [
+          {
+            "bldNm": "디에이치 퍼스티어 아이파크",
+            "platPlc": "서울특별시 강남구 개포동 660-1",
+            "mainPurpsCdNm": "공동주택",
+            "grndFlrCnt": "35",
+            "ugrndFlrCnt": "4",
+            "totArea": "412345.11",
+            "vlRat": "249.87",
+            "bcRat": "18.23"
+          },
+          {
+            "bldNm": "센트럴파크 해링턴 스퀘어",
+            "platPlc": "인천광역시 연수구 송도동 29-13",
+            "mainPurpsCdNm": "업무시설",
+            "grndFlrCnt": "39",
+            "ugrndFlrCnt": "5",
+            "totArea": "287654.90",
+            "vlRat": "398.41",
+            "bcRat": "42.15"
+          }
+        ]
+      },
+      "numOfRows": 10,
+      "pageNo": 1,
+      "totalCount": 2
+    }
+  }
+}

--- a/tests/fixtures/datago/success_building_title.json
+++ b/tests/fixtures/datago/success_building_title.json
@@ -1,0 +1,39 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "00",
+      "resultMsg": "NORMAL SERVICE."
+    },
+    "body": {
+      "items": {
+        "item": [
+          {
+            "bldNm": "래미안 블레스티지",
+            "platPlc": "서울특별시 강남구 개포동 1280",
+            "mainPurpsCdNm": "공동주택",
+            "grndFlrCnt": "35",
+            "ugrndFlrCnt": "4",
+            "totArea": "198765.43",
+            "useAprDay": "20190215",
+            "sigunguCd": "11680",
+            "bjdongCd": "10300"
+          },
+          {
+            "bldNm": "마포자이 더 센트리지",
+            "platPlc": "서울특별시 마포구 염리동 488",
+            "mainPurpsCdNm": "공동주택",
+            "grndFlrCnt": "29",
+            "ugrndFlrCnt": "3",
+            "totArea": "154321.88",
+            "useAprDay": "20211130",
+            "sigunguCd": "11440",
+            "bjdongCd": "10900"
+          }
+        ]
+      },
+      "numOfRows": 10,
+      "pageNo": 1,
+      "totalCount": 2
+    }
+  }
+}

--- a/tests/unit/providers/datago/test_fixtures.py
+++ b/tests/unit/providers/datago/test_fixtures.py
@@ -334,3 +334,48 @@ def test_fixture_metro_path_parses() -> None:
     assert batch.items[0]["stationName"] == "서울역"
     assert "lineNum" in batch.items[0]
     assert batch.total_count == 3
+
+
+def test_fixture_building_title_parses() -> None:
+    adapter, dataset = _build_real_estate_adapter("success_building_title.json", "building_title")
+
+    batch = adapter.query_records(dataset, Query())
+
+    assert len(batch.items) == 2
+    assert "bldNm" in batch.items[0]
+    assert batch.total_count == 2
+
+
+def test_fixture_building_recap_title_parses() -> None:
+    adapter, dataset = _build_real_estate_adapter(
+        "success_building_recap_title.json", "building_recap_title"
+    )
+
+    batch = adapter.query_records(dataset, Query())
+
+    assert len(batch.items) == 2
+    assert "vlRat" in batch.items[0]
+    assert "bcRat" in batch.items[0]
+    assert batch.total_count == 2
+
+
+def test_fixture_building_floor_parses() -> None:
+    adapter, dataset = _build_real_estate_adapter("success_building_floor.json", "building_floor")
+
+    batch = adapter.query_records(dataset, Query())
+
+    assert len(batch.items) == 2
+    assert "flrNo" in batch.items[0]
+    assert "area" in batch.items[0]
+    assert batch.total_count == 2
+
+
+def test_fixture_building_area_parses() -> None:
+    adapter, dataset = _build_real_estate_adapter("success_building_area.json", "building_area")
+
+    batch = adapter.query_records(dataset, Query())
+
+    assert len(batch.items) == 2
+    assert "hoNm" in batch.items[0]
+    assert "exposPubuseGbCdNm" in batch.items[0]
+    assert batch.total_count == 2


### PR DESCRIPTION
## Summary
- datago 카탈로그에 건축물대장 v2 데이터셋 4종(`building_title`, `building_recap_title`, `building_floor`, `building_area`)을 추가했습니다.
- 각 데이터셋에 대해 fixture와 fixture 기반 unit test를 추가해 generic DataGoAdapter 파싱 경로를 검증했습니다.
- `SUPPORTED_DATA.md`에 4개 데이터셋을 `지원` / `테스트 검증` 상태로 반영했습니다.

## Validation
- `uv run pytest -x -q`
- `uv run mypy src`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m build`