### PR TITLE
feat: dataset metadata enrichment (description, tags, source_url) #55

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -52,6 +52,12 @@ client.datasets.search("지하철")
 client.dataset("molit.apartment_trades")
 ```
 
+Each `DatasetRef` returned by discovery exposes:
+- `id`, `provider`, `dataset_key`, `name`, `representation`, `operations`
+- `description`: human-readable summary (may be ``None``)
+- `tags`: categorization keywords as a tuple (e.g. ``("weather", "forecast")``)
+- `source_url`: link to original API documentation (may be ``None``)
+
 ## 4. Bound dataset operations
 
 ### List/query

--- a/CANONICAL_MODEL.md
+++ b/CANONICAL_MODEL.md
@@ -23,6 +23,9 @@ classDiagram
         +str provider
         +str dataset_key
         +str name
+        +str description
+        +tuple tags
+        +str source_url
         +Representation representation
         +frozenset[Capability] capabilities
     }
@@ -64,7 +67,7 @@ KPubData에서 사용하는 핵심 타입들을 일상적인 도서관 비유로
 
 ### 3.1 DatasetRef (도서 카드)
 - **비유**: 도서관의 **"도서 목록 카드"**와 같습니다. 책이 어느 서가에 있는지, 대출이 가능한지(지원하는 기능), 어떤 내용인지 알려줍니다.
-- **역할**: 이 데이터셋이 어디에 있고(Provider), 고유한 이름(ID)은 무엇인지, 어떤 형식(Representation)인지 정보를 담고 있습니다.
+- **역할**: 이 데이터셋이 어디에 있고(Provider), 고유한 이름(ID)은 무엇인지, 어떤 형식(Representation)인지 정보를 담고 있습니다. 또한 데이터셋에 대한 설명(description), 분류 태그(tags), 원본 문서 링크(source_url)를 포함할 수 있습니다.
 
 ### 3.2 Query (검색 조건)
 - **비유**: 도서관에서 책을 찾을 때 쓰는 **"검색 조건"**입니다. "2024년에 나온 소설 중 서울에서 발간된 것" 같은 조건이죠.
@@ -106,6 +109,9 @@ ref = DatasetRef(
     dataset_key="village_fcst",
     name="동네예보",
     representation=Representation.OPENAPI,
+    description="Korea Meteorological Administration short-range forecast",
+    tags=("weather", "forecast"),
+    source_url="https://www.data.go.kr",
     operations=frozenset([Operation.LIST])
 )
 
@@ -215,6 +221,9 @@ class DatasetRef:
     dataset_key: str
     name: str
     representation: Representation
+    description: str | None = None
+    tags: tuple[str, ...] = ()
+    source_url: str | None = None
     capabilities: frozenset[Capability] = frozenset()
     raw_metadata: dict[str, Any] = field(default_factory=dict)
 ```
@@ -223,6 +232,9 @@ Notes:
 
 - `id` is the stable bound identifier, e.g. `molit.apartment_trades`
 - `representation` matters because the same logical dataset may be offered in more than one form
+- `description` is a human-readable summary of what the dataset provides
+- `tags` are categorization keywords for discovery (e.g. `("weather", "forecast")`)
+- `source_url` links to the original API documentation or data portal page
 
 ### 3.4 Query
 

--- a/src/kpubdata/core/models.py
+++ b/src/kpubdata/core/models.py
@@ -45,6 +45,9 @@ class DatasetRef:
     """Canonical immutable reference to a provider dataset.
 
     Attributes:
+        description: Human-readable description of what this dataset provides.
+        tags: Categorization tags for discovery (e.g. ``("weather", "forecast")``).
+        source_url: URL to the original API documentation or data portal page.
         query_support: Structured list-query feature metadata, if known.
         raw_metadata: Provider-native discovery metadata for debugging.
     """
@@ -54,6 +57,9 @@ class DatasetRef:
     dataset_key: str
     name: str
     representation: Representation
+    description: str | None = None
+    tags: tuple[str, ...] = ()
+    source_url: str | None = None
     operations: frozenset[Operation] = frozenset()
     query_support: QuerySupport | None = None
     raw_metadata: MappingProxyType[str, object] = field(default_factory=_empty_proxy)

--- a/src/kpubdata/core/models.py
+++ b/src/kpubdata/core/models.py
@@ -57,12 +57,12 @@ class DatasetRef:
     dataset_key: str
     name: str
     representation: Representation
-    description: str | None = None
-    tags: tuple[str, ...] = ()
-    source_url: str | None = None
     operations: frozenset[Operation] = frozenset()
     query_support: QuerySupport | None = None
     raw_metadata: MappingProxyType[str, object] = field(default_factory=_empty_proxy)
+    description: str | None = None
+    tags: tuple[str, ...] = ()
+    source_url: str | None = None
 
     def supports(self, op: Operation) -> bool:
         """Return whether this dataset supports the requested operation."""

