### PR TITLE
test: live integration tests for semas, sgis, law (#80)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -67,6 +67,22 @@ def require_seoul_key() -> str:
 
 
 @pytest.fixture(scope="session")
+def require_semas_key() -> str:
+    key = os.getenv("KPUBDATA_SEMAS_API_KEY", "")
+    if not key:
+        pytest.skip("KPUBDATA_SEMAS_API_KEY not set")
+    return key
+
+
+@pytest.fixture(scope="session")
+def require_sgis_key() -> str:
+    key = os.getenv("KPUBDATA_SGIS_API_KEY", "")
+    if not key:
+        pytest.skip("KPUBDATA_SGIS_API_KEY not set")
+    return key
+
+
+@pytest.fixture(scope="session")
 def live_client() -> Client:
     if not any(
         os.getenv(name, "")
@@ -77,6 +93,8 @@ def live_client() -> Client:
             "KPUBDATA_LOFIN_API_KEY",
             "KPUBDATA_LOCALDATA_API_KEY",
             "KPUBDATA_SEOUL_API_KEY",
+            "KPUBDATA_SEMAS_API_KEY",
+            "KPUBDATA_SGIS_API_KEY",
         )
     ):
         pytest.skip("No API keys set")

--- a/tests/integration/test_law_live.py
+++ b/tests/integration/test_law_live.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+from kpubdata.client import Client
+from kpubdata.core.models import RecordBatch
+
+
+@pytest.mark.integration
+def test_law_search_returns_record_batch(live_client: Client) -> None:
+    ds = live_client.dataset("law.law_search")
+
+    result = ds.list(query="민법")
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) > 0
+    assert isinstance(result.items[0], dict)
+
+
+@pytest.mark.integration
+def test_law_search_raw_returns_envelope(live_client: Client) -> None:
+    ds = live_client.dataset("law.law_search")
+
+    raw = ds.call_raw("list", query="헌법")
+
+    assert isinstance(raw, dict)
+
+
+@pytest.mark.integration
+def test_law_search_item_has_law_name(live_client: Client) -> None:
+    ds = live_client.dataset("law.law_search")
+    result = ds.list(query="민법")
+
+    item = result.items[0]
+    assert any(key in item for key in ("법령명한글", "lawNameKorean", "법령명"))
+
+
+@pytest.mark.integration
+def test_law_search_pagination(live_client: Client) -> None:
+    ds = live_client.dataset("law.law_search")
+
+    result = ds.list(query="법", page_size=5)
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) <= 5
+
+
+@pytest.mark.integration
+def test_ordin_search_returns_record_batch(live_client: Client) -> None:
+    ds = live_client.dataset("law.ordin_search")
+
+    result = ds.list(query="서울")
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) > 0

--- a/tests/integration/test_semas_live.py
+++ b/tests/integration/test_semas_live.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from kpubdata.client import Client
+from kpubdata.core.models import RecordBatch
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_semas_key")
+def test_store_radius_returns_record_batch(live_client: Client) -> None:
+    ds = live_client.dataset("semas.store_radius")
+
+    result = ds.list(cx="127.02758", cy="37.49794", radius="500")
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) > 0
+    assert isinstance(result.items[0], dict)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_semas_key")
+def test_store_radius_raw_returns_envelope(live_client: Client) -> None:
+    ds = live_client.dataset("semas.store_radius")
+
+    raw = ds.call_raw("storeListInRadius", cx="127.02758", cy="37.49794", radius="500")
+
+    assert isinstance(raw, dict)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_semas_key")
+def test_store_radius_item_has_business_name(live_client: Client) -> None:
+    ds = live_client.dataset("semas.store_radius")
+    result = ds.list(cx="127.02758", cy="37.49794", radius="500")
+
+    assert len(result.items) > 0
+    item = result.items[0]
+    assert "bizesNm" in item
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_semas_key")
+def test_upjong_large_returns_categories(live_client: Client) -> None:
+    ds = live_client.dataset("semas.upjong_large")
+
+    result = ds.list()
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) > 0
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_semas_key")
+def test_zone_one_returns_record_batch(live_client: Client) -> None:
+    ds = live_client.dataset("semas.zone_one")
+
+    result = ds.list(key="D00001")
+
+    assert isinstance(result, RecordBatch)

--- a/tests/integration/test_sgis_live.py
+++ b/tests/integration/test_sgis_live.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from kpubdata.client import Client
+from kpubdata.core.models import RecordBatch
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_sgis_key")
+def test_boundary_sido_returns_record_batch(live_client: Client) -> None:
+    ds = live_client.dataset("sgis.boundary.sido")
+
+    result = ds.list()
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) > 0
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_sgis_key")
+def test_boundary_sido_has_geometry(live_client: Client) -> None:
+    ds = live_client.dataset("sgis.boundary.sido")
+    result = ds.list()
+
+    item = result.items[0]
+    assert "geometry" in item or "adm_cd" in item
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_sgis_key")
+def test_boundary_sido_raw_returns_geojson(live_client: Client) -> None:
+    ds = live_client.dataset("sgis.boundary.sido")
+
+    raw = ds.call_raw("list")
+
+    assert isinstance(raw, dict)
+    assert "features" in raw
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_sgis_key")
+def test_boundary_sigungu_returns_record_batch(live_client: Client) -> None:
+    ds = live_client.dataset("sgis.boundary.sigungu")
+
+    result = ds.list()
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) > 0
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_sgis_key")
+def test_boundary_sido_count_is_reasonable(live_client: Client) -> None:
+    ds = live_client.dataset("sgis.boundary.sido")
+    result = ds.list()
+
+    assert 15 <= len(result.items) <= 20


### PR DESCRIPTION
## Summary

Closes #80

semas, sgis, law 3개 provider에 대한 실제 API 호출 기반 integration test를 추가합니다.
기존 datago/bok/kosis/lofin/localdata/seoul은 이미 live test가 존재하여, 이번 PR로 전체 provider의 integration test 커버리지가 완성됩니다.

## Changes

| File | Change |
|---|---|
| tests/integration/conftest.py | require_semas_key, require_sgis_key fixture 추가, live_client에 새 키 포함 |
| tests/integration/test_semas_live.py | store_radius, upjong_large, zone_one 등 5개 테스트 |
| tests/integration/test_sgis_live.py | boundary.sido/sigungu GeoJSON 응답 검증 5개 테스트 |
| tests/integration/test_law_live.py | law_search, ordin_search 페이지네이션 포함 5개 테스트 |

## Notes

- law provider는 공개 API (인증키 불필요)이므로 require fixture 없이 바로 실행
- 모든 테스트는 API 키 미설정 시 자동 skip
- SUPPORTED_DATA.md는 실API 검증 통과 후 업데이트 예정 (AGENTS.md 규칙 준수)

## Quality Gates

- ruff/mypy pass
- 794 passed, 88 deselected (새 integration tests는 키 없이 skip)