### PR TITLE
Implement Issue #197 — bok.usd_krw ECOS dataset

### DIFF
--- a/SUPPORTED_DATA.md
+++ b/SUPPORTED_DATA.md
@@ -269,6 +269,7 @@
 | 지원 | 테스트 검증 | - | 서울 열린데이터광장 (`seoul`) | `subway_realtime_arrival` | 서울시 지하철 실시간 도착정보 | [서울 열린데이터광장](https://data.seoul.go.kr/) 인증키 | [data.seoul.go.kr](https://data.seoul.go.kr/) | 경로 기반 인증키 + 서비스별 top-level envelope |
 | 지원 | 테스트 검증 | - | 서울 열린데이터광장 (`seoul`) | `bike_rent_month` | 서울시 공공자전거 이용정보(월별) | [서울 열린데이터광장](https://data.seoul.go.kr/) 인증키 | [data.seoul.go.kr](https://data.seoul.go.kr/) | 경로 기반 인증키 + 인덱스 페이지네이션 |
 | 지원 | 실API 검증 | 2025-04-15 | 한국은행 ECOS (`bok`) | `base_rate` | 한국은행 기준금리 | [ECOS](https://ecos.bok.or.kr/api/) 인증키 | [ecos.bok.or.kr](https://ecos.bok.or.kr/api/) | |
+| 지원 | 테스트 검증 | - | 한국은행 ECOS (`bok`) | `usd_krw` | 원/달러 환율 매매기준율 | [ECOS](https://ecos.bok.or.kr/api/) 인증키 | [ecos.bok.or.kr](https://ecos.bok.or.kr/api/) | ECOS 통계표 `731Y003`, 항목코드 `0000003`, 일별 데이터 |
 | 지원 | 실API 검증 | 2025-04-15 | 통계청 KOSIS (`kosis`) | `population_migration` | 시도별 이동자수 | [KOSIS](https://kosis.kr/openapi/index/index.jsp) 인증키 | [kosis.kr](https://kosis.kr/openapi/index/index.jsp) | |
 | 지원 | 실API 검증 | 2025-04-16 | 지방재정365 (`lofin`) | `expenditure_budget` | 세출결산총괄 | [지방재정365](https://www.lofin365.go.kr) 인증키 | [lofin365.go.kr](https://www.lofin365.go.kr) | API 코드: AJGCF |
 | 지원 | 실API 검증 | 2025-04-16 | 지방재정365 (`lofin`) | `revenue_budget` | 세입결산총괄 | [지방재정365](https://www.lofin365.go.kr) 인증키 | [lofin365.go.kr](https://www.lofin365.go.kr) | API 코드: IIBBH |

--- a/src/kpubdata/providers/bok/catalogue.json
+++ b/src/kpubdata/providers/bok/catalogue.json
@@ -23,5 +23,31 @@
       {"name": "ITEM_CODE1", "title": "항목코드", "type": "string"},
       {"name": "ITEM_NAME1", "title": "항목명", "type": "string"}
     ]
+  },
+  {
+    "dataset_key": "usd_krw",
+    "name": "원/달러 환율 매매기준율 (USD/KRW Exchange Rate)",
+    "base_url": "https://ecos.bok.or.kr/api/StatisticSearch",
+    "default_operation": "StatisticSearch",
+    "representation": "api_json",
+    "stat_code": "731Y003",
+    "item_code1": "0000003",
+    "description": "Bank of Korea USD/KRW exchange rate historical data",
+    "tags": ["finance", "exchange-rate", "fx"],
+    "source_url": "https://ecos.bok.or.kr/api/StatisticSearch",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000,
+      "frequency": ["D"]
+    },
+    "fields": [
+      {"name": "TIME", "title": "기간", "type": "string", "constraints": {"format": "YYYYMMDD", "pattern": "^\\d{8}$"}},
+      {"name": "DATA_VALUE", "title": "매매기준율", "type": "string"},
+      {"name": "UNIT_NAME", "title": "단위", "type": "string"},
+      {"name": "STAT_CODE", "title": "통계표코드", "type": "string", "constraints": {"pattern": "^[A-Z0-9]+$"}},
+      {"name": "ITEM_CODE1", "title": "항목코드", "type": "string"},
+      {"name": "ITEM_NAME1", "title": "항목명", "type": "string"}
+    ]
   }
 ]

--- a/src/kpubdata/providers/bok/catalogue.json
+++ b/src/kpubdata/providers/bok/catalogue.json
@@ -32,7 +32,7 @@
     "representation": "api_json",
     "stat_code": "731Y003",
     "item_code1": "0000003",
-    "description": "Bank of Korea USD/KRW exchange rate historical data",
+    "description": "Bank of Korea ECOS USD/KRW exchange rate historical data",
     "tags": ["finance", "exchange-rate", "fx"],
     "source_url": "https://ecos.bok.or.kr/api/StatisticSearch",
     "operations": ["list", "raw"],

--- a/tests/contract/test_bok.py
+++ b/tests/contract/test_bok.py
@@ -51,7 +51,9 @@ class _AdapterFactory(Protocol):
     ) -> ProviderAdapter: ...
 
 
-def _build_adapter(fixture_names: list[str]) -> ProviderAdapter:
+def _build_adapter_with_transport(
+    fixture_names: list[str],
+) -> tuple[ProviderAdapter, _FixtureTransport]:
     transport = _FixtureTransport(fixture_names)
     config = KPubDataConfig(provider_keys={"bok": "test-key"})
     adapter_module = import_module("kpubdata.providers.bok.adapter")
@@ -63,7 +65,12 @@ def _build_adapter(fixture_names: list[str]) -> ProviderAdapter:
         config=config,
         transport=cast(HttpTransport, cast(object, transport)),
     )
-    return adapter_obj
+    return adapter_obj, transport
+
+
+def _build_adapter(fixture_names: list[str]) -> ProviderAdapter:
+    adapter, _ = _build_adapter_with_transport(fixture_names)
+    return adapter
 
 
 class TestBokAdapterContract(ProviderAdapterContract):
@@ -93,3 +100,27 @@ class TestBokAdapterContract(ProviderAdapterContract):
             "StatisticSearch",
             {"start_date": "202401", "end_date": "202403", "frequency": "M"},
         )
