### PR TITLE
feat: catalog-level fuzzy search for robust discovery (#63)

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -48,9 +48,23 @@ client = Client.from_env()
 
 ```python
 client.datasets.list()
-client.datasets.search("지하철")
+client.datasets.list(provider="datago")
+client.datasets.search("예보")
+client.datasets.search("forecast", provider="weather")
+client.datasets.search("weathr", threshold=0.5)  # fuzzy match
 client.dataset("molit.apartment_trades")
 ```
+
+### Search behavior
+
+`search(text, *, provider=None, threshold=0.5)` scores each dataset against
+*text* using substring and fuzzy matching across **name**, **description**,
+**tags**, and **id**.  Results are returned in descending relevance order.
+
+- **Exact substring** match in any field → score 1.0 (always included).
+- **Fuzzy match** via `difflib.SequenceMatcher` → included if score ≥ *threshold*.
+- **threshold** default is `0.5`.  Raise it (e.g. `0.8`) for stricter results,
+  lower it (e.g. `0.2`) for broader recall.
 
 Each `DatasetRef` returned by discovery exposes:
 - `id`, `provider`, `dataset_key`, `name`, `representation`, `operations`

--- a/src/kpubdata/catalog.py
+++ b/src/kpubdata/catalog.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import builtins
 import logging
+import unicodedata
+from difflib import SequenceMatcher
 from typing import cast
 
 from kpubdata.core.models import DatasetRef
@@ -12,6 +14,50 @@ from kpubdata.exceptions import DatasetNotFoundError, ProviderNotRegisteredError
 from kpubdata.registry import ProviderRegistry
 
 logger = logging.getLogger("kpubdata.catalog")
+
+# Minimum relevance score (0.0–1.0) for a dataset to appear in search results.
+_DEFAULT_SCORE_THRESHOLD = 0.5
+
+
+def _normalize(text: str) -> str:
+    """NFC-normalize, strip, and casefold a string for search comparison."""
+    return unicodedata.normalize("NFC", text).strip().casefold()
+
+
+def _score_dataset(needle: str, dataset: DatasetRef) -> float:
+    """Score a dataset against a search term.
+
+    Returns a relevance score between 0.0 and 1.0.  An exact substring
+    match in any searchable field yields 1.0.  Otherwise the best
+    ``SequenceMatcher`` ratio across fields is returned.
+
+    Searchable fields: name, description, tags, id.
+    """
+    needle_lower = _normalize(needle)
+    if not needle_lower:
+        return 1.0
+
+    fields: builtins.list[str] = []
+    fields.append(_normalize(dataset.name))
+    if dataset.description:
+        fields.append(_normalize(dataset.description))
+    for tag in dataset.tags:
+        fields.append(_normalize(tag))
+    fields.append(_normalize(dataset.id))
+
+    # Fast path: exact substring match → score 1.0
+    for text in fields:
+        if needle_lower in text:
+            return 1.0
+
+    # Slow path: fuzzy matching via SequenceMatcher
+    best: float = 0.0
+    for text in fields:
+        ratio = SequenceMatcher(None, needle_lower, text).ratio()
+        if ratio > best:
+            best = ratio
+
+    return best
 
 
 class Catalog:
@@ -49,11 +95,17 @@ class Catalog:
         )
         return datasets
 
-    def search(self, text: str, *, provider: str | None = None) -> builtins.list[DatasetRef]:
-        """Search datasets by delegating to each adapter's search logic.
+    def search(
+        self,
+        text: str,
+        *,
+        provider: str | None = None,
+        threshold: float = _DEFAULT_SCORE_THRESHOLD,
+    ) -> builtins.list[DatasetRef]:
+        """Search datasets with fuzzy matching across name, description, tags, and id.
 
-        Each adapter implements its own ``search_datasets(text)`` method,
-        allowing provider-specific search semantics.
+        Results are scored by relevance and returned in descending order.
+        Only datasets whose score meets *threshold* (0.0–1.0) are included.
 
         Raises:
             ProviderNotRegisteredError: If ``provider`` is given but unknown.
@@ -61,24 +113,28 @@ class Catalog:
 
         logger.debug(
             "Catalog search",
-            extra={"text": text, "provider_filter": provider},
+            extra={"text": text, "provider_filter": provider, "threshold": threshold},
         )
-        if provider is not None:
-            adapter = self._get_adapter(provider)
-            provider_results = adapter.search_datasets(text)
-            logger.debug(
-                "Catalog search result",
-                extra={"provider": provider, "text": text, "count": len(provider_results)},
-            )
-            return provider_results
+        candidates = self.list(provider=provider)
 