--- a/src/kpubdata/providers/_common.py
+++ b/src/kpubdata/providers/_common.py
@@ -17,6 +17,19 @@ from kpubdata.core.models import (
 from kpubdata.core.representation import Representation
 from kpubdata.exceptions import ConfigError
 
+_CATALOGUE_CANONICAL_KEYS = frozenset(
+    {
+        "dataset_key",
+        "name",
+        "representation",
+        "operations",
+        "query_support",
+        "description",
+        "tags",
+        "source_url",
+    }
+)
+
 
 def load_catalogue(package_name: str, provider: str) -> tuple[DatasetRef, ...]:
     """Load and parse a catalogue.json from a provider package."""
@@ -92,20 +105,8 @@ def build_dataset_ref(provider: str, entry: dict[str, object]) -> DatasetRef:
     source_url_raw = entry.get("source_url")
     source_url = source_url_raw if isinstance(source_url_raw, str) and source_url_raw else None
 
-    _CANONICAL_KEYS = frozenset(
-        {
-            "dataset_key",
-            "name",
-            "representation",
-            "operations",
-            "query_support",
-            "description",
-            "tags",
-            "source_url",
-        }
-    )
     raw_metadata = MappingProxyType(
-        {key: value for key, value in entry.items() if key not in _CANONICAL_KEYS}
+        {key: value for key, value in entry.items() if key not in _CATALOGUE_CANONICAL_KEYS}
     )
 
     return DatasetRef(

--- a/src/kpubdata/providers/_common.py
+++ b/src/kpubdata/providers/_common.py
@@ -81,12 +81,31 @@ def build_dataset_ref(provider: str, entry: dict[str, object]) -> DatasetRef:
 
     query_support = _parse_query_support(entry, provider)
 
-    raw_metadata = MappingProxyType(
+    description_raw = entry.get("description")
+    description = description_raw if isinstance(description_raw, str) and description_raw else None
+
+    tags_raw = entry.get("tags")
+    tags: tuple[str, ...] = ()
+    if isinstance(tags_raw, list):
+        tags = tuple(t for t in cast(list[object], tags_raw) if isinstance(t, str))
+
+    source_url_raw = entry.get("source_url")
+    source_url = source_url_raw if isinstance(source_url_raw, str) and source_url_raw else None
+
+    _CANONICAL_KEYS = frozenset(
         {
-            key: value
-            for key, value in entry.items()
-            if key not in ("dataset_key", "name", "representation", "operations", "query_support")
+            "dataset_key",
+            "name",
+            "representation",
+            "operations",
+            "query_support",
+            "description",
+            "tags",
+            "source_url",
         }
+    )
+    raw_metadata = MappingProxyType(
+        {key: value for key, value in entry.items() if key not in _CANONICAL_KEYS}
     )
 
     return DatasetRef(
@@ -95,6 +114,9 @@ def build_dataset_ref(provider: str, entry: dict[str, object]) -> DatasetRef:
         dataset_key=dataset_key,
         name=name,
         representation=representation,
+        description=description,
+        tags=tags,
+        source_url=source_url,
         operations=frozenset(operations),
         query_support=query_support,
         raw_metadata=raw_metadata,

--- a/src/kpubdata/providers/bok/catalogue.json
+++ b/src/kpubdata/providers/bok/catalogue.json
@@ -8,6 +8,8 @@
     "stat_code": "722Y001",
     "item_code1": "0101000",
     "description": "Bank of Korea base interest rate historical data",
+    "tags": ["finance", "interest-rate", "monetary-policy"],
+    "source_url": "https://ecos.bok.or.kr/api/StatisticSearch",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",

--- a/src/kpubdata/providers/datago/catalogue.json
+++ b/src/kpubdata/providers/datago/catalogue.json
@@ -8,6 +8,8 @@
     "service_key_param": "serviceKey",
     "format_param": "dataType",
     "description": "Korea Meteorological Administration short-range forecast",
+    "tags": ["weather", "forecast", "kma"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -23,6 +25,8 @@
     "service_key_param": "serviceKey",
     "format_param": "dataType",
     "description": "KMA ultra short-term observed weather conditions",
+    "tags": ["weather", "nowcast", "kma"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -38,6 +42,8 @@
     "service_key_param": "serviceKey",
     "format_param": "returnType",
     "description": "AirKorea real-time particulate matter and atmospheric pollution",
+    "tags": ["environment", "air-quality", "pollution"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -54,6 +60,8 @@
     "service_key_param": "serviceKey",
     "format_param": "_type",
     "description": "Gyeonggi-do real-time bus arrival information",
+    "tags": ["transportation", "bus", "realtime"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -69,6 +77,8 @@
     "service_key_param": "serviceKey",
     "format_param": "_type",
     "description": "Hospital basic information and medical institution lookup",
+    "tags": ["healthcare", "hospital", "medical"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -84,6 +94,8 @@
     "service_key_param": "serviceKey",
     "format_param": "_type",
     "description": "MOLIT building registry title info from building ledger",
+    "tags": ["real-estate", "building", "registry"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -99,6 +111,8 @@
     "service_key_param": "serviceKey",
     "format_param": "_type",
     "description": "MOLIT building registry recap title info from building ledger",
+    "tags": ["real-estate", "building", "registry"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -114,6 +128,8 @@
     "service_key_param": "serviceKey",
     "format_param": "_type",
     "description": "MOLIT building registry floor outline info from building ledger",
+    "tags": ["real-estate", "building", "registry"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -129,6 +145,8 @@
     "service_key_param": "serviceKey",
     "format_param": "_type",
     "description": "MOLIT building registry exclusive/common area info from building ledger",
+    "tags": ["real-estate", "building", "registry"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -144,6 +162,8 @@
     "service_key_param": "serviceKey",
     "format_param": "resultType",
     "description": "MOLIT apartment trade real transaction data",
+    "tags": ["real-estate", "apartment", "trade"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -159,6 +179,8 @@
     "service_key_param": "serviceKey",
     "format_param": "resultType",
     "description": "MOLIT apartment rent real transaction data",
+    "tags": ["real-estate", "apartment", "rent"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -174,6 +196,8 @@
     "service_key_param": "serviceKey",
     "format_param": "resultType",
     "description": "MOLIT officetel trade real transaction data",
+    "tags": ["real-estate", "officetel", "trade"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -189,6 +213,8 @@
     "service_key_param": "serviceKey",
     "format_param": "resultType",
     "description": "MOLIT officetel rent real transaction data",
+    "tags": ["real-estate", "officetel", "rent"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -204,6 +230,8 @@
     "service_key_param": "serviceKey",
     "format_param": "resultType",
     "description": "MOLIT row house trade real transaction data",
+    "tags": ["real-estate", "row-house", "trade"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -219,6 +247,8 @@
     "service_key_param": "serviceKey",
     "format_param": "resultType",
     "description": "MOLIT row house rent real transaction data",
+    "tags": ["real-estate", "row-house", "rent"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -234,6 +264,8 @@
     "service_key_param": "serviceKey",
     "format_param": "resultType",
     "description": "MOLIT single house trade real transaction data",
+    "tags": ["real-estate", "single-house", "trade"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -249,6 +281,8 @@
     "service_key_param": "serviceKey",
     "format_param": "resultType",
     "description": "MOLIT single house rent real transaction data",
+    "tags": ["real-estate", "single-house", "rent"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -262,6 +296,8 @@
     "service_key_param": "serviceKey",
     "format_param": "resultType",
     "description": "Call any data.go.kr API endpoint by passing _base_url at call time. Only call_raw is supported; list() is not available because schema and pagination vary by endpoint.",
+    "tags": ["api", "generic"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["raw"],
     "generic": true
   },
@@ -274,6 +310,8 @@
     "service_key_param": "serviceKey",
     "format_param": "_type",
     "description": "KTO Korean tourism information by region (TourAPI KorService2)",
+    "tags": ["tourism", "area", "travel"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -289,6 +327,8 @@
     "service_key_param": "serviceKey",
     "format_param": "_type",
     "description": "KTO Korean tourism information by latitude/longitude (TourAPI KorService2)",
+    "tags": ["tourism", "location", "travel"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -304,6 +344,8 @@
     "service_key_param": "serviceKey",
     "format_param": "_type",
     "description": "KTO Korean tourism keyword search (TourAPI KorService2)",
+    "tags": ["tourism", "search", "travel"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -319,6 +361,8 @@
     "service_key_param": "serviceKey",
     "format_param": "_type",
     "description": "KTO Korean tourism festival/event search by date (TourAPI KorService2)",
+    "tags": ["tourism", "festival", "travel"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -334,6 +378,8 @@
     "service_key_param": "serviceKey",
     "format_param": "_type",
     "description": "Seoul Metro real-time fare information by station pair",
+    "tags": ["transportation", "subway", "fare"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",
@@ -349,6 +395,8 @@
     "service_key_param": "serviceKey",
     "format_param": "_type",
     "description": "Seoul Metro shortest path between two subway stations",
+    "tags": ["transportation", "subway", "route"],
+    "source_url": "https://www.data.go.kr",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",

--- a/src/kpubdata/providers/kosis/catalogue.json
+++ b/src/kpubdata/providers/kosis/catalogue.json
@@ -8,6 +8,8 @@
     "org_id": "101",
     "tbl_id": "DT_1B26003_A01",
     "description": "KOSTAT inter-regional population migration statistics",
+    "tags": ["population", "migration", "statistics"],
+    "source_url": "https://kosis.kr/openapi/Param/statisticsParameterData.do",
     "operations": ["list", "raw"],
     "query_support": {
       "pagination": "offset",

--- a/src/kpubdata/providers/law/catalogue.json
+++ b/src/kpubdata/providers/law/catalogue.json
@@ -2,6 +2,8 @@
   {
     "dataset_key": "law_search",
     "name": "법령 검색 (Law Search)",
+    "tags": ["law", "legislation", "search"],
+    "source_url": "https://www.law.go.kr/DRF/lawSearch.do",
     "base_url": "http://www.law.go.kr/DRF/lawSearch.do",
     "default_operation": "lawSearch",
     "representation": "api_json",
@@ -16,6 +18,8 @@
   {
     "dataset_key": "law_detail",
     "name": "법령 본문 조회 (Law Detail)",
+    "tags": ["law", "legislation", "detail"],
+    "source_url": "https://www.law.go.kr/DRF/lawSearch.do",
     "base_url": "http://www.law.go.kr/DRF/lawService.do",
     "default_operation": "lawService",
     "representation": "api_json",
@@ -25,6 +29,8 @@
   {
     "dataset_key": "ordin_search",
     "name": "자치법규 검색 (Ordinance Search)",
+    "tags": ["law", "ordinance", "search"],
+    "source_url": "https://www.law.go.kr/DRF/lawSearch.do",
     "base_url": "http://www.law.go.kr/DRF/lawSearch.do",
     "default_operation": "ordinSearch",
     "representation": "api_json",

--- a/src/kpubdata/providers/localdata/catalogue.json
+++ b/src/kpubdata/providers/localdata/catalogue.json
@@ -2,6 +2,8 @@
   {
     "dataset_key": "general_restaurant",
     "name": "일반음식점 인허가 (General Restaurant Permits)",
+    "tags": ["permits", "local-government", "food-service"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/general_restaurants",
     "default_operation": "info",
     "representation": "api_json",
@@ -91,6 +93,8 @@
   {
     "dataset_key": "rest_cafe",
     "name": "휴게음식점 인허가 (Rest Cafe Permits)",
+    "tags": ["permits", "local-government", "food-service"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/rest_cafes",
     "default_operation": "info",
     "representation": "api_json",
@@ -180,6 +184,8 @@
   {
     "dataset_key": "bakery",
     "name": "제과점 인허가 (Bakery Permits)",
+    "tags": ["permits", "local-government", "food-service"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/bakeries",
     "default_operation": "info",
     "representation": "api_json",
@@ -269,6 +275,8 @@
   {
     "dataset_key": "hospital",
     "name": "병원 인허가 (Hospital Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/hospitals",
     "default_operation": "info",
     "representation": "api_json",
@@ -358,6 +366,8 @@
   {
     "dataset_key": "clinic",
     "name": "의원 인허가 (Clinic Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/clinics",
     "default_operation": "info",
     "representation": "api_json",
@@ -447,6 +457,8 @@
   {
     "dataset_key": "pharmacy",
     "name": "약국 인허가 (Pharmacy Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/pharmacies",
     "default_operation": "info",
     "representation": "api_json",
@@ -536,6 +548,8 @@
   {
     "dataset_key": "animal_hospital",
     "name": "동물병원 인허가 (Animal Hospital Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/animal_hospitals",
     "default_operation": "info",
     "representation": "api_json",
@@ -625,6 +639,8 @@
   {
     "dataset_key": "optical_shop",
     "name": "안경점 인허가 (Optical Shop Permits)",
+    "tags": ["permits", "local-government", "personal-care"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/optical_shops",
     "default_operation": "info",
     "representation": "api_json",
@@ -714,6 +730,8 @@
   {
     "dataset_key": "public_bath",
     "name": "목욕장 인허가 (Public Bath Permits)",
+    "tags": ["permits", "local-government", "personal-care"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/public_baths",
     "default_operation": "info",
     "representation": "api_json",
@@ -803,6 +821,8 @@
   {
     "dataset_key": "laundry",
     "name": "세탁소 인허가 (Laundry Permits)",
+    "tags": ["permits", "local-government", "personal-care"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/laundries",
     "default_operation": "info",
     "representation": "api_json",
@@ -892,6 +912,8 @@
   {
     "dataset_key": "barber_shop",
     "name": "이발소 인허가 (Barber Shop Permits)",
+    "tags": ["permits", "local-government", "personal-care"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/barber_shops",
     "default_operation": "info",
     "representation": "api_json",
@@ -981,6 +1003,8 @@
   {
     "dataset_key": "beauty_salon",
     "name": "미용원 인허가 (Beauty Salon Permits)",
+    "tags": ["permits", "local-government", "personal-care"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/beauty_salons",
     "default_operation": "info",
     "representation": "api_json",
@@ -1070,6 +1094,8 @@
   {
     "dataset_key": "pet_grooming",
     "name": "반려동물미용 인허가 (Pet Grooming Permits)",
+    "tags": ["permits", "local-government", "animal"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/pet_grooming",
     "default_operation": "info",
     "representation": "api_json",
@@ -1159,6 +1185,8 @@
   {
     "dataset_key": "dance_academy",
     "name": "댄스학원 인허가 (Dance Academy Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/dance_academies",
     "default_operation": "info",
     "representation": "api_json",
@@ -1248,6 +1276,8 @@
   {
     "dataset_key": "karaoke",
     "name": "노래연습장 인허가 (Karaoke Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/karaoke_rooms",
     "default_operation": "info",
     "representation": "api_json",
@@ -1337,6 +1367,8 @@
   {
     "dataset_key": "singing_bar",
     "name": "유흥주점 인허가 (Singing Bar Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/singing_bars",
     "default_operation": "info",
     "representation": "api_json",
@@ -1426,6 +1458,8 @@
   {
     "dataset_key": "billiard_hall",
     "name": "당구장 인허가 (Billiard Hall Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/billiard_halls",
     "default_operation": "info",
     "representation": "api_json",
@@ -1515,6 +1549,8 @@
   {
     "dataset_key": "performance_hall",
     "name": "공연장 인허가 (Performance Hall Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/performance_halls",
     "default_operation": "info",
     "representation": "api_json",
@@ -1604,6 +1640,8 @@
   {
     "dataset_key": "movie_theater",
     "name": "영화관 인허가 (Movie Theater Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/movie_theaters",
     "default_operation": "info",
     "representation": "api_json",
@@ -1693,6 +1731,8 @@
   {
     "dataset_key": "swimming_pool",
     "name": "수영장 인허가 (Swimming Pool Permits)",
+    "tags": ["permits", "local-government", "sports"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/swimming_pools",
     "default_operation": "info",
     "representation": "api_json",
@@ -1782,6 +1822,8 @@
   {
     "dataset_key": "fitness_center",
     "name": "피트니스센터 인허가 (Fitness Center Permits)",
+    "tags": ["permits", "local-government", "sports"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/fitness_centers",
     "default_operation": "info",
     "representation": "api_json",
@@ -1871,6 +1913,8 @@
   {
     "dataset_key": "ice_rink",
     "name": "아이스링크 인허가 (Ice Rink Permits)",
+    "tags": ["permits", "local-government", "sports"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/ice_rinks",
     "default_operation": "info",
     "representation": "api_json",
@@ -1960,6 +2004,8 @@
   {
     "dataset_key": "golf_course",
     "name": "골프장 인허가 (Golf Course Permits)",
+    "tags": ["permits", "local-government", "sports"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/golf_courses",
     "default_operation": "info",
     "representation": "api_json",
@@ -2049,6 +2095,8 @@
   {
     "dataset_key": "golf_practice_range",
     "name": "골프연습장 인허가 (Golf Practice Range Permits)",
+    "tags": ["permits", "local-government", "sports"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/golf_practice_ranges",
     "default_operation": "info",
     "representation": "api_json",
@@ -2138,6 +2186,8 @@
   {
     "dataset_key": "horse_riding",
     "name": "승마장 인허가 (Horse Riding Permits)",
+    "tags": ["permits", "local-government", "sports"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/horse_riding",
     "default_operation": "info",
     "representation": "api_json",
@@ -2227,6 +2277,8 @@
   {
     "dataset_key": "ski_resort",
     "name": "스키장 인허가 (Ski Resort Permits)",
+    "tags": ["permits", "local-government", "sports"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/ski_resorts",
     "default_operation": "info",
     "representation": "api_json",
@@ -2316,6 +2368,8 @@
   {
     "dataset_key": "affiliated_medical_institution",
     "name": "부속의료기관 인허가 (Affiliated Medical Institution Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/affiliated_medical_institutions",
     "default_operation": "info",
     "representation": "api_json",
@@ -2405,6 +2459,8 @@
   {
     "dataset_key": "postpartum_care",
     "name": "산후조리업 인허가 (Postpartum Care Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/postpartum_care",
     "default_operation": "info",
     "representation": "api_json",
@@ -2494,6 +2550,8 @@
   {
     "dataset_key": "safe_over_the_counter_drug_store",
     "name": "안전상비의약품판매업소 인허가 (Safe Over The Counter Drug Store Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/safe_over_the_counter_drug_stores",
     "default_operation": "info",
     "representation": "api_json",
@@ -2583,6 +2641,8 @@
   {
     "dataset_key": "emergency_patient_transport",
     "name": "응급환자이송업 인허가 (Emergency Patient Transport Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/emergency_patient_transports",
     "default_operation": "info",
     "representation": "api_json",
@@ -2672,6 +2732,8 @@
   {
     "dataset_key": "medical_foundation",
     "name": "의료법인 인허가 (Medical Foundation Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/medical_foundations",
     "default_operation": "info",
     "representation": "api_json",
@@ -2761,6 +2823,8 @@
   {
     "dataset_key": "quasi_medical_business",
     "name": "의료유사업 인허가 (Quasi Medical Business Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/quasi_medical_businesses",
     "default_operation": "info",
     "representation": "api_json",
@@ -2850,6 +2914,8 @@
   {
     "dataset_key": "medical_device_repair",
     "name": "의료기기수리업 인허가 (Medical Device Repair Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/medical_device_repairs",
     "default_operation": "info",
     "representation": "api_json",
@@ -2939,6 +3005,8 @@
   {
     "dataset_key": "dental_lab",
     "name": "치과기공소 인허가 (Dental Lab Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/dental_labs",
     "default_operation": "info",
     "representation": "api_json",
@@ -3028,6 +3096,8 @@
   {
     "dataset_key": "medical_device_sales",
     "name": "의료기기판매업 인허가 (Medical Device Sales Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/medical_device_sales",
     "default_operation": "info",
     "representation": "api_json",
@@ -3117,6 +3187,8 @@
   {
     "dataset_key": "animal_breeding",
     "name": "동물생산업 인허가 (Animal Breeding Permits)",
+    "tags": ["permits", "local-government", "animal"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/animal_breedings",
     "default_operation": "info",
     "representation": "api_json",
@@ -3206,6 +3278,8 @@
   {
     "dataset_key": "animal_import",
     "name": "동물수입업 인허가 (Animal Import Permits)",
+    "tags": ["permits", "local-government", "animal"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/animal_import",
     "default_operation": "info",
     "representation": "api_json",
@@ -3295,6 +3369,8 @@
   {
     "dataset_key": "animal_care_service",
     "name": "동물위탁관리업 인허가 (Animal Care Service Permits)",
+    "tags": ["permits", "local-government", "animal"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/animal_care_services",
     "default_operation": "info",
     "representation": "api_json",
@@ -3384,6 +3460,8 @@
   {
     "dataset_key": "animal_transport",
     "name": "동물운송업 인허가 (Animal Transport Permits)",
+    "tags": ["permits", "local-government", "animal"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/animal_transports",
     "default_operation": "info",
     "representation": "api_json",
@@ -3473,6 +3551,8 @@
   {
     "dataset_key": "animal_funeral",
     "name": "동물장묘업 인허가 (Animal Funeral Permits)",
+    "tags": ["permits", "local-government", "animal"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/animal_funerals",
     "default_operation": "info",
     "representation": "api_json",
@@ -3562,6 +3642,8 @@
   {
     "dataset_key": "animal_exhibition",
     "name": "동물전시업 인허가 (Animal Exhibition Permits)",
+    "tags": ["permits", "local-government", "animal"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/animal_exhibitions",
     "default_operation": "info",
     "representation": "api_json",
@@ -3651,6 +3733,8 @@
   {
     "dataset_key": "animal_sales",
     "name": "동물판매업 인허가 (Animal Sales Permits)",
+    "tags": ["permits", "local-government", "animal"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/animal_saleses",
     "default_operation": "info",
     "representation": "api_json",
@@ -3740,6 +3824,8 @@
   {
     "dataset_key": "animal_crematorium",
     "name": "동물화장장업 인허가 (Animal Crematorium Permits)",
+    "tags": ["permits", "local-government", "animal"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/animal_crematoriums",
     "default_operation": "info",
     "representation": "api_json",
@@ -3829,6 +3915,8 @@
   {
     "dataset_key": "animal_training",
     "name": "동물훈련업 인허가 (Animal Training Permits)",
+    "tags": ["permits", "local-government", "animal"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/animal_training",
     "default_operation": "info",
     "representation": "api_json",
@@ -3918,6 +4006,8 @@
   {
     "dataset_key": "companion_animal_related_business",
     "name": "반려동물관련업 인허가 (Companion Animal Related Business Permits)",
+    "tags": ["permits", "local-government", "animal"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/companion_animal_related_businesses",
     "default_operation": "info",
     "representation": "api_json",
@@ -4007,6 +4097,8 @@
   {
     "dataset_key": "livestock_farming",
     "name": "가축사육업 인허가 (Livestock Farming Permits)",
+    "tags": ["permits", "local-government", "livestock"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/livestock_farmings",
     "default_operation": "info",
     "representation": "api_json",
@@ -4096,6 +4188,8 @@
   {
     "dataset_key": "livestock_artificial_insemination_center",
     "name": "가축인공수정소 인허가 (Livestock Artificial Insemination Center Permits)",
+    "tags": ["permits", "local-government", "livestock"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/livestock_artificial_insemination_centers",
     "default_operation": "info",
     "representation": "api_json",
@@ -4185,6 +4279,8 @@
   {
     "dataset_key": "slaughterhouse",
     "name": "도축업 인허가 (Slaughterhouse Permits)",
+    "tags": ["permits", "local-government", "livestock"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/slaughterhouses",
     "default_operation": "info",
     "representation": "api_json",
@@ -4274,6 +4370,8 @@
   {
     "dataset_key": "hatchery",
     "name": "부화업 인허가 (Hatchery Permits)",
+    "tags": ["permits", "local-government", "livestock"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/hatcheries",
     "default_operation": "info",
     "representation": "api_json",
@@ -4363,6 +4461,8 @@
   {
     "dataset_key": "feed_manufacturing",
     "name": "사료제조업 인허가 (Feed Manufacturing Permits)",
+    "tags": ["permits", "local-government", "livestock"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/feed_manufacturings",
     "default_operation": "info",
     "representation": "api_json",
@@ -4452,6 +4552,8 @@
   {
     "dataset_key": "breeding_stock",
     "name": "종축업 인허가 (Breeding Stock Permits)",
+    "tags": ["permits", "local-government", "livestock"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/breeding_stocks",
     "default_operation": "info",
     "representation": "api_json",
@@ -4541,6 +4643,8 @@
   {
     "dataset_key": "game_distribution",
     "name": "게임물배급업 인허가 (Game Distribution Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/game_distributions",
     "default_operation": "info",
     "representation": "api_json",
@@ -4630,6 +4734,8 @@
   {
     "dataset_key": "game_manufacturing",
     "name": "게임물제작업 인허가 (Game Manufacturing Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/game_manufacturings",
     "default_operation": "info",
     "representation": "api_json",
@@ -4719,6 +4825,8 @@
   {
     "dataset_key": "game_provider",
     "name": "게임제공업 인허가 (Game Provider Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/game_providers",
     "default_operation": "info",
     "representation": "api_json",
@@ -4808,6 +4916,8 @@
   {
     "dataset_key": "composite_game_provider",
     "name": "복합유통게임제공업 인허가 (Composite Game Provider Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/composite_game_providers",
     "default_operation": "info",
     "representation": "api_json",
@@ -4897,6 +5007,8 @@
   {
     "dataset_key": "internet_computer_game_facility",
     "name": "인터넷컴퓨터게임시설제공업 인허가 (Internet Computer Game Facility Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/internet_computer_game_facilities",
     "default_operation": "info",
     "representation": "api_json",
@@ -4986,6 +5098,8 @@
   {
     "dataset_key": "youth_game_provider",
     "name": "청소년게임제공업 인허가 (Youth Game Provider Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/youth_game_providers",
     "default_operation": "info",
     "representation": "api_json",
@@ -5075,6 +5189,8 @@
   {
     "dataset_key": "electronic_distribution",
     "name": "전자유통배급업 인허가 (Electronic Distribution Permits)",
+    "tags": ["permits", "local-government", "electronic"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/electronic_distribution",
     "default_operation": "info",
     "representation": "api_json",
@@ -5164,6 +5280,8 @@
   {
     "dataset_key": "tourist_performance_hall",
     "name": "관광공연장업 인허가 (Tourist Performance Hall Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tourist_performance_halls",
     "default_operation": "info",
     "representation": "api_json",
@@ -5253,6 +5371,8 @@
   {
     "dataset_key": "tourist_theater_entertainment",
     "name": "관광극장유흥업 인허가 (Tourist Theater Entertainment Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tourist_theater_entertainments",
     "default_operation": "info",
     "representation": "api_json",
@@ -5342,6 +5462,8 @@
   {
     "dataset_key": "tourist_track",
     "name": "관광궤도업 인허가 (Tourist Track Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tourist_tracks",
     "default_operation": "info",
     "representation": "api_json",
@@ -5431,6 +5553,8 @@
   {
     "dataset_key": "tourism_business",
     "name": "관광사업자 인허가 (Tourism Business Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tourism_businesses",
     "default_operation": "info",
     "representation": "api_json",
@@ -5520,6 +5644,8 @@
   {
     "dataset_key": "tourist_excursion_boat",
     "name": "관광유람선업 인허가 (Tourist Excursion Boat Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tourist_excursion_boats",
     "default_operation": "info",
     "representation": "api_json",
@@ -5609,6 +5735,8 @@
   {
     "dataset_key": "tourism_convenience_facility",
     "name": "관광편의시설업 인허가 (Tourism Convenience Facility Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tourism_convenience_facilities",
     "default_operation": "info",
     "representation": "api_json",
@@ -5698,6 +5826,8 @@
   {
     "dataset_key": "international_conference_facility",
     "name": "국제회의시설업 인허가 (International Conference Facility Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/international_conference_facilities",
     "default_operation": "info",
     "representation": "api_json",
@@ -5787,6 +5917,8 @@
   {
     "dataset_key": "foreign_tourist_city_homestay",
     "name": "외국인관광도시민박업 인허가 (Foreign Tourist City Homestay Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/foreign_tourist_city_homestays",
     "default_operation": "info",
     "representation": "api_json",
@@ -5876,6 +6008,8 @@
   {
     "dataset_key": "amusement_facility",
     "name": "유원시설업 인허가 (Amusement Facility Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/amusement_facilities",
     "default_operation": "info",
     "representation": "api_json",
@@ -5965,6 +6099,8 @@
   {
     "dataset_key": "general_amusement_facility",
     "name": "일반유원시설업 인허가 (General Amusement Facility Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/general_amusement_facilities",
     "default_operation": "info",
     "representation": "api_json",
@@ -6054,6 +6190,8 @@
   {
     "dataset_key": "comprehensive_amusement_facility",
     "name": "종합유원시설업 인허가 (Comprehensive Amusement Facility Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/comprehensive_amusement_facilities",
     "default_operation": "info",
     "representation": "api_json",
@@ -6143,6 +6281,8 @@
   {
     "dataset_key": "comprehensive_resort_business",
     "name": "종합휴양업 인허가 (Comprehensive Resort Business Permits)",
+    "tags": ["permits", "local-government", "comprehensive"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/comprehensive_resort_businesses",
     "default_operation": "info",
     "representation": "api_json",
@@ -6232,6 +6372,8 @@
   {
     "dataset_key": "specialized_resort_business",
     "name": "전문휴양업 인허가 (Specialized Resort Business Permits)",
+    "tags": ["permits", "local-government", "specialized"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/specialized_resort_businesses",
     "default_operation": "info",
     "representation": "api_json",
@@ -6321,6 +6463,8 @@
   {
     "dataset_key": "hanok_experience",
     "name": "한옥체험업 인허가 (Hanok Experience Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/hanok_experiences",
     "default_operation": "info",
     "representation": "api_json",
@@ -6410,6 +6554,8 @@
   {
     "dataset_key": "tourism_duty_free",
     "name": "관광면세업 인허가 (Tourism Duty Free Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tourism_duty_frees",
     "default_operation": "info",
     "representation": "api_json",
@@ -6499,6 +6645,8 @@
   {
     "dataset_key": "international_conference_planning",
     "name": "국제회의기획업 인허가 (International Conference Planning Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/international_conference_planning",
     "default_operation": "info",
     "representation": "api_json",
@@ -6588,6 +6736,8 @@
   {
     "dataset_key": "popular_culture_arts_planning",
     "name": "대중문화예술기획업 인허가 (Popular Culture Arts Planning Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/popular_culture_arts_planning",
     "default_operation": "info",
     "representation": "api_json",
@@ -6677,6 +6827,8 @@
   {
     "dataset_key": "culture_industry_company",
     "name": "문화산업전문회사 인허가 (Culture Industry Company Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/culture_industry_companies",
     "default_operation": "info",
     "representation": "api_json",
@@ -6766,6 +6918,8 @@
   {
     "dataset_key": "video_viewing_room",
     "name": "비디오물감상실업 인허가 (Video Viewing Room Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/video_viewing_rooms",
     "default_operation": "info",
     "representation": "api_json",
@@ -6855,6 +7009,8 @@
   {
     "dataset_key": "video_distribution",
     "name": "비디오물배급업 인허가 (Video Distribution Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/video_distributions",
     "default_operation": "info",
     "representation": "api_json",
@@ -6944,6 +7100,8 @@
   {
     "dataset_key": "video_small_theater",
     "name": "비디오물소극장업 인허가 (Video Small Theater Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/video_small_theaters",
     "default_operation": "info",
     "representation": "api_json",
@@ -7033,6 +7191,8 @@
   {
     "dataset_key": "video_viewing_service",
     "name": "비디오물시청제공업 인허가 (Video Viewing Service Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/video_viewing_services",
     "default_operation": "info",
     "representation": "api_json",
@@ -7122,6 +7282,8 @@
   {
     "dataset_key": "video_production",
     "name": "비디오물제작업 인허가 (Video Production Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/video_productions",
     "default_operation": "info",
     "representation": "api_json",
@@ -7211,6 +7373,8 @@
   {
     "dataset_key": "tourist_accommodation",
     "name": "관광숙박업 인허가 (Tourist Accommodation Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tourist_accommodations",
     "default_operation": "info",
     "representation": "api_json",
@@ -7300,6 +7464,8 @@
   {
     "dataset_key": "tourist_pension",
     "name": "관광펜션업 인허가 (Tourist Pension Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tourist_pensions",
     "default_operation": "info",
     "representation": "api_json",
@@ -7389,6 +7555,8 @@
   {
     "dataset_key": "rural_guesthouse",
     "name": "농어촌민박업 인허가 (Rural Guesthouse Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/rural_guesthouses",
     "default_operation": "info",
     "representation": "api_json",
@@ -7478,6 +7646,8 @@
   {
     "dataset_key": "small_hotel",
     "name": "소형호텔업 인허가 (Small Hotel Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/small_hotels",
     "default_operation": "info",
     "representation": "api_json",
@@ -7567,6 +7737,8 @@
   {
     "dataset_key": "foreign_tourist_city_homestay_lodging",
     "name": "외국인관광도시민박업(숙박) 인허가 (Foreign Tourist City Homestay Lodging Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/foreign_tourist_city_homestay_lodgings",
     "default_operation": "info",
     "representation": "api_json",
@@ -7656,6 +7828,8 @@
   {
     "dataset_key": "general_lodging",
     "name": "일반숙박업 인허가 (General Lodging Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/general_lodgings",
     "default_operation": "info",
     "representation": "api_json",
@@ -7745,6 +7919,8 @@
   {
     "dataset_key": "hanok_experience_lodging",
     "name": "한옥체험업(숙박) 인허가 (Hanok Experience Lodging Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/hanok_experience_lodgings",
     "default_operation": "info",
     "representation": "api_json",
@@ -7834,6 +8010,8 @@
   {
     "dataset_key": "residential_accommodation",
     "name": "생활숙박업 인허가 (Residential Accommodation Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/residential_accommodations",
     "default_operation": "info",
     "representation": "api_json",
@@ -7923,6 +8101,8 @@
   {
     "dataset_key": "domestic_travel",
     "name": "국내여행업 인허가 (Domestic Travel Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/domestic_travels",
     "default_operation": "info",
     "representation": "api_json",
@@ -8012,6 +8192,8 @@
   {
     "dataset_key": "domestic_international_travel",
     "name": "국내외여행업 인허가 (Domestic International Travel Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/domestic_international_travels",
     "default_operation": "info",
     "representation": "api_json",
@@ -8101,6 +8283,8 @@
   {
     "dataset_key": "comprehensive_travel",
     "name": "종합여행업 인허가 (Comprehensive Travel Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/comprehensive_travels",
     "default_operation": "info",
     "representation": "api_json",
@@ -8190,6 +8374,8 @@
   {
     "dataset_key": "movie_distribution",
     "name": "영화배급업 인허가 (Movie Distribution Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/movie_distributions",
     "default_operation": "info",
     "representation": "api_json",
@@ -8279,6 +8465,8 @@
   {
     "dataset_key": "movie_screening",
     "name": "영화상영업 인허가 (Movie Screening Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/movie_screenings",
     "default_operation": "info",
     "representation": "api_json",
@@ -8368,6 +8556,8 @@
   {
     "dataset_key": "movie_import",
     "name": "영화수입업 인허가 (Movie Import Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/movie_imports",
     "default_operation": "info",
     "representation": "api_json",
@@ -8457,6 +8647,8 @@
   {
     "dataset_key": "movie_production",
     "name": "영화제작업 인허가 (Movie Production Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/movie_productions",
     "default_operation": "info",
     "representation": "api_json",
@@ -8546,6 +8738,8 @@
   {
     "dataset_key": "online_music_service",
     "name": "온라인음악서비스제공업 인허가 (Online Music Service Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/online_music_services",
     "default_operation": "info",
     "representation": "api_json",
@@ -8635,6 +8829,8 @@
   {
     "dataset_key": "record_distribution",
     "name": "음반물배급업 인허가 (Record Distribution Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/record_distributions",
     "default_operation": "info",
     "representation": "api_json",
@@ -8724,6 +8920,8 @@
   {
     "dataset_key": "record_production",
     "name": "음반물제작업 인허가 (Record Production Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/record_productions",
     "default_operation": "info",
     "representation": "api_json",
@@ -8813,6 +9011,8 @@
   {
     "dataset_key": "music_video_distribution",
     "name": "음악영상물배급업 인허가 (Music Video Distribution Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/music_video_distributions",
     "default_operation": "info",
     "representation": "api_json",
@@ -8902,6 +9102,8 @@
   {
     "dataset_key": "music_video_production",
     "name": "음악영상물제작업 인허가 (Music Video Production Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/music_video_productions",
     "default_operation": "info",
     "representation": "api_json",
@@ -8991,6 +9193,8 @@
   {
     "dataset_key": "medical_linen_processing",
     "name": "의료기관세탁물처리업 인허가 (Medical Linen Processing Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/medical_linen_processing",
     "default_operation": "info",
     "representation": "api_json",
@@ -9080,6 +9284,8 @@
   {
     "dataset_key": "multilevel_sales",
     "name": "다단계판매업체 인허가 (Multilevel Sales Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/multilevel_sales",
     "default_operation": "info",
     "representation": "api_json",
@@ -9169,6 +9375,8 @@
   {
     "dataset_key": "large_store",
     "name": "대규모점포 인허가 (Large Store Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/large_stores",
     "default_operation": "info",
     "representation": "api_json",
@@ -9258,6 +9466,8 @@
   {
     "dataset_key": "door_to_door_sales",
     "name": "방문판매업 인허가 (Door To Door Sales Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/door_to_door_sales",
     "default_operation": "info",
     "representation": "api_json",
@@ -9347,6 +9557,8 @@
   {
     "dataset_key": "prepaid_installment_trade",
     "name": "선불식할부거래업 인허가 (Prepaid Installment Trade Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/prepaid_installment_trades",
     "default_operation": "info",
     "representation": "api_json",
@@ -9436,6 +9648,8 @@
   {
     "dataset_key": "ecommerce",
     "name": "전자상거래업 인허가 (E-Commerce Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/ecommerce",
     "default_operation": "info",
     "representation": "api_json",
@@ -9525,6 +9739,8 @@
   {
     "dataset_key": "mail_order_sales",
     "name": "통신판매업 인허가 (Mail Order Sales Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/mail_order_sales",
     "default_operation": "info",
     "representation": "api_json",
@@ -9614,6 +9830,8 @@
   {
     "dataset_key": "dance_hall",
     "name": "무도장업 인허가 (Dance Hall Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/dance_halls",
     "default_operation": "info",
     "representation": "api_json",
@@ -9703,6 +9921,8 @@
   {
     "dataset_key": "yacht_marina",
     "name": "요트장업 인허가 (Yacht Marina Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/yacht_marinas",
     "default_operation": "info",
     "representation": "api_json",
@@ -9792,6 +10012,8 @@
   {
     "dataset_key": "motor_racing_course",
     "name": "자동차경주장업 인허가 (Motor Racing Course Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/motor_racing_courses",
     "default_operation": "info",
     "representation": "api_json",
@@ -9881,6 +10103,8 @@
   {
     "dataset_key": "comprehensive_sports_facility",
     "name": "종합체육시설업 인허가 (Comprehensive Sports Facility Permits)",
+    "tags": ["permits", "local-government", "sports"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/comprehensive_sports_facilities",
     "default_operation": "info",
     "representation": "api_json",
@@ -9970,6 +10194,8 @@
   {
     "dataset_key": "martial_arts_gym",
     "name": "체육도장업 인허가 (Martial Arts Gym Permits)",
+    "tags": ["permits", "local-government", "sports"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/martial_arts_gyms",
     "default_operation": "info",
     "representation": "api_json",
@@ -10059,6 +10285,8 @@
   {
     "dataset_key": "boxing_gym",
     "name": "권투전용체육시설 인허가 (Boxing Gym Permits)",
+    "tags": ["permits", "local-government", "sports"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/boxing_gyms",
     "default_operation": "info",
     "representation": "api_json",
@@ -10148,6 +10376,8 @@
   {
     "dataset_key": "contract_foodservice",
     "name": "위탁급식영업 인허가 (Contract Foodservice Permits)",
+    "tags": ["permits", "local-government", "food-service"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/contract_foodservices",
     "default_operation": "info",
     "representation": "api_json",
@@ -10237,6 +10467,8 @@
   {
     "dataset_key": "group_cafeteria",
     "name": "집단급식소 인허가 (Group Cafeteria Permits)",
+    "tags": ["permits", "local-government", "food-service"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/group_cafeterias",
     "default_operation": "info",
     "representation": "api_json",
@@ -10326,6 +10558,8 @@
   {
     "dataset_key": "health_functional_food_retail",
     "name": "건강기능식품일반판매업 인허가 (Health Functional Food Retail Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/health_functional_food_retail",
     "default_operation": "info",
     "representation": "api_json",
@@ -10415,6 +10649,8 @@
   {
     "dataset_key": "health_functional_food_specialty",
     "name": "건강기능식품전문판매업 인허가 (Health Functional Food Specialty Permits)",
+    "tags": ["permits", "local-government", "health"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/health_functional_food_specialties",
     "default_operation": "info",
     "representation": "api_json",
@@ -10504,6 +10740,8 @@
   {
     "dataset_key": "health_functional_food_distributor",
     "name": "건강기능식품유통전문판매업 인허가 (Health Functional Food Distributor Permits)",
+    "tags": ["permits", "local-government", "health"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/health_functional_food_distributors",
     "default_operation": "info",
     "representation": "api_json",
@@ -10593,6 +10831,8 @@
   {
     "dataset_key": "food_cold_storage",
     "name": "식품냉동냉장업 인허가 (Food Cold Storage Permits)",
+    "tags": ["permits", "local-government", "food"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/food_cold_storage",
     "default_operation": "info",
     "representation": "api_json",
@@ -10682,6 +10922,8 @@
   {
     "dataset_key": "food_repackaging",
     "name": "식품소분업 인허가 (Food Repackaging Permits)",
+    "tags": ["permits", "local-government", "food"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/food_repackaging",
     "default_operation": "info",
     "representation": "api_json",
@@ -10771,6 +11013,8 @@
   {
     "dataset_key": "food_transportation",
     "name": "식품운반업 인허가 (Food Transportation Permits)",
+    "tags": ["permits", "local-government", "logistics"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/food_transportation",
     "default_operation": "info",
     "representation": "api_json",
@@ -10860,6 +11104,8 @@
   {
     "dataset_key": "food_vending_machine",
     "name": "식품자동판매기영업 인허가 (Food Vending Machine Permits)",
+    "tags": ["permits", "local-government", "food"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/food_vending_machines",
     "default_operation": "info",
     "representation": "api_json",
@@ -10949,6 +11195,8 @@
   {
     "dataset_key": "food_manufacturing",
     "name": "식품제조가공업 인허가 (Food Manufacturing Permits)",
+    "tags": ["permits", "local-government", "food"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/food_manufacturing",
     "default_operation": "info",
     "representation": "api_json",
@@ -11038,6 +11286,8 @@
   {
     "dataset_key": "food_additive_manufacturing",
     "name": "식품첨가물제조업 인허가 (Food Additive Manufacturing Permits)",
+    "tags": ["permits", "local-government", "food"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/food_additive_manufacturing",
     "default_operation": "info",
     "representation": "api_json",
@@ -11127,6 +11377,8 @@
   {
     "dataset_key": "edible_ice_sales",
     "name": "식용얼음판매업 인허가 (Edible Ice Sales Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/edible_ice_saleses",
     "default_operation": "info",
     "representation": "api_json",
@@ -11216,6 +11468,8 @@
   {
     "dataset_key": "onggi_manufacturing",
     "name": "옹기류제조업 인허가 (Onggi Manufacturing Permits)",
+    "tags": ["permits", "local-government", "onggi"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/onggi_manufacturings",
     "default_operation": "info",
     "representation": "api_json",
@@ -11305,6 +11559,8 @@
   {
     "dataset_key": "distribution_specialized_sales",
     "name": "유통전문판매업 인허가 (Distribution Specialized Sales Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/distribution_specialized_sales",
     "default_operation": "info",
     "representation": "api_json",
@@ -11394,6 +11650,8 @@
   {
     "dataset_key": "instant_food_manufacturing",
     "name": "즉석판매제조가공업 인허가 (Instant Food Manufacturing Permits)",
+    "tags": ["permits", "local-government", "instant"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/instant_food_manufacturing",
     "default_operation": "info",
     "representation": "api_json",
@@ -11483,6 +11741,8 @@
   {
     "dataset_key": "milk_collection",
     "name": "집유업 인허가 (Milk Collection Permits)",
+    "tags": ["permits", "local-government", "milk"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/milk_collection",
     "default_operation": "info",
     "representation": "api_json",
@@ -11572,6 +11832,8 @@
   {
     "dataset_key": "livestock_processing",
     "name": "축산물가공업 인허가 (Livestock Processing Permits)",
+    "tags": ["permits", "local-government", "livestock"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/livestock_processing",
     "default_operation": "info",
     "representation": "api_json",
@@ -11661,6 +11923,8 @@
   {
     "dataset_key": "livestock_storage",
     "name": "축산물보관업 인허가 (Livestock Storage Permits)",
+    "tags": ["permits", "local-government", "livestock"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/livestock_storage",
     "default_operation": "info",
     "representation": "api_json",
@@ -11750,6 +12014,8 @@
   {
     "dataset_key": "livestock_transportation",
     "name": "축산물운반업 인허가 (Livestock Transportation Permits)",
+    "tags": ["permits", "local-government", "livestock"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/livestock_transportation",
     "default_operation": "info",
     "representation": "api_json",
@@ -11839,6 +12105,8 @@
   {
     "dataset_key": "livestock_sales",
     "name": "축산물판매업 인허가 (Livestock Sales Permits)",
+    "tags": ["permits", "local-government", "livestock"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/livestock_sales",
     "default_operation": "info",
     "representation": "api_json",
@@ -11928,6 +12196,8 @@
   {
     "dataset_key": "imported_livestock_sales",
     "name": "축산물수입판매업 인허가 (Imported Livestock Sales Permits)",
+    "tags": ["permits", "local-government", "livestock"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/imported_livestock_sales",
     "default_operation": "info",
     "representation": "api_json",
@@ -12017,6 +12287,8 @@
   {
     "dataset_key": "container_packaging_manufacturing",
     "name": "용기포장류제조업 인허가 (Container Packaging Manufacturing Permits)",
+    "tags": ["permits", "local-government", "container"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/container_packaging_manufacturings",
     "default_operation": "info",
     "representation": "api_json",
@@ -12106,6 +12378,8 @@
   {
     "dataset_key": "other_food_sales",
     "name": "기타식품판매업 인허가 (Other Food Sales Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/other_food_sales",
     "default_operation": "info",
     "representation": "api_json",
@@ -12195,6 +12469,8 @@
   {
     "dataset_key": "imported_food_sales",
     "name": "식품등수입판매업 인허가 (Imported Food Sales Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/imported_food_sales",
     "default_operation": "info",
     "representation": "api_json",
@@ -12284,6 +12560,8 @@
   {
     "dataset_key": "entertainment_bar",
     "name": "유흥주점영업 인허가 (Entertainment Bar Permits)",
+    "tags": ["permits", "local-government", "tourism"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/entertainment_bars",
     "default_operation": "info",
     "representation": "api_json",
@@ -12373,6 +12651,8 @@
   {
     "dataset_key": "tourist_restaurant",
     "name": "관광식당 인허가 (Tourist Restaurant Permits)",
+    "tags": ["permits", "local-government", "food-service"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tourist_restaurants",
     "default_operation": "info",
     "representation": "api_json",
@@ -12462,6 +12742,8 @@
   {
     "dataset_key": "foreigner_exclusive_entertainment_restaurant",
     "name": "외국인전용유흥음식점업 인허가 (Foreigner Exclusive Entertainment Restaurant Permits)",
+    "tags": ["permits", "local-government", "food-service"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/foreigner_exclusive_entertainment_restaurants",
     "default_operation": "info",
     "representation": "api_json",
@@ -12551,6 +12833,8 @@
   {
     "dataset_key": "tourist_entertainment_restaurant",
     "name": "관광유흥음식점업 인허가 (Tourist Entertainment Restaurant Permits)",
+    "tags": ["permits", "local-government", "food-service"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tourist_entertainment_restaurants",
     "default_operation": "info",
     "representation": "api_json",
@@ -12640,6 +12924,8 @@
   {
     "dataset_key": "timber_import_distribution",
     "name": "목재수입유통업 인허가 (Timber Import Distribution Permits)",
+    "tags": ["permits", "local-government", "timber"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/timber_import_distributions",
     "default_operation": "info",
     "representation": "api_json",
@@ -12729,6 +13015,8 @@
   {
     "dataset_key": "log_production",
     "name": "원목생산업 인허가 (Log Production Permits)",
+    "tags": ["permits", "local-government", "log"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/log_production",
     "default_operation": "info",
     "representation": "api_json",
@@ -12818,6 +13106,8 @@
   {
     "dataset_key": "sawmill",
     "name": "제재업 인허가 (Sawmill Permits)",
+    "tags": ["permits", "local-government", "sawmill"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/sawmills",
     "default_operation": "info",
     "representation": "api_json",
@@ -12907,6 +13197,8 @@
   {
     "dataset_key": "meter_repair",
     "name": "계량기수리업 인허가 (Meter Repair Permits)",
+    "tags": ["permits", "local-government", "energy"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/meter_repairs",
     "default_operation": "info",
     "representation": "api_json",
@@ -12996,6 +13288,8 @@
   {
     "dataset_key": "high_pressure_gas",
     "name": "고압가스업 인허가 (High Pressure Gas Permits)",
+    "tags": ["permits", "local-government", "energy"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/high_pressure_gas",
     "default_operation": "info",
     "representation": "api_json",
@@ -13085,6 +13379,8 @@
   {
     "dataset_key": "petroleum_sales",
     "name": "석유판매업 인허가 (Petroleum Sales Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/petroleum_sales",
     "default_operation": "info",
     "representation": "api_json",
@@ -13174,6 +13470,8 @@
   {
     "dataset_key": "petroleum_import_export",
     "name": "석유수출입업 인허가 (Petroleum Import Export Permits)",
+    "tags": ["permits", "local-government", "energy"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/petroleum_import_exports",
     "default_operation": "info",
     "representation": "api_json",
@@ -13263,6 +13561,8 @@
   {
     "dataset_key": "energy_saving_company",
     "name": "에너지절약전문기업 인허가 (Energy Saving Company Permits)",
+    "tags": ["permits", "local-government", "energy"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/energy_saving_companies",
     "default_operation": "info",
     "representation": "api_json",
@@ -13352,6 +13652,8 @@
   {
     "dataset_key": "lpg_charging",
     "name": "액화석유가스충전사업 인허가 (LPG Charging Permits)",
+    "tags": ["permits", "local-government", "energy"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/lpg_chargings",
     "default_operation": "info",
     "representation": "api_json",
@@ -13441,6 +13743,8 @@
   {
     "dataset_key": "lpg_collective_supply",
     "name": "액화석유가스집단공급사업 인허가 (LPG Collective Supply Permits)",
+    "tags": ["permits", "local-government", "energy"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/lpg_collective_supplies",
     "default_operation": "info",
     "representation": "api_json",
@@ -13530,6 +13834,8 @@
   {
     "dataset_key": "lpg_sales",
     "name": "액화석유가스판매사업 인허가 (LPG Sales Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/lpg_saleses",
     "default_operation": "info",
     "representation": "api_json",
@@ -13619,6 +13925,8 @@
   {
     "dataset_key": "electrical_construction",
     "name": "전기공사업 인허가 (Electrical Construction Permits)",
+    "tags": ["permits", "local-government", "energy"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/electrical_construction",
     "default_operation": "info",
     "representation": "api_json",
@@ -13708,6 +14016,8 @@
   {
     "dataset_key": "electrical_safety_management_agency",
     "name": "전기안전관리대행사업 인허가 (Electrical Safety Management Agency Permits)",
+    "tags": ["permits", "local-government", "energy"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/electrical_safety_management_agencies",
     "default_operation": "info",
     "representation": "api_json",
@@ -13797,6 +14107,8 @@
   {
     "dataset_key": "electricity_sales",
     "name": "전기판매사업 인허가 (Electricity Sales Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/electricity_sales",
     "default_operation": "info",
     "representation": "api_json",
@@ -13886,6 +14198,8 @@
   {
     "dataset_key": "city_gas",
     "name": "도시가스사업 인허가 (City Gas Permits)",
+    "tags": ["permits", "local-government", "energy"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/city_gas",
     "default_operation": "info",
     "representation": "api_json",
@@ -13975,6 +14289,8 @@
   {
     "dataset_key": "gas_appliance_manufacturing",
     "name": "가스용품제조사업 인허가 (Gas Appliance Manufacturing Permits)",
+    "tags": ["permits", "local-government", "energy"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/gas_appliance_manufacturings",
     "default_operation": "info",
     "representation": "api_json",
@@ -14064,6 +14380,8 @@
   {
     "dataset_key": "groundwater_construction",
     "name": "지하수시공업체 인허가 (Groundwater Construction Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/groundwater_construction",
     "default_operation": "info",
     "representation": "api_json",
@@ -14153,6 +14471,8 @@
   {
     "dataset_key": "groundwater_impact_assessment",
     "name": "지하수영향조사기관 인허가 (Groundwater Impact Assessment Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/groundwater_impact_assessments",
     "default_operation": "info",
     "representation": "api_json",
@@ -14242,6 +14562,8 @@
   {
     "dataset_key": "groundwater_purification",
     "name": "지하수정화업체 인허가 (Groundwater Purification Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/groundwater_purification",
     "default_operation": "info",
     "representation": "api_json",
@@ -14331,6 +14653,8 @@
   {
     "dataset_key": "building_sanitation_management",
     "name": "건물위생관리업 인허가 (Building Sanitation Management Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/building_sanitation_managements",
     "default_operation": "info",
     "representation": "api_json",
@@ -14420,6 +14744,8 @@
   {
     "dataset_key": "water_tank_cleaning",
     "name": "저수조청소업 인허가 (Water Tank Cleaning Permits)",
+    "tags": ["permits", "local-government", "construction"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/water_tank_cleaning",
     "default_operation": "info",
     "representation": "api_json",
@@ -14509,6 +14835,8 @@
   {
     "dataset_key": "disinfection_business",
     "name": "소독업 인허가 (Disinfection Business Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/disinfection_businesses",
     "default_operation": "info",
     "representation": "api_json",
@@ -14598,6 +14926,8 @@
   {
     "dataset_key": "sanitary_product_manufacturing",
     "name": "위생용품제조업 인허가 (Sanitary Product Manufacturing Permits)",
+    "tags": ["permits", "local-government", "sanitary"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/sanitary_product_manufacturings",
     "default_operation": "info",
     "representation": "api_json",
@@ -14687,6 +15017,8 @@
   {
     "dataset_key": "sanitation_treatment",
     "name": "위생처리업 인허가 (Sanitation Treatment Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/sanitation_treatments",
     "default_operation": "info",
     "representation": "api_json",
@@ -14776,6 +15108,8 @@
   {
     "dataset_key": "waste_treatment",
     "name": "폐기물처리업 인허가 (Waste Treatment Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/waste_treatment",
     "default_operation": "info",
     "representation": "api_json",
@@ -14865,6 +15199,8 @@
   {
     "dataset_key": "waste_collection_transportation",
     "name": "폐기물수집운반업 인허가 (Waste Collection Transportation Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/waste_collection_transportation",
     "default_operation": "info",
     "representation": "api_json",
@@ -14954,6 +15290,8 @@
   {
     "dataset_key": "night_soil_collection_transportation",
     "name": "분뇨수집운반업 인허가 (Night Soil Collection Transportation Permits)",
+    "tags": ["permits", "local-government", "logistics"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/night_soil_collection_transportation",
     "default_operation": "info",
     "representation": "api_json",
@@ -15043,6 +15381,8 @@
   {
     "dataset_key": "environmental_measurement_agency",
     "name": "환경측정대행업 인허가 (Environmental Measurement Agency Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/environmental_measurement_agencies",
     "default_operation": "info",
     "representation": "api_json",
@@ -15132,6 +15472,8 @@
   {
     "dataset_key": "environmental_impact_assessment",
     "name": "환경영향평가업 인허가 (Environmental Impact Assessment Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/environmental_impact_assessment",
     "default_operation": "info",
     "representation": "api_json",
@@ -15221,6 +15563,8 @@
   {
     "dataset_key": "air_pollution_prevention_facility",
     "name": "대기오염방지시설업 인허가 (Air Pollution Prevention Facility Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/air_pollution_prevention_facilities",
     "default_operation": "info",
     "representation": "api_json",
@@ -15310,6 +15654,8 @@
   {
     "dataset_key": "water_pollution_prevention_facility",
     "name": "수질오염방지시설업 인허가 (Water Pollution Prevention Facility Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/water_pollution_prevention_facilities",
     "default_operation": "info",
     "representation": "api_json",
@@ -15399,6 +15745,8 @@
   {
     "dataset_key": "soil_remediation",
     "name": "토양정화업 인허가 (Soil Remediation Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/soil_remediation",
     "default_operation": "info",
     "representation": "api_json",
@@ -15488,6 +15836,8 @@
   {
     "dataset_key": "noise_vibration_prevention_facility",
     "name": "소음진동방지시설업 인허가 (Noise Vibration Prevention Facility Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/noise_vibration_prevention_facilities",
     "default_operation": "info",
     "representation": "api_json",
@@ -15577,6 +15927,8 @@
   {
     "dataset_key": "waste_recycling",
     "name": "폐기물재활용업 인허가 (Waste Recycling Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/waste_recycling",
     "default_operation": "info",
     "representation": "api_json",
@@ -15666,6 +16018,8 @@
   {
     "dataset_key": "medical_waste_treatment",
     "name": "의료폐기물처리업 인허가 (Medical Waste Treatment Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/medical_waste_treatments",
     "default_operation": "info",
     "representation": "api_json",
@@ -15755,6 +16109,8 @@
   {
     "dataset_key": "marine_environment_management",
     "name": "해양환경관리업 인허가 (Marine Environment Management Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/marine_environment_managements",
     "default_operation": "info",
     "representation": "api_json",
@@ -15844,6 +16200,8 @@
   {
     "dataset_key": "environmental_consulting",
     "name": "환경컨설팅업 인허가 (Environmental Consulting Permits)",
+    "tags": ["permits", "local-government", "environment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/environmental_consulting",
     "default_operation": "info",
     "representation": "api_json",
@@ -15933,6 +16291,8 @@
   {
     "dataset_key": "outdoor_advertising",
     "name": "옥외광고업 인허가 (Outdoor Advertising Permits)",
+    "tags": ["permits", "business", "business"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/outdoor_advertising",
     "default_operation": "info",
     "representation": "api_json",
@@ -16022,6 +16382,8 @@
   {
     "dataset_key": "printing_house",
     "name": "인쇄사 인허가 (Printing House Permits)",
+    "tags": ["permits", "business", "business"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/printing_houses",
     "default_operation": "info",
     "representation": "api_json",
@@ -16111,6 +16473,8 @@
   {
     "dataset_key": "publisher",
     "name": "출판사 인허가 (Publisher Permits)",
+    "tags": ["permits", "business", "business"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/publishers",
     "default_operation": "info",
     "representation": "api_json",
@@ -16200,6 +16564,8 @@
   {
     "dataset_key": "tobacco_wholesale",
     "name": "담배도매업 인허가 (Tobacco Wholesale Permits)",
+    "tags": ["permits", "business", "business"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tobacco_wholesales",
     "default_operation": "info",
     "representation": "api_json",
@@ -16289,6 +16655,8 @@
   {
     "dataset_key": "tobacco_retail",
     "name": "담배소매업 인허가 (Tobacco Retail Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tobacco_retails",
     "default_operation": "info",
     "representation": "api_json",
@@ -16378,6 +16746,8 @@
   {
     "dataset_key": "tobacco_import_sales",
     "name": "담배수입판매업체 인허가 (Tobacco Import Sales Permits)",
+    "tags": ["permits", "local-government", "retail"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/tobacco_import_saleses",
     "default_operation": "info",
     "representation": "api_json",
@@ -16467,6 +16837,8 @@
   {
     "dataset_key": "international_freight_forwarding",
     "name": "국제물류주선업 인허가 (International Freight Forwarding Permits)",
+    "tags": ["permits", "local-government", "logistics"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/international_freight_forwarding",
     "default_operation": "info",
     "representation": "api_json",
@@ -16556,6 +16928,8 @@
   {
     "dataset_key": "logistics_warehouse",
     "name": "물류창고업체 인허가 (Logistics Warehouse Permits)",
+    "tags": ["permits", "local-government", "logistics"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/logistics_warehouses",
     "default_operation": "info",
     "representation": "api_json",
@@ -16645,6 +17019,8 @@
   {
     "dataset_key": "civil_defense_water_supply",
     "name": "민방위급수시설 인허가 (Civil Defense Water Supply Permits)",
+    "tags": ["permits", "local-government", "logistics"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/civil_defense_water_supply",
     "default_operation": "info",
     "representation": "api_json",
@@ -16734,6 +17110,8 @@
   {
     "dataset_key": "funeral_service",
     "name": "상조업 인허가 (Funeral Service Permits)",
+    "tags": ["permits", "local-government", "funeral"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/funeral_service",
     "default_operation": "info",
     "representation": "api_json",
@@ -16823,6 +17201,8 @@
   {
     "dataset_key": "elevator_maintenance",
     "name": "승강기유지관리업체 인허가 (Elevator Maintenance Permits)",
+    "tags": ["permits", "local-government", "construction"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/elevator_maintenances",
     "default_operation": "info",
     "representation": "api_json",
@@ -16912,6 +17292,8 @@
   {
     "dataset_key": "elevator_manufacturing_import",
     "name": "승강기제조및수입업체 인허가 (Elevator Manufacturing Import Permits)",
+    "tags": ["permits", "local-government", "construction"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/elevator_manufacturing_imports",
     "default_operation": "info",
     "representation": "api_json",
@@ -17001,6 +17383,8 @@
   {
     "dataset_key": "caregiver_training_institution",
     "name": "요양보호사교육기관 인허가 (Caregiver Training Institution Permits)",
+    "tags": ["permits", "local-government", "healthcare"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/caregiver_training_institutions",
     "default_operation": "info",
     "representation": "api_json",
@@ -17090,6 +17474,8 @@
   {
     "dataset_key": "funeral_director_training_institution",
     "name": "장례지도사교육기관 인허가 (Funeral Director Training Institution Permits)",
+    "tags": ["permits", "local-government", "employment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/funeral_director_training_institutions",
     "default_operation": "info",
     "representation": "api_json",
@@ -17179,6 +17565,8 @@
   {
     "dataset_key": "free_job_placement",
     "name": "무료직업소개소 인허가 (Free Job Placement Permits)",
+    "tags": ["permits", "local-government", "employment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/free_job_placements",
     "default_operation": "info",
     "representation": "api_json",
@@ -17268,6 +17656,8 @@
   {
     "dataset_key": "paid_job_placement",
     "name": "유료직업소개소 인허가 (Paid Job Placement Permits)",
+    "tags": ["permits", "local-government", "employment"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/1741000/paid_job_placements",
     "default_operation": "info",
     "representation": "api_json",

--- a/src/kpubdata/providers/lofin/catalogue.json
+++ b/src/kpubdata/providers/lofin/catalogue.json
@@ -2,6 +2,8 @@
   {
     "dataset_key": "expenditure_budget",
     "name": "지방재정 세출결산총괄 (LOFIN Expenditure Budget Summary)",
+    "tags": ["local-finance", "budget", "expenditure"],
+    "source_url": "https://www.lofin365.go.kr/lf/hub",
     "api_code": "AJGCF",
     "base_url": "https://www.lofin365.go.kr/lf/hub",
     "representation": "api_json",
@@ -27,6 +29,8 @@
   {
     "dataset_key": "expenditure_function",
     "name": "지방재정 기능별세출 (LOFIN Expenditure by Function)",
+    "tags": ["local-finance", "budget", "function"],
+    "source_url": "https://www.lofin365.go.kr/lf/hub",
     "api_code": "GGNSE",
     "base_url": "https://www.lofin365.go.kr/lf/hub",
     "representation": "api_json",
@@ -54,6 +58,8 @@
   {
     "dataset_key": "revenue_budget",
     "name": "지방재정 세입결산총괄 (LOFIN Revenue Budget Summary)",
+    "tags": ["local-finance", "budget", "revenue"],
+    "source_url": "https://www.lofin365.go.kr/lf/hub",
     "api_code": "IIBBH",
     "base_url": "https://www.lofin365.go.kr/lf/hub",
     "representation": "api_json",
@@ -79,6 +85,8 @@
   {
     "dataset_key": "revenue_by_source",
     "name": "지방재정 재원별 회계별 세입결산 (LOFIN Revenue by Source & Account)",
+    "tags": ["local-finance", "revenue", "source"],
+    "source_url": "https://www.lofin365.go.kr/lf/hub",
     "api_code": "FIACRV",
     "base_url": "https://www.lofin365.go.kr/lf/hub",
     "representation": "api_json",
@@ -110,6 +118,8 @@
   {
     "dataset_key": "debt_ratio",
     "name": "지방재정 채무비율현황 (LOFIN Debt Ratio Status)",
+    "tags": ["local-finance", "debt", "ratio"],
+    "source_url": "https://www.lofin365.go.kr/lf/hub",
     "api_code": "HEDFC",
     "base_url": "https://www.lofin365.go.kr/lf/hub",
     "representation": "api_json",
@@ -133,6 +143,8 @@
   {
     "dataset_key": "fiscal_independence",
     "name": "지방재정 재정자립도현황 (LOFIN Fiscal Independence)",
+    "tags": ["local-finance", "fiscal-independence", "finance"],
+    "source_url": "https://www.lofin365.go.kr/lf/hub",
     "api_code": "JFIED",
     "base_url": "https://www.lofin365.go.kr/lf/hub",
     "representation": "api_json",

--- a/src/kpubdata/providers/semas/catalogue.json
+++ b/src/kpubdata/providers/semas/catalogue.json
@@ -2,6 +2,8 @@
   {
     "dataset_key": "zone_one",
     "name": "지정상권 조회 (Zone One)",
+    "tags": ["commercial-district", "retail", "zone"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeZoneOne",
     "representation": "api_json",
@@ -25,6 +27,8 @@
   {
     "dataset_key": "zone_radius",
     "name": "반경상권 조회 (Zone Radius)",
+    "tags": ["commercial-district", "retail", "zone"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeZoneInRadius",
     "representation": "api_json",
@@ -48,6 +52,8 @@
   {
     "dataset_key": "zone_rect",
     "name": "사각형상권 조회 (Zone Rectangle)",
+    "tags": ["commercial-district", "retail", "zone"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeZoneInRectangle",
     "representation": "api_json",
@@ -71,6 +77,8 @@
   {
     "dataset_key": "zone_admi",
     "name": "행정구역상권 조회 (Zone Administrative)",
+    "tags": ["commercial-district", "retail", "zone"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeZoneInAdmi",
     "representation": "api_json",
@@ -94,6 +102,8 @@
   {
     "dataset_key": "store_one",
     "name": "단일상가 조회 (Store One)",
+    "tags": ["retail", "business", "store"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeOne",
     "representation": "api_json",
@@ -146,6 +156,8 @@
   {
     "dataset_key": "store_building",
     "name": "건물상가 조회 (Store in Building)",
+    "tags": ["retail", "business", "store"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeListInBuilding",
     "representation": "api_json",
@@ -198,6 +210,8 @@
   {
     "dataset_key": "store_pnu",
     "name": "지번상가 조회 (Store in PNU)",
+    "tags": ["retail", "business", "store"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeListInPnu",
     "representation": "api_json",
@@ -250,6 +264,8 @@
   {
     "dataset_key": "store_dong",
     "name": "행정동상가 조회 (Store in Dong)",
+    "tags": ["retail", "business", "store"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeListInDong",
     "representation": "api_json",
@@ -302,6 +318,8 @@
   {
     "dataset_key": "store_area",
     "name": "상권상가 조회 (Store in Area)",
+    "tags": ["retail", "business", "store"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeListInArea",
     "representation": "api_json",
@@ -354,6 +372,8 @@
   {
     "dataset_key": "store_radius",
     "name": "반경상가 조회 (Store Radius)",
+    "tags": ["retail", "business", "store"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeListInRadius",
     "representation": "api_json",
@@ -406,6 +426,8 @@
   {
     "dataset_key": "store_rect",
     "name": "사각형상가 조회 (Store Rectangle)",
+    "tags": ["retail", "business", "store"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeListInRectangle",
     "representation": "api_json",
@@ -458,6 +480,8 @@
   {
     "dataset_key": "store_polygon",
     "name": "다각형상가 조회 (Store Polygon)",
+    "tags": ["retail", "business", "store"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeListInPolygon",
     "representation": "api_json",
@@ -510,6 +534,8 @@
   {
     "dataset_key": "store_upjong",
     "name": "업종별상가 조회 (Store by Upjong)",
+    "tags": ["retail", "industry-code", "classification"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeListInUpjong",
     "representation": "api_json",
@@ -562,6 +588,8 @@
   {
     "dataset_key": "store_date",
     "name": "수정일자상가 조회 (Store by Date)",
+    "tags": ["retail", "business", "history"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "storeListByDate",
     "representation": "api_json",
@@ -614,6 +642,8 @@
   {
     "dataset_key": "upjong_large",
     "name": "업종대분류 조회 (Upjong Large)",
+    "tags": ["retail", "industry-code", "classification"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "largeUpjongList",
     "representation": "api_json",
@@ -629,6 +659,8 @@
   {
     "dataset_key": "upjong_middle",
     "name": "업종중분류 조회 (Upjong Middle)",
+    "tags": ["retail", "industry-code", "classification"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "middleUpjongList",
     "representation": "api_json",
@@ -646,6 +678,8 @@
   {
     "dataset_key": "upjong_small",
     "name": "업종소분류 조회 (Upjong Small)",
+    "tags": ["retail", "industry-code", "classification"],
+    "source_url": "https://www.data.go.kr",
     "base_url": "http://apis.data.go.kr/B553077/api/open/sdsc2",
     "default_operation": "smallUpjongList",
     "representation": "api_json",

--- a/src/kpubdata/providers/seoul/catalogue.json
+++ b/src/kpubdata/providers/seoul/catalogue.json
@@ -6,6 +6,8 @@
     "default_operation": "realtimeStationArrival",
     "representation": "api_json",
     "description": "Real-time subway arrival information for Seoul Metro stations",
+    "tags": ["transportation", "subway", "realtime"],
+    "source_url": "https://data.seoul.go.kr/",
     "operations": ["list", "raw"],
     "query_support": {"pagination": "index", "max_page_size": 1000},
     "required_path_params": ["stationName"]
@@ -17,6 +19,8 @@
     "default_operation": "tbCycleRentUseMonthInfo",
     "representation": "api_json",
     "description": "Seoul public bicycle (Ttareungi) monthly usage statistics",
+    "tags": ["transportation", "bicycle", "monthly"],
+    "source_url": "https://data.seoul.go.kr/",
     "operations": ["list", "raw"],
     "query_support": {"pagination": "index", "max_page_size": 1000},
     "required_path_params": ["RENT_NM"]

--- a/src/kpubdata/providers/sgis/catalogue.json
+++ b/src/kpubdata/providers/sgis/catalogue.json
@@ -2,6 +2,8 @@
   {
     "dataset_key": "boundary.sido",
     "name": "시도 행정구역 경계 (SGIS)",
+    "tags": ["gis", "boundary", "region"],
+    "source_url": "https://sgis.kostat.go.kr/developer/html/main.html",
     "representation": "api_json",
     "operations": ["list", "raw", "schema"],
     "endpoint": "boundary/hadmarea.geojson",
@@ -20,6 +22,8 @@
   {
     "dataset_key": "boundary.sigungu",
     "name": "시군구 행정구역 경계 (SGIS)",
+    "tags": ["gis", "boundary", "region"],
+    "source_url": "https://sgis.kostat.go.kr/developer/html/main.html",
     "representation": "api_json",
     "operations": ["list", "raw", "schema"],
     "endpoint": "boundary/hadmarea.geojson",
@@ -38,6 +42,8 @@
   {
     "dataset_key": "boundary.emd",
     "name": "읍면동 행정구역 경계 (SGIS)",
+    "tags": ["gis", "boundary", "region"],
+    "source_url": "https://sgis.kostat.go.kr/developer/html/main.html",
     "representation": "api_json",
     "operations": ["list", "raw", "schema"],
     "endpoint": "boundary/hadmarea.geojson",

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -78,6 +78,35 @@ class TestDatasetRef:
         assert "test.dataset" in r
         assert "test" in r
 
+    def test_metadata_defaults(self) -> None:
+        ref = self._make_ref()
+        assert ref.description is None
+        assert ref.tags == ()
+        assert ref.source_url is None
+
+    def test_metadata_populated(self) -> None:
+        ref = self._make_ref(
+            description="Weather forecast data",
+            tags=("weather", "forecast"),
+            source_url="https://data.go.kr/example",
+        )
+        assert ref.description == "Weather forecast data"
+        assert ref.tags == ("weather", "forecast")
+        assert ref.source_url == "https://data.go.kr/example"
+
+    def test_metadata_frozen(self) -> None:
+        ref = self._make_ref(description="test", tags=("a",), source_url="http://x")
+        try:
+            ref.description = "changed"  # type: ignore[misc]
+            raise AssertionError("Should be frozen")
+        except AttributeError:
+            pass
+        try:
+            ref.tags = ("b",)  # type: ignore[misc]
+            raise AssertionError("Should be frozen")
+        except AttributeError:
+            pass
+
 
 class TestQuery:
     def test_defaults(self) -> None:

--- a/tests/unit/test_catalogue_validation.py
+++ b/tests/unit/test_catalogue_validation.py
@@ -111,3 +111,98 @@ def test_valid_provider_catalogues_pass_validation(package_name: str, provider: 
 
     assert datasets
     assert all(dataset.provider == provider for dataset in datasets)
+
+
+class TestBuildDatasetRefMetadata:
+    def test_description_parsed(self) -> None:
+        ref = build_dataset_ref(
+            "test",
+            {
+                "dataset_key": "s",
+                "name": "S",
+                "representation": "api_json",
+                "description": "A test dataset",
+            },
+        )
+        assert ref.description == "A test dataset"
+        assert "description" not in ref.raw_metadata
+
+    def test_description_empty_string_becomes_none(self) -> None:
+        ref = build_dataset_ref(
+            "test",
+            {"dataset_key": "s", "name": "S", "representation": "api_json", "description": ""},
+        )
+        assert ref.description is None
+
+    def test_description_absent_is_none(self) -> None:
+        ref = build_dataset_ref(
+            "test",
+            {"dataset_key": "s", "name": "S", "representation": "api_json"},
+        )
+        assert ref.description is None
+
+    def test_tags_parsed(self) -> None:
+        ref = build_dataset_ref(
+            "test",
+            {
+                "dataset_key": "s",
+                "name": "S",
+                "representation": "api_json",
+                "tags": ["weather", "forecast"],
+            },
+        )
+        assert ref.tags == ("weather", "forecast")
+        assert "tags" not in ref.raw_metadata
+
+    def test_tags_absent_is_empty(self) -> None:
+        ref = build_dataset_ref(
+            "test",
+            {"dataset_key": "s", "name": "S", "representation": "api_json"},
+        )
+        assert ref.tags == ()
+
+    def test_tags_filters_non_strings(self) -> None:
+        ref = build_dataset_ref(
+            "test",
+            {
+                "dataset_key": "s",
+                "name": "S",
+                "representation": "api_json",
+                "tags": ["valid", 123, None, "also_valid"],
+            },
+        )
+        assert ref.tags == ("valid", "also_valid")
+
+    def test_source_url_parsed(self) -> None:
+        ref = build_dataset_ref(
+            "test",
+            {
+                "dataset_key": "s",
+                "name": "S",
+                "representation": "api_json",
+                "source_url": "https://data.go.kr/example",
+            },
+        )
+        assert ref.source_url == "https://data.go.kr/example"
+        assert "source_url" not in ref.raw_metadata
+
+    def test_source_url_absent_is_none(self) -> None:
+        ref = build_dataset_ref(
+            "test",
+            {"dataset_key": "s", "name": "S", "representation": "api_json"},
+        )
+        assert ref.source_url is None
+
+    def test_existing_description_removed_from_raw_metadata(self) -> None:
+        ref = build_dataset_ref(
+            "test",
+            {
+                "dataset_key": "s",
+                "name": "S",
+                "representation": "api_json",
+                "description": "test",
+                "base_url": "http://example.com",
+            },
+        )
+        assert "description" not in ref.raw_metadata
+        assert "base_url" in ref.raw_metadata

--- a/uv.lock
+++ b/uv.lock
@@ -462,7 +462,7 @@ wheels = [
 
 [[package]]
 name = "kpubdata"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- `DatasetRef`에 `description`, `tags`, `source_url` 3개 optional 메타데이터 필드 추가
- `build_dataset_ref()`에서 catalogue.json → DatasetRef 변환 시 새 필드 자동 파싱 (description은 raw_metadata에서 canonical 필드로 승격)
- 9개 provider catalogue.json에 `tags`와 `source_url` 전수 추가
- 단위 테스트 12개 추가 (필드 파싱, 기본값, immutability, raw_metadata 분리)
- `CANONICAL_MODEL.md`, `API_SPEC.md` 문서 업데이트

## Changes
### Core model (`src/kpubdata/core/models.py`)
- `DatasetRef.description: str | None = None`
- `DatasetRef.tags: tuple[str, ...] = ()`
- `DatasetRef.source_url: str | None = None`

### Catalogue parser (`src/kpubdata/providers/_common.py`)
- `build_dataset_ref()`: description/tags/source_url을 canonical 필드로 추출, raw_metadata에서 제외

### Provider catalogues (9 files)
- 모든 dataset entry에 `tags` (2-4개 영어 키워드)와 `source_url` 추가

### Tests
- `test_models.py`: 3 tests (defaults, populated, frozen)
- `test_catalogue_validation.py`: 9 tests (parsing, edge cases, raw_metadata 분리)

## Quality gates
- ✅ 765 passed, 1 skipped
- ✅ mypy clean (40 source files)
- ✅ ruff check + format clean
- ✅ build success

Closes #55