+
+
+def test_usd_krw_query_records_builds_daily_ecos_url_and_parses_fixture() -> None:
+    adapter, transport = _build_adapter_with_transport(["usd_krw_success.json"])
+    dataset = adapter.get_dataset("usd_krw")
+
+    batch = adapter.query_records(
+        dataset,
+        Query(
+            start_date="20240101",
+            end_date="20240105",
+            extra={"frequency": "D"},
+        ),
+    )
+
+    request_url = cast(str, transport.calls[0]["url"])
+    assert "731Y003/D/20240101/20240105/0000003" in request_url
+    assert len(batch.items) == 4
+    assert [item["TIME"] for item in batch.items] == [
+        "20240102",
+        "20240103",
+        "20240104",
+        "20240105",
+    ]

--- a/tests/contract/test_bok.py
+++ b/tests/contract/test_bok.py
@@ -116,6 +116,7 @@ def test_usd_krw_query_records_builds_daily_ecos_url_and_parses_fixture() -> Non
     )
 
     request_url = cast(str, transport.calls[0]["url"])
+    assert "/StatisticSearch/" in request_url
     assert "731Y003/D/20240101/20240105/0000003" in request_url
     assert len(batch.items) == 4
     assert [item["TIME"] for item in batch.items] == [

--- a/tests/fixtures/bok/usd_krw_success.json
+++ b/tests/fixtures/bok/usd_krw_success.json
@@ -1,0 +1,43 @@
+{
+  "StatisticSearch": {
+    "list_total_count": 4,
+    "row": [
+      {
+        "STAT_CODE": "731Y003",
+        "STAT_NAME": "원/달러 환율(종가 기준)",
+        "ITEM_CODE1": "0000003",
+        "ITEM_NAME1": "원/달러(매매기준율)",
+        "UNIT_NAME": "KRW/USD",
+        "TIME": "20240102",
+        "DATA_VALUE": "1312.60"
+      },
+      {
+        "STAT_CODE": "731Y003",
+        "STAT_NAME": "원/달러 환율(종가 기준)",
+        "ITEM_CODE1": "0000003",
+        "ITEM_NAME1": "원/달러(매매기준율)",
+        "UNIT_NAME": "KRW/USD",
+        "TIME": "20240103",
+        "DATA_VALUE": "1314.80"
+      },
+      {
+        "STAT_CODE": "731Y003",
+        "STAT_NAME": "원/달러 환율(종가 기준)",
+        "ITEM_CODE1": "0000003",
+        "ITEM_NAME1": "원/달러(매매기준율)",
+        "UNIT_NAME": "KRW/USD",
+        "TIME": "20240104",
+        "DATA_VALUE": "1322.40"
+      },
+      {
+        "STAT_CODE": "731Y003",
+        "STAT_NAME": "원/달러 환율(종가 기준)",
+        "ITEM_CODE1": "0000003",
+        "ITEM_NAME1": "원/달러(매매기준율)",
+        "UNIT_NAME": "KRW/USD",
+        "TIME": "20240105",
+        "DATA_VALUE": "1316.90"
+      }
+    ]
+  }
+}

--- a/tests/integration/test_bok_live.py
+++ b/tests/integration/test_bok_live.py
@@ -123,7 +123,7 @@ def test_base_rate_data_value_is_numeric_string(live_client: Client) -> None:
     for item in result.items:
         value = item["DATA_VALUE"]
         assert isinstance(value, str)
-        float(value)  # raises ValueError if not numeric
+        _ = float(value)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_bok_live.py
+++ b/tests/integration/test_bok_live.py
@@ -217,3 +217,14 @@ def test_usage_single_month_query(live_client: Client) -> None:
 
     assert len(result.items) == 1
     assert str(result.items[0]["TIME"]) == "202406"
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_bok_key")
+def test_usd_krw_daily_returns_record_batch(live_client: Client) -> None:
+    ds = live_client.dataset("bok.usd_krw")
+
+    result = ds.list(start_date="20240101", end_date="20240105", frequency="D")
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) > 0

