### PR TITLE
docs: cookbook guides and example scripts (#59)

### DIFF
--- a/docs/cookbook/discovery.md
+++ b/docs/cookbook/discovery.md
@@ -1,0 +1,84 @@
+# 데이터셋 검색하기
+
+사용 가능한 데이터셋을 찾고, 원하는 데이터를 빠르게 발견하는 방법을 안내합니다.
+
+## 왜 검색이 필요한가요?
+
+KPubData는 9개 기관에서 250개 이상의 데이터셋을 지원합니다.
+정확한 데이터셋 ID를 외울 필요 없이, 키워드로 검색하면 됩니다.
+
+## 전체 목록 보기
+
+```python
+from kpubdata import Client
+
+client = Client.from_env()
+
+for ds in client.datasets.list():
+    print(ds.id, ds.name)
+```
+
+## 기관별 필터링
+
+```python
+for ds in client.datasets.list(provider="datago"):
+    print(ds.id, ds.name)
+```
+
+사용 가능한 provider 이름: `datago`, `bok`, `kosis`, `lofin`, `localdata`, `semas`, `seoul`, `sgis`, `law`
+
+## 키워드 검색
+
+`search()`는 데이터셋의 이름, 설명, 태그, ID를 모두 검색합니다:
+
+```python
+results = client.datasets.search("예보")
+for ds in results:
+    print(ds.id, ds.name, ds.tags)
+```
+
+예상 출력:
+
+```
+datago.village_fcst 동네예보 ('weather', 'forecast', '기상')
+datago.ultra_srt_ncst 초단기실황 ('weather', 'realtime', '기상')
+```
+
+## 정밀도 조절 (threshold)
+
+검색 결과가 너무 많으면 `threshold`를 올려 엄격하게, 적으면 내려 느슨하게 조절합니다:
+
+```python
+# 엄격한 검색 (정확한 일치에 가까운 결과만)
+strict = client.datasets.search("기준금리", threshold=0.8)
+
+# 느슨한 검색 (오타 허용)
+loose = client.datasets.search("기준금리", threshold=0.3)
+```
+
+기본값은 `0.5`입니다.
+
+## 검색 결과 활용
+
+검색으로 찾은 `DatasetRef`는 다음 정보를 포함합니다:
+
+| 속성 | 설명 |
+|---|---|
+| `id` | 정규화된 데이터셋 ID (예: `bok.base_rate`) |
+| `name` | 데이터셋 이름 |
+| `description` | 설명 (없을 수 있음) |
+| `tags` | 분류 태그 |
+| `source_url` | 원본 API 문서 링크 |
+| `operations` | 지원 연산 (list, raw 등) |
+
+검색으로 ID를 알았으면 바로 데이터를 조회할 수 있습니다:
+
+```python
+ds = client.dataset("datago.village_fcst")
+result = ds.list(base_date="20250401", base_time="0500", nx="55", ny="127")
+```
+
+## 다음 단계
+
+- [시작하기](./getting-started.md) — 처음부터 데이터 조회까지
+- [Raw API 사용하기](./raw-access.md) — 정규화되지 않은 원본 호출

--- a/docs/cookbook/getting-started.md
+++ b/docs/cookbook/getting-started.md
@@ -1,0 +1,82 @@
+# 시작하기
+
+이 문서는 KPubData를 처음 사용하는 개발자를 위한 단계별 안내입니다.
+
+## 왜 이 가이드가 필요한가요?
+
+한국 공공데이터 API는 기관마다 인증 방식, 파라미터, 응답 형식이 모두 다릅니다.
+KPubData는 이 차이를 하나의 인터페이스로 통합해, 데이터셋 이름만 알면 바로 조회할 수 있게 합니다.
+
+## 준비물
+
+- Python 3.10 이상
+- API 키 (아래 참고)
+
+## Step 1: 설치
+
+```bash
+pip install kpubdata
+```
+
+## Step 2: API 키 설정
+
+가장 간단한 한국은행(BOK) 키부터 시작합니다.
+
+1. https://ecos.bok.or.kr/api/ 에서 인증키 신청
+2. 환경 변수 설정:
+
+```bash
+export KPUBDATA_BOK_API_KEY="발급받은_키"
+```
+
+## Step 3: 클라이언트 생성
+
+```python
+from kpubdata import Client
+
+client = Client.from_env()
+```
+
+또는 키를 직접 전달:
+
+```python
+client = Client(provider_keys={"bok": "발급받은_키"})
+```
+
+## Step 4: 데이터 조회
+
+```python
+ds = client.dataset("bok.base_rate")
+result = ds.list(start_date="202401", end_date="202406")
+
+for item in result.items:
+    print(f"{item['TIME']} — {item['DATA_VALUE']}%")
+```
+
+예상 출력:
+
+```
+202401 — 3.5%
+202402 — 3.5%
+202403 — 3.5%
+202404 — 3.5%
+202405 — 3.5%
+202406 — 3.5%
+```
+
+## Step 5: 스키마 확인
+
+데이터셋의 필드 구조를 확인할 수 있습니다:
+
+```python
+schema = ds.schema()
+if schema:
+    for field in schema.fields:
+        print(f"{field.name}: {field.type}")
+```
+
+## 다음 단계
+
+- [데이터셋 검색하기](./discovery.md) — 원하는 데이터를 찾는 방법
+- [Raw API 사용하기](./raw-access.md) — 원본 API 직접 호출
+- [CLI 사용법](../cli.md) — 터미널에서 바로 조회

--- a/docs/cookbook/raw-access.md
+++ b/docs/cookbook/raw-access.md
@@ -1,0 +1,67 @@
+# Raw API 사용하기
+
+정규화된 인터페이스 대신, 기관의 원본 API를 직접 호출하는 방법을 안내합니다.
+
+## 왜 Raw 호출이 필요한가요?
+
+KPubData의 `list()`, `schema()` 등은 기관마다 다른 파라미터를 표준화합니다.
+하지만 때로는 원본 API의 특수한 파라미터나 operation이 필요할 수 있습니다.
+
+`call_raw()`는 이런 경우를 위한 비상구(escape hatch)입니다.
+
+## 기본 사용법
+
+```python
+from kpubdata import Client
+
+client = Client.from_env()
+ds = client.dataset("datago.air_quality")
+
+raw = ds.call_raw(
+    "getCtprvnRltmMesureDnsty",
+    sidoName="서울",
+    numOfRows="5",
+)
+print(raw)
+```
+
+첫 번째 인자는 기관에서 정의한 operation 이름이고,
+나머지는 원본 API의 파라미터를 그대로 전달합니다.
+
+## 정규화 vs Raw 비교
+
+| | `list()` | `call_raw()` |
+|---|---|---|
+| 파라미터 | KPubData 표준 | 기관 원본 그대로 |
+| 반환값 | `RecordBatch` | 원본 응답 (dict/list) |
+| 페이지네이션 | 자동 (`list_all()`) | 직접 처리 |
+| 스키마 보장 | 있음 | 없음 |
+
+## Generic 엔드포인트 (datago)
+
+카탈로그에 등록되지 않은 data.go.kr API도 `datago.generic`으로 호출 가능합니다:
+
+```python
+ds = client.dataset("datago.generic")
+raw = ds.call_raw(
+    "getUltraSrtFcst",
+    _base_url="http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0",
+    base_date="20250401",
+    base_time="0600",
+    nx="55",
+    ny="127",
+)
+```
+
+## 언제 Raw를 쓰나요?
+
+- KPubData가 아직 정규화하지 않은 operation을 호출할 때
+- 원본 응답의 특정 필드를 확인해야 할 때
+- 디버깅 시 기관 API의 실제 응답을 보고 싶을 때
+
+일반적인 데이터 조회에는 `list()`를 권장합니다.
+
+## 다음 단계
+
+- [시작하기](./getting-started.md) — 처음부터 데이터 조회까지
+- [데이터셋 검색하기](./discovery.md) — 원하는 데이터를 찾는 방법

--- a/examples/pandas_export.py
+++ b/examples/pandas_export.py
@@ -1,0 +1,15 @@
+"""Export query results to a pandas DataFrame.
+
+Requires: pip install kpubdata[pandas]
+"""
+
+from kpubdata import Client
+
+client = Client.from_env()
+
+ds = client.dataset("bok.base_rate")
+result = ds.list(start_date="202401", end_date="202412")
+
+df = result.to_pandas()
+print(df.head())
+print(f"\nTotal rows: {len(df)}")

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,0 +1,13 @@
+"""Quickstart: create a client and fetch base rate data from BOK."""
+
+from kpubdata import Client
+
+# Set KPUBDATA_BOK_API_KEY env var, or pass provider_keys directly.
+client = Client.from_env()
+
+ds = client.dataset("bok.base_rate")
+
+result = ds.list(start_date="202401", end_date="202406")
+
+for item in result.items:
+    print(f"{item['TIME']} — {item['DATA_VALUE']}%")

--- a/examples/raw_call.py
+++ b/examples/raw_call.py
@@ -1,0 +1,16 @@
+"""Use call_raw to access the original provider API directly."""
+
+from kpubdata import Client
+
+client = Client.from_env()
+
+ds = client.dataset("datago.air_quality")
+
+# Call the provider's native operation with original parameter names.
+raw = ds.call_raw(
+    "getCtprvnRltmMesureDnsty",
+    sidoName="서울",
+    numOfRows="5",
+)
+
+print(raw)

--- a/examples/search_datasets.py
+++ b/examples/search_datasets.py
@@ -1,0 +1,19 @@
+"""Search and browse available datasets using the Catalog API."""
+
+from kpubdata import Client
+
+client = Client.from_env()
+
+# List all datasets from a specific provider
+for ds in client.datasets.list(provider="bok"):
+    print(ds.id, ds.name)
+
+# Fuzzy search across name, description, tags, and id
+results = client.datasets.search("예보")
+for ds in results:
+    print(ds.id, ds.name, ds.tags)
+
+# Strict search with higher threshold
+strict = client.datasets.search("금리", threshold=0.8)
+for ds in strict:
+    print(ds.id, ds.name)


### PR DESCRIPTION
## Summary

Closes #59

초보자용 예제 스크립트 4개와 cookbook 문서 3편을 추가합니다.

## 추가된 파일

### 예제 스크립트 (examples/)
| 파일 | 내용 |
|---|---|
| quickstart.py | Client 생성 + BOK 기준금리 조회 |
| search_datasets.py | 데이터셋 검색 + fuzzy threshold 사용 |
| raw_call.py | call_raw 비상구 사용법 |
| pandas_export.py | 조회 결과 pandas DataFrame 변환 |

### Cookbook 문서 (docs/cookbook/)
| 파일 | 내용 |
|---|---|
| getting-started.md | 설치부터 첫 조회까지 단계별 안내 |
| discovery.md | 데이터셋 검색/필터링/threshold 활용 |
| raw-access.md | 원본 API 직접 호출 방법 |

## Quality Gates
- ruff/mypy/pytest 794 passed/build 모두 통과
- 기존 파일 수정 없음 (신규 파일만 추가)