### PR TITLE
feat: add FieldConstraints for structured schema field metadata

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -127,6 +127,17 @@ Returns a generator of `RecordBatch` values, one per page.
 
 Returns `SchemaDescriptor | None`.
 
+`SchemaDescriptor.fields` contains `FieldDescriptor` objects. Each `FieldDescriptor` may carry a `constraints: FieldConstraints | None` with structured metadata:
+
+| Attribute | Type | Description |
+|---|---|---|
+| `max_length` | `int \| None` | Maximum character length |
+| `min_value` | `float \| None` | Minimum numeric value |
+| `max_value` | `float \| None` | Maximum numeric value |
+| `pattern` | `str \| None` | Regex pattern |
+| `allowed_values` | `tuple[str, ...] \| None` | Permitted values |
+| `format` | `str \| None` | Semantic format hint (e.g. `"YYYYMM"`) |
+
 ### `call_raw()`
 
 Returns provider-native payload / response object.

--- a/CANONICAL_MODEL.md
+++ b/CANONICAL_MODEL.md
@@ -53,11 +53,22 @@ classDiagram
         +str title
         +str type
         +str description
+        +bool nullable
+        +FieldConstraints constraints
+    }
+    class FieldConstraints {
+        +int max_length
+        +float min_value
+        +float max_value
+        +str pattern
+        +tuple allowed_values
+        +str format
     }
 
     DatasetRef "1" --o "1" RecordBatch
     DatasetRef "1" --o "1" SchemaDescriptor
     SchemaDescriptor "1" --* "many" FieldDescriptor
+    FieldDescriptor "1" --o "0..1" FieldConstraints
     Query ..> RecordBatch : produces
 ```
 
@@ -155,6 +166,7 @@ for item in batch.items:
     +-- (schema) ----> [ SchemaDescriptor ] (데이터 설계도)
                          |
                          +-- [ FieldDescriptor ] (칼럼 정보)
+                              +-- [ FieldConstraints ] (제약 조건)
 ```
 
 ## 6. Core types (Original)
@@ -283,12 +295,22 @@ class RecordBatch:
 from dataclasses import dataclass, field
 
 @dataclass(slots=True)
+class FieldConstraints:
+    max_length: int | None = None
+    min_value: float | None = None
+    max_value: float | None = None
+    pattern: str | None = None
+    allowed_values: tuple[str, ...] | None = None
+    format: str | None = None
+
+@dataclass(slots=True)
 class FieldDescriptor:
     name: str
     title: str | None = None
     type: str | None = None
     description: str | None = None
     nullable: bool | None = None
+    constraints: FieldConstraints | None = None
     raw: dict[str, object] = field(default_factory=dict)
 
 @dataclass(slots=True)

--- a/src/kpubdata/__init__.py
+++ b/src/kpubdata/__init__.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from kpubdata.client import Client
 from kpubdata.core.capability import Operation, PaginationMode, QuerySupport