-        results: builtins.list[DatasetRef] = []
-        for provider_name in self._registry:
-            adapter = self._get_adapter(provider_name)
-            results.extend(adapter.search_datasets(text))
+        scored: builtins.list[tuple[float, DatasetRef]] = []
+        for dataset in candidates:
+            score = _score_dataset(text, dataset)
+            if score >= threshold:
+                scored.append((score, dataset))
+
+        # Sort by score descending, then by id for stable ordering
+        scored.sort(key=lambda pair: (-pair[0], pair[1].id))
+        results = [dataset for _, dataset in scored]
+
         logger.debug(
             "Catalog search result",
-            extra={"provider": None, "text": text, "count": len(results)},
+            extra={
+                "provider": provider,
+                "text": text,
+                "candidates": len(candidates),
+                "count": len(results),
+            },
         )
         return results
 

--- a/tests/integration/test_client_flow.py
+++ b/tests/integration/test_client_flow.py
@@ -98,8 +98,8 @@ def test_register_and_search_datasets() -> None:
 
     refs = client.datasets.search("weather")
 
-    assert len(refs) == 1
-    assert refs[0].id == "fake.weather"
+    matched_ids = {ref.id for ref in refs}
+    assert "fake.weather" in matched_ids
 
 
 def test_dataset_resolves_to_bound_dataset() -> None:

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -133,3 +133,185 @@ class TestCatalog:
         catalog = self._build()
         with pytest.raises(DatasetNotFoundError):
             _ = catalog.resolve("alpha.nonexistent")