--- a/tests/unit/providers/bok/test_bok_adapter.py
+++ b/tests/unit/providers/bok/test_bok_adapter.py
@@ -52,7 +52,7 @@ def _build_adapter_with_transport(
 
 
 def test_catalogue_includes_usd_krw_daily_dataset() -> None:
-    adapter, dataset, _ = _build_adapter_with_transport([], dataset_key="usd_krw")
+    _, dataset, _ = _build_adapter_with_transport([], dataset_key="usd_krw")
 
     assert dataset.id == "bok.usd_krw"
     assert dataset.name == "원/달러 환율 매매기준율 (USD/KRW Exchange Rate)"
@@ -62,7 +62,8 @@ def test_catalogue_includes_usd_krw_daily_dataset() -> None:
     assert dataset.query_support is not None
     assert dataset.query_support.pagination.value == "offset"
     assert dataset.query_support.max_page_size == 1000
-    assert [field["name"] for field in dataset.raw_metadata["fields"]] == [
+    raw_fields = cast(list[dict[str, object]], dataset.raw_metadata["fields"])
+    assert [field["name"] for field in raw_fields] == [
         "TIME",
         "DATA_VALUE",
         "UNIT_NAME",
@@ -92,7 +93,7 @@ def test_query_records_uses_default_page_size_100() -> None:
     payload = _success_payload(items=[{"id": 1}], total_count=1)
     adapter, dataset, transport = _build_adapter_with_transport([FakeResponse(payload)])
 
-    _ = adapter.query_records(dataset, Query(start_date="202401", end_date="202403"))
+    _batch = adapter.query_records(dataset, Query(start_date="202401", end_date="202403"))
 
     request_url = cast(str, transport.calls[0]["url"])
     assert "/1/100/" in request_url
@@ -116,7 +117,7 @@ def test_query_records_missing_dates_logs_debug(caplog: pytest.LogCaptureFixture
 
     caplog.set_level(logging.DEBUG, logger="kpubdata.provider.bok")
     with pytest.raises(InvalidRequestError, match="start_date and end_date"):
-        adapter.query_records(dataset, Query())
+        _ = adapter.query_records(dataset, Query())
 
     record = next(
         record

--- a/tests/unit/providers/bok/test_bok_adapter.py
+++ b/tests/unit/providers/bok/test_bok_adapter.py
@@ -40,15 +40,38 @@ def _success_payload(*, items: object, total_count: object) -> dict[str, object]
 
 
 def _build_adapter_with_transport(
-    responses: list[FakeResponse],
+    responses: list[FakeResponse], *, dataset_key: str = "base_rate"
 ) -> tuple[BokAdapter, DatasetRef, FakeTransport]:
     transport = FakeTransport(responses)
     adapter = BokAdapter(
         config=KPubDataConfig(provider_keys={"bok": "test-key"}),
         transport=cast(HttpTransport, cast(object, transport)),
     )
-    dataset = adapter.get_dataset("base_rate")
+    dataset = adapter.get_dataset(dataset_key)
     return adapter, dataset, transport
+
+
+def test_catalogue_includes_usd_krw_daily_dataset() -> None:
+    adapter, dataset, _ = _build_adapter_with_transport([], dataset_key="usd_krw")
+
+    assert dataset.id == "bok.usd_krw"
+    assert dataset.name == "원/달러 환율 매매기준율 (USD/KRW Exchange Rate)"
+    assert dataset.raw_metadata["stat_code"] == "731Y003"
+    assert dataset.raw_metadata["item_code1"] == "0000003"
+    assert dataset.raw_metadata["tags"] == ["finance", "exchange-rate", "fx"]
+    assert dataset.raw_metadata["query_support"] == {
+        "pagination": "offset",
+        "max_page_size": 1000,
+        "frequency": ["D"],
+    }
+    assert [field["name"] for field in dataset.raw_metadata["fields"]] == [
+        "TIME",
+        "DATA_VALUE",
+        "UNIT_NAME",
+        "STAT_CODE",
+        "ITEM_CODE1",
+        "ITEM_NAME1",
+    ]
 
 
 def test_query_records_returns_single_page_and_sets_next_page() -> None:

--- a/tests/unit/providers/bok/test_bok_adapter.py
+++ b/tests/unit/providers/bok/test_bok_adapter.py
@@ -58,12 +58,10 @@ def test_catalogue_includes_usd_krw_daily_dataset() -> None:
     assert dataset.name == "원/달러 환율 매매기준율 (USD/KRW Exchange Rate)"
     assert dataset.raw_metadata["stat_code"] == "731Y003"
     assert dataset.raw_metadata["item_code1"] == "0000003"
-    assert dataset.raw_metadata["tags"] == ["finance", "exchange-rate", "fx"]
-    assert dataset.raw_metadata["query_support"] == {
-        "pagination": "offset",
-        "max_page_size": 1000,
-        "frequency": ["D"],
-    }
+    assert dataset.tags == ("finance", "exchange-rate", "fx")
+    assert dataset.query_support is not None
+    assert dataset.query_support.pagination.value == "offset"
+    assert dataset.query_support.max_page_size == 1000
     assert [field["name"] for field in dataset.raw_metadata["fields"]] == [
         "TIME",
         "DATA_VALUE",

--- a/tests/unit/providers/bok/test_bok_adapter.py
+++ b/tests/unit/providers/bok/test_bok_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from importlib.resources import files
 from typing import cast
 
 import pytest
@@ -53,15 +54,26 @@ def _build_adapter_with_transport(
 
 def test_catalogue_includes_usd_krw_daily_dataset() -> None:
     _, dataset, _ = _build_adapter_with_transport([], dataset_key="usd_krw")
+    catalogue = cast(
+        list[dict[str, object]],
+        json.loads(files("kpubdata.providers.bok").joinpath("catalogue.json").read_text()),
+    )
+    usd_krw_entry = next(entry for entry in catalogue if entry["dataset_key"] == "usd_krw")
 
     assert dataset.id == "bok.usd_krw"
     assert dataset.name == "원/달러 환율 매매기준율 (USD/KRW Exchange Rate)"
+    assert dataset.description == "Bank of Korea ECOS USD/KRW exchange rate historical data"
     assert dataset.raw_metadata["stat_code"] == "731Y003"
     assert dataset.raw_metadata["item_code1"] == "0000003"
     assert dataset.tags == ("finance", "exchange-rate", "fx")
     assert dataset.query_support is not None
     assert dataset.query_support.pagination.value == "offset"
     assert dataset.query_support.max_page_size == 1000
+    assert usd_krw_entry["query_support"] == {
+        "pagination": "offset",
+        "max_page_size": 1000,
+        "frequency": ["D"],
+    }
     raw_fields = cast(list[dict[str, object]], dataset.raw_metadata["fields"])
     assert [field["name"] for field in raw_fields] == [
         "TIME",


### PR DESCRIPTION
Closes #197

## Summary
- add the `bok.usd_krw` ECOS catalogue entry for series `731Y003/0000003` with daily query coverage and a representative fixture response
- extend BOK unit, contract, and live integration tests to cover catalogue loading, daily URL construction, fixture parsing, and opt-in live fetching
- document `bok.usd_krw` in `SUPPORTED_DATA.md`