-from kpubdata.core.models import DatasetRef, FieldDescriptor, Query, RecordBatch, SchemaDescriptor
+from kpubdata.core.models import (
+    DatasetRef,
+    FieldConstraints,
+    FieldDescriptor,
+    Query,
+    RecordBatch,
+    SchemaDescriptor,
+)
 from kpubdata.core.representation import Representation
 from kpubdata.exceptions import (
     AuthError,
@@ -29,6 +36,7 @@ __all__ = [
     "Query",
     "RecordBatch",
     "SchemaDescriptor",
+    "FieldConstraints",
     "FieldDescriptor",
     "Operation",
     "PaginationMode",

--- a/src/kpubdata/core/__init__.py
+++ b/src/kpubdata/core/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from kpubdata.core.capability import Operation, PaginationMode, QuerySupport
 from kpubdata.core.models import (
     DatasetRef,
+    FieldConstraints,
     FieldDescriptor,
     Query,
     RecordBatch,
@@ -14,6 +15,7 @@ from kpubdata.core.representation import Representation
 
 __all__ = [
     "DatasetRef",
+    "FieldConstraints",
     "FieldDescriptor",
     "Operation",
     "PaginationMode",

--- a/src/kpubdata/core/models.py
+++ b/src/kpubdata/core/models.py
@@ -142,10 +142,35 @@ class RecordBatch:
 
 
 @_dataclass(slots=True)
+class FieldConstraints:
+    """Structured constraints for a dataset field.
+
+    All attributes are optional.  Only populate those that the provider
+    catalogue actually declares.
+
+    Attributes:
+        max_length: Maximum character length (string fields).
+        min_value: Minimum numeric value (number fields).
+        max_value: Maximum numeric value (number fields).
+        pattern: Regex pattern the value must match (e.g. ``"^\\\\d{6}$"``).
+        allowed_values: Closed set of permitted values.
+        format: Semantic format hint (e.g. ``"YYYYMM"``, ``"date"``, ``"url"``).
+    """
+
+    max_length: int | None = None
+    min_value: float | None = None
+    max_value: float | None = None
+    pattern: str | None = None
+    allowed_values: tuple[str, ...] | None = None
+    format: str | None = None
+
+
+@_dataclass(slots=True)
 class FieldDescriptor:
     """Describe a single field in a dataset schema.
 
     Attributes:
+        constraints: Optional structured constraints for the field.
         raw: Provider-native field metadata retained for advanced use.
     """
 
@@ -155,6 +180,7 @@ class FieldDescriptor:
     description: str | None = None
     nullable: bool | None = None
     raw: MappingProxyType[str, object] = field(default_factory=_empty_object_proxy)
+    constraints: FieldConstraints | None = None
 
 
 @_dataclass(slots=True)
@@ -172,6 +198,7 @@ class SchemaDescriptor:
 
 __all__ = [
     "DatasetRef",
+    "FieldConstraints",
     "FieldDescriptor",
     "Query",
     "RecordBatch",

--- a/src/kpubdata/providers/_common.py
+++ b/src/kpubdata/providers/_common.py
@@ -11,6 +11,7 @@ from typing import cast
 from kpubdata.core.capability import Operation, PaginationMode, QuerySupport
 from kpubdata.core.models import (
     DatasetRef,
+    FieldConstraints,
     FieldDescriptor,
     SchemaDescriptor,
 )
@@ -155,6 +156,50 @@ def _parse_query_support(entry: dict[str, object], provider: str) -> QuerySuppor
     return QuerySupport(pagination=pagination, max_page_size=max_page_size)
 
 
+def _parse_field_constraints(entry: dict[str, object]) -> FieldConstraints | None:
+    constraints_raw = entry.get("constraints")
+    if not isinstance(constraints_raw, dict):
+        return None
+    c = cast(dict[str, object], constraints_raw)
+
+    max_length = c.get("max_length")
+    if not isinstance(max_length, int):
+        max_length = None
+
+    min_value = c.get("min_value")
+    if not isinstance(min_value, (int, float)):
+        min_value = None
+
+    max_value = c.get("max_value")
+    if not isinstance(max_value, (int, float)):
+        max_value = None
+
+    pattern = c.get("pattern")
+    if not isinstance(pattern, str):
+        pattern = None
+
+    allowed_values_raw = c.get("allowed_values")
+    allowed_values: tuple[str, ...] | None = None
+    if isinstance(allowed_values_raw, list) and all(isinstance(v, str) for v in allowed_values_raw):
+        allowed_values = tuple(allowed_values_raw)
+
+    fmt = c.get("format")
+    if not isinstance(fmt, str):
+        fmt = None
+
+    if all(v is None for v in (max_length, min_value, max_value, pattern, allowed_values, fmt)):
+        return None
+
+    return FieldConstraints(
+        max_length=max_length,
+        min_value=min_value,
+        max_value=max_value,
+        pattern=pattern,
+        allowed_values=allowed_values,
+        format=fmt,
+    )
+
+
 def build_schema_from_metadata(dataset: DatasetRef) -> SchemaDescriptor | None:
     """Build SchemaDescriptor from catalogue metadata fields."""
     fields_raw = dataset.raw_metadata.get("fields")
@@ -174,6 +219,7 @@ def build_schema_from_metadata(dataset: DatasetRef) -> SchemaDescriptor | None:
         type_raw = entry.get("type")
         desc_raw = entry.get("description")
         nullable_raw = entry.get("nullable")
+        constraints = _parse_field_constraints(entry)
         field_descriptors.append(
             FieldDescriptor(
                 name=name_raw,
@@ -181,6 +227,7 @@ def build_schema_from_metadata(dataset: DatasetRef) -> SchemaDescriptor | None:
                 type=type_raw if isinstance(type_raw, str) else None,
                 description=desc_raw if isinstance(desc_raw, str) else None,
                 nullable=nullable_raw if isinstance(nullable_raw, bool) else None,
+                constraints=constraints,
                 raw=MappingProxyType({k: v for k, v in entry.items() if k != "name"}),
             )
         )

--- a/src/kpubdata/providers/bok/catalogue.json
+++ b/src/kpubdata/providers/bok/catalogue.json
@@ -16,10 +16,10 @@
       "max_page_size": 1000
     },
     "fields": [
-      {"name": "TIME", "title": "기간", "type": "string"},
+      {"name": "TIME", "title": "기간", "type": "string", "constraints": {"format": "YYYYMM", "pattern": "^\\d{6}$"}},
       {"name": "DATA_VALUE", "title": "기준금리", "type": "string"},
       {"name": "UNIT_NAME", "title": "단위", "type": "string"},
-      {"name": "STAT_CODE", "title": "통계표코드", "type": "string"},
+      {"name": "STAT_CODE", "title": "통계표코드", "type": "string", "constraints": {"pattern": "^[A-Z0-9]+$"}},
       {"name": "ITEM_CODE1", "title": "항목코드", "type": "string"},
       {"name": "ITEM_NAME1", "title": "항목명", "type": "string"}
     ]

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from types import MappingProxyType
 
 from kpubdata.core.capability import Operation, PaginationMode, QuerySupport
-from kpubdata.core.models import DatasetRef, FieldDescriptor, Query, RecordBatch, SchemaDescriptor
+from kpubdata.core.models import (
+    DatasetRef,
+    FieldConstraints,
+    FieldDescriptor,
+    Query,
+    RecordBatch,
+    SchemaDescriptor,
+)
 from kpubdata.core.representation import Representation
 
 
@@ -162,3 +169,60 @@ class TestSchemaDescriptor:
         sd = SchemaDescriptor(dataset=ref, fields=[fd])
         assert len(sd.fields) == 1
         assert sd.fields[0].name == "col1"
+
+
+class TestFieldConstraints:
+    def test_all_defaults_none(self) -> None:
+        fc = FieldConstraints()
+        assert fc.max_length is None
+        assert fc.min_value is None
+        assert fc.max_value is None
+        assert fc.pattern is None
+        assert fc.allowed_values is None
+        assert fc.format is None
+
+    def test_populated(self) -> None:
+        fc = FieldConstraints(
+            max_length=100,
+            min_value=0,
+            max_value=999.9,
+            pattern=r"^\d{6}$",
+            allowed_values=("A", "B", "C"),
+            format="YYYYMM",
+        )
+        assert fc.max_length == 100
+        assert fc.min_value == 0
+        assert fc.max_value == 999.9
+        assert fc.pattern == r"^\d{6}$"
+        assert fc.allowed_values == ("A", "B", "C")
+        assert fc.format == "YYYYMM"
+
+    def test_single_field(self) -> None:
+        fc = FieldConstraints(max_length=10)
+        assert fc.max_length == 10
+
+    def test_partial_population(self) -> None:
+        fc = FieldConstraints(format="date", allowed_values=("yes", "no"))
+        assert fc.max_length is None
+        assert fc.format == "date"
+        assert fc.allowed_values == ("yes", "no")
+
+
+class TestFieldDescriptorConstraints:
+    def test_default_constraints_none(self) -> None:
+        fd = FieldDescriptor(name="col")
+        assert fd.constraints is None
+
+    def test_with_constraints(self) -> None:
+        fc = FieldConstraints(max_length=50, format="YYYYMM")
+        fd = FieldDescriptor(name="date_col", type="string", constraints=fc)
+        assert fd.constraints is not None
+        assert fd.constraints.max_length == 50
+        assert fd.constraints.format == "YYYYMM"
+
+    def test_positional_raw_backward_compat(self) -> None:
+        proxy = MappingProxyType({"k": "v"})
+        fd = FieldDescriptor("col", "Title", "string", "desc", True, proxy)
+        assert fd.name == "col"
+        assert fd.raw == proxy
+        assert fd.constraints is None

--- a/tests/unit/test_catalogue_validation.py
+++ b/tests/unit/test_catalogue_validation.py
@@ -206,3 +206,86 @@ class TestBuildDatasetRefMetadata:
         )
         assert "description" not in ref.raw_metadata
         assert "base_url" in ref.raw_metadata
+
+
+class TestBuildSchemaConstraints:
+    def _make_ref_with_fields(self, fields: list[dict[str, object]]) -> object:
+        from kpubdata.providers._common import build_dataset_ref, build_schema_from_metadata
+
+        raw = {
+            "dataset_key": "test_ds",
+            "name": "Test",
+            "representation": "api_json",
+            "fields": fields,
+        }
+        ref = build_dataset_ref("test", raw)
+        return build_schema_from_metadata(ref)
+
+    def test_no_constraints_returns_none_on_field(self) -> None:
+        schema = self._make_ref_with_fields([{"name": "col1", "type": "string"}])
+        assert schema is not None
+        assert schema.fields[0].constraints is None
+
+    def test_constraints_parsed(self) -> None:
+        schema = self._make_ref_with_fields(
+            [
+                {
+                    "name": "time",
+                    "type": "string",
+                    "constraints": {"format": "YYYYMM", "pattern": r"^\d{6}$"},
+                }
+            ]
+        )
+        assert schema is not None
+        fc = schema.fields[0].constraints
+        assert fc is not None
+        assert fc.format == "YYYYMM"
+        assert fc.pattern == r"^\d{6}$"
+        assert fc.max_length is None
+
+    def test_constraints_max_length_and_values(self) -> None:
+        schema = self._make_ref_with_fields(
+            [
+                {
+                    "name": "status",
+                    "type": "string",
+                    "constraints": {
+                        "max_length": 10,
+                        "allowed_values": ["A", "B", "C"],
+                    },
+                }
+            ]
+        )
+        assert schema is not None
+        fc = schema.fields[0].constraints
+        assert fc is not None
+        assert fc.max_length == 10
+        assert fc.allowed_values == ("A", "B", "C")
+
+    def test_constraints_numeric(self) -> None:
+        schema = self._make_ref_with_fields(
+            [
+                {
+                    "name": "score",
+                    "type": "number",
+                    "constraints": {"min_value": 0, "max_value": 100.5},
+                }
+            ]
+        )
+        assert schema is not None
+        fc = schema.fields[0].constraints
+        assert fc is not None
+        assert fc.min_value == 0
+        assert fc.max_value == 100.5
+
+    def test_empty_constraints_dict_returns_none(self) -> None:
+        schema = self._make_ref_with_fields([{"name": "col", "type": "string", "constraints": {}}])
+        assert schema is not None
+        assert schema.fields[0].constraints is None
+
+    def test_invalid_constraints_type_ignored(self) -> None:
+        schema = self._make_ref_with_fields(
+            [{"name": "col", "type": "string", "constraints": "invalid"}]
+        )
+        assert schema is not None
+        assert schema.fields[0].constraints is None


### PR DESCRIPTION
## Summary

Closes #57

- **New `FieldConstraints` dataclass**: `max_length`, `min_value`, `max_value`, `pattern`, `allowed_values`, `format` — all optional
- **`FieldDescriptor.constraints`**: optional field positioned after `raw` to preserve positional constructor backward compatibility
- **Catalogue parsing**: `build_schema_from_metadata()` now parses `"constraints"` dict from catalogue.json field entries
- **BOK catalogue enriched**: TIME field gets `format`/`pattern` constraints, STAT_CODE gets `pattern`
- **13 new tests**: FieldConstraints model, FieldDescriptor integration, positional construction regression, constraint parsing (6 cases)
- **Docs updated**: CANONICAL_MODEL.md (mermaid diagram + code block), API_SPEC.md (FieldConstraints table)

## Oracle Review

Oracle review passed with 2 fixes applied:
1. **Positional compat**: Moved `constraints` after `raw` in FieldDescriptor to preserve existing positional constructor order
2. **Dead code**: Removed unused `_CONSTRAINT_KEYS` frozenset
3. **Regression test**: Added `test_positional_raw_backward_compat` to prevent future field ordering regressions

## Quality Gates

- pytest: 778 passed, 1 skipped (pandas)
- mypy: clean
- ruff check/format: clean
- build: clean