+
+
+class TestCatalogFuzzySearch:
+    """Tests for catalog-level fuzzy search across name, description, tags, and id."""
+
+    @staticmethod
+    def _make_rich_ref(
+        provider: str,
+        key: str,
+        name: str,
+        *,
+        description: str | None = None,
+        tags: tuple[str, ...] = (),
+    ) -> DatasetRef:
+        return DatasetRef(
+            id=f"{provider}.{key}",
+            provider=provider,
+            dataset_key=key,
+            name=name,
+            representation=Representation.API_JSON,
+            operations=frozenset({Operation.LIST}),
+            description=description,
+            tags=tags,
+        )
+
+    def _build_rich(self) -> Catalog:
+        reg = ProviderRegistry()
+        reg.register(
+            StubAdapter(
+                "weather",
+                [
+                    self._make_rich_ref(
+                        "weather",
+                        "village_fcst",
+                        "동네예보",
+                        description="기상청 단기예보 조회 서비스",
+                        tags=("weather", "forecast", "기상"),
+                    ),
+                    self._make_rich_ref(
+                        "weather",
+                        "air_quality",
+                        "대기오염정보",
+                        description="한국환경공단 대기질 정보",
+                        tags=("air", "pollution", "환경"),
+                    ),
+                ],
+            )
+        )
+        reg.register(
+            StubAdapter(
+                "finance",
+                [
+                    self._make_rich_ref(
+                        "finance",
+                        "base_rate",
+                        "기준금리",
+                        description="한국은행 기준금리 조회",
+                        tags=("economy", "interest-rate", "금리"),
+                    ),
+                ],
+            )
+        )
+        return Catalog(reg)
+
+    def test_search_by_description(self) -> None:
+        catalog = self._build_rich()
+        result = catalog.search("기상청")
+        assert len(result) == 1
+        assert result[0].dataset_key == "village_fcst"
+
+    def test_search_by_tag(self) -> None:
+        catalog = self._build_rich()
+        result = catalog.search("pollution")
+        assert len(result) == 1
+        assert result[0].dataset_key == "air_quality"
+
+    def test_search_by_korean_tag(self) -> None:
+        catalog = self._build_rich()
+        result = catalog.search("금리")
+        assert len(result) == 1
+        assert result[0].dataset_key == "base_rate"
+
+    def test_search_by_id_substring(self) -> None:
+        catalog = self._build_rich()
+        result = catalog.search("base_rate")
+        assert len(result) >= 1
+        assert result[0].dataset_key == "base_rate"
+
+    def test_search_partial_name(self) -> None:
+        catalog = self._build_rich()
+        result = catalog.search("예보")
+        assert len(result) == 1
+        assert result[0].dataset_key == "village_fcst"
+
+    def test_search_sorted_by_relevance(self) -> None:
+        catalog = self._build_rich()
+        result = catalog.search("대기")
+        assert len(result) >= 1
+        assert result[0].dataset_key == "air_quality"
+
+    def test_search_custom_threshold(self) -> None:
+        catalog = self._build_rich()
+        strict = catalog.search("weathr", threshold=0.9)
+        lenient = catalog.search("weathr", threshold=0.1)
+        assert len(lenient) >= len(strict)
+
+    def test_search_empty_string(self) -> None:
+        catalog = self._build_rich()
+        result = catalog.search("")
+        assert len(result) == 3
+
+    def test_search_provider_filter_with_fuzzy(self) -> None:
+        catalog = self._build_rich()
+        result = catalog.search("정보", provider="weather")
+        assert all(r.provider == "weather" for r in result)
+
+
+class TestScoreDataset:
+    """Direct unit tests for the _score_dataset helper."""
+
+    @staticmethod
+    def _ref(name: str, **kwargs: object) -> DatasetRef:
+        return DatasetRef(
+            id="test.ds",
+            provider="test",
+            dataset_key="ds",
+            name=name,
+            representation=Representation.API_JSON,
+            **kwargs,  # type: ignore[arg-type]
+        )
+
+    def test_exact_substring_returns_one(self) -> None:
+        from kpubdata.catalog import _score_dataset
+
+        ref = self._ref("Hello World")
+        assert _score_dataset("hello", ref) == 1.0
+
+    def test_no_match_returns_low(self) -> None:
+        from kpubdata.catalog import _score_dataset
+
+        ref = self._ref("Hello World")
+        score = _score_dataset("zzzzzzzzz", ref)
+        assert score < 0.2
+
+    def test_description_match(self) -> None:
+        from kpubdata.catalog import _score_dataset
+
+        ref = self._ref("Short Name", description="A detailed description with keywords")
+        assert _score_dataset("keywords", ref) == 1.0
+
+    def test_tag_match(self) -> None:
+        from kpubdata.catalog import _score_dataset
+
+        ref = self._ref("Name", tags=("weather", "forecast"))
+        assert _score_dataset("forecast", ref) == 1.0
+
+    def test_case_insensitive(self) -> None:
+        from kpubdata.catalog import _score_dataset
+
+        ref = self._ref("Base Rate")
+        assert _score_dataset("BASE RATE", ref) == 1.0
+
+    def test_whitespace_only_returns_one(self) -> None:
+        from kpubdata.catalog import _score_dataset
+
+        ref = self._ref("Anything")
+        assert _score_dataset("   ", ref) == 1.0
+
+    def test_search_does_not_call_adapter_search_datasets(self) -> None:
+        """Catalog.search uses catalog-level scoring, not adapter delegation."""
+        from unittest.mock import MagicMock
+
+        adapter = StubAdapter("mock", [_make_ref("mock", "ds", "Mock Data")])
+        adapter.search_datasets = MagicMock(side_effect=AssertionError("should not be called"))  # type: ignore[method-assign]
+
+        reg = ProviderRegistry()
+        reg.register(adapter)
+        catalog = Catalog(reg)
+
+        result = catalog.search("Mock")
+        assert len(result) == 1
+        adapter.search_datasets.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #63

- Catalog.search를 어댑터 위임 방식에서 카탈로그 레벨 fuzzy 매칭으로 전환
- difflib.SequenceMatcher 기반 점수 산정 (name, description, tags, id 전 필드 검색)
- unicodedata.normalize(NFC) + strip() + casefold()로 한글 텍스트 정규화
- 관련도 점수 내림차순 정렬, threshold 파라미터로 정밀도 조절 가능 (기본값 0.5)
- 외부 의존성 없음 (stdlib만 사용)

## Changes

| File | Change |
|---|---|
| src/kpubdata/catalog.py | _normalize(), _score_dataset() 헬퍼 추가, Catalog.search 개선 |
| tests/unit/test_catalog.py | 16개 새 테스트 (fuzzy, tag, description, Korean, whitespace, regression) |
| tests/integration/test_client_flow.py | fuzzy 결과 반영하여 assertion 수정 |
| API_SPEC.md | search 동작 설명 및 threshold 파라미터 문서화 |

## Oracle Review

- threshold 0.4 -> 0.5 (false positive 감소)
- NFC 정규화 추가 (한글 자모 결합 이슈 방지)
- docstring priority order 오해 소지 문구 제거
- adapter search_datasets 미호출 regression 테스트 추가
- search_datasets protocol 제거는 별도 PR로 분리 예정

## Quality Gates

- ruff check . pass
- ruff format --check . pass
- mypy src pass
- pytest 794 passed
- python -m build pass