### PR TITLE
feat(bok): add bond_yield_3y ECOS dataset

### DIFF
--- a/SUPPORTED_DATA.md
+++ b/SUPPORTED_DATA.md
@@ -269,6 +269,7 @@
 | 지원 | 테스트 검증 | - | 서울 열린데이터광장 (`seoul`) | `subway_realtime_arrival` | 서울시 지하철 실시간 도착정보 | [서울 열린데이터광장](https://data.seoul.go.kr/) 인증키 | [data.seoul.go.kr](https://data.seoul.go.kr/) | 경로 기반 인증키 + 서비스별 top-level envelope |
 | 지원 | 테스트 검증 | - | 서울 열린데이터광장 (`seoul`) | `bike_rent_month` | 서울시 공공자전거 이용정보(월별) | [서울 열린데이터광장](https://data.seoul.go.kr/) 인증키 | [data.seoul.go.kr](https://data.seoul.go.kr/) | 경로 기반 인증키 + 인덱스 페이지네이션 |
 | 지원 | 실API 검증 | 2025-04-15 | 한국은행 ECOS (`bok`) | `base_rate` | 한국은행 기준금리 | [ECOS](https://ecos.bok.or.kr/api/) 인증키 | [ecos.bok.or.kr](https://ecos.bok.or.kr/api/) | |
+| 지원 | 테스트 검증 | - | 한국은행 ECOS (`bok`) | `bond_yield_3y` | 국고채 3년물 수익률 | [ECOS](https://ecos.bok.or.kr/api/) 인증키 | [ecos.bok.or.kr](https://ecos.bok.or.kr/api/) | ECOS 통계표 `817Y002`, 항목코드 `010200000`, 일별 데이터 |
 | 지원 | 테스트 검증 | - | 한국은행 ECOS (`bok`) | `usd_krw` | 원/달러 환율 매매기준율 | [ECOS](https://ecos.bok.or.kr/api/) 인증키 | [ecos.bok.or.kr](https://ecos.bok.or.kr/api/) | ECOS 통계표 `731Y003`, 항목코드 `0000003`, 일별 데이터 |
 | 지원 | 실API 검증 | 2025-04-15 | 통계청 KOSIS (`kosis`) | `population_migration` | 시도별 이동자수 | [KOSIS](https://kosis.kr/openapi/index/index.jsp) 인증키 | [kosis.kr](https://kosis.kr/openapi/index/index.jsp) | |
 | 지원 | 실API 검증 | 2025-04-16 | 지방재정365 (`lofin`) | `expenditure_budget` | 세출결산총괄 | [지방재정365](https://www.lofin365.go.kr) 인증키 | [lofin365.go.kr](https://www.lofin365.go.kr) | API 코드: AJGCF |

--- a/src/kpubdata/providers/bok/catalogue.json
+++ b/src/kpubdata/providers/bok/catalogue.json
@@ -49,5 +49,31 @@
       {"name": "ITEM_CODE1", "title": "항목코드", "type": "string"},
       {"name": "ITEM_NAME1", "title": "항목명", "type": "string"}
     ]
+  },
+  {
+    "dataset_key": "bond_yield_3y",
+    "name": "국고채 3년물 수익률 (Korea Treasury Bond 3Y Yield)",
+    "base_url": "https://ecos.bok.or.kr/api/StatisticSearch",
+    "default_operation": "StatisticSearch",
+    "representation": "api_json",
+    "stat_code": "817Y002",
+    "item_code1": "010200000",
+    "description": "Bank of Korea ECOS Korea Treasury Bond 3Y yield historical data",
+    "tags": ["finance", "interest-rate", "bond", "treasury"],
+    "source_url": "https://ecos.bok.or.kr/api/StatisticSearch",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000,
+      "frequency": ["D"]
+    },
+    "fields": [
+      {"name": "TIME", "title": "기간", "type": "string", "constraints": {"format": "YYYYMMDD", "pattern": "^\\d{8}$"}},
+      {"name": "DATA_VALUE", "title": "수익률", "type": "string"},
+      {"name": "UNIT_NAME", "title": "단위", "type": "string"},
+      {"name": "STAT_CODE", "title": "통계표코드", "type": "string", "constraints": {"pattern": "^[A-Z0-9]+$"}},
+      {"name": "ITEM_CODE1", "title": "항목코드", "type": "string"},
+      {"name": "ITEM_NAME1", "title": "항목명", "type": "string"}
+    ]
   }
 ]

--- a/tests/contract/test_bok.py
+++ b/tests/contract/test_bok.py
@@ -125,3 +125,29 @@ def test_usd_krw_query_records_builds_daily_ecos_url_and_parses_fixture() -> Non
         "20240104",
         "20240105",
     ]
+
+
+def test_bond_yield_3y_query_records_builds_daily_ecos_url_and_parses_fixture() -> None:
+    adapter, transport = _build_adapter_with_transport(["bond_yield_3y_success.json"])
+    dataset = adapter.get_dataset("bond_yield_3y")
+
+    batch = adapter.query_records(
+        dataset,
+        Query(
+            start_date="20240102",
+            end_date="20240108",
+            extra={"frequency": "D"},
+        ),
+    )
+
+    request_url = cast(str, transport.calls[0]["url"])
+    assert "/StatisticSearch/" in request_url
+    assert "817Y002/D/20240102/20240108/010200000" in request_url
+    assert len(batch.items) == 5
+    assert [item["TIME"] for item in batch.items] == [
+        "20240102",
+        "20240103",
+        "20240104",
+        "20240105",
+        "20240108",
+    ]

--- a/tests/fixtures/bok/bond_yield_3y_success.json
+++ b/tests/fixtures/bok/bond_yield_3y_success.json
@@ -1,0 +1,52 @@
+{
+  "StatisticSearch": {
+    "list_total_count": 5,
+    "row": [
+      {
+        "STAT_CODE": "817Y002",
+        "STAT_NAME": "국고채금리",
+        "ITEM_CODE1": "010200000",
+        "ITEM_NAME1": "국고채(3년)",
+        "UNIT_NAME": "%",
+        "TIME": "20240102",
+        "DATA_VALUE": "3.154"
+      },
+      {
+        "STAT_CODE": "817Y002",
+        "STAT_NAME": "국고채금리",
+        "ITEM_CODE1": "010200000",
+        "ITEM_NAME1": "국고채(3년)",
+        "UNIT_NAME": "%",
+        "TIME": "20240103",
+        "DATA_VALUE": "3.143"
+      },
+      {
+        "STAT_CODE": "817Y002",
+        "STAT_NAME": "국고채금리",
+        "ITEM_CODE1": "010200000",
+        "ITEM_NAME1": "국고채(3년)",
+        "UNIT_NAME": "%",
+        "TIME": "20240104",
+        "DATA_VALUE": "3.145"
+      },
+      {
+        "STAT_CODE": "817Y002",
+        "STAT_NAME": "국고채금리",
+        "ITEM_CODE1": "010200000",
+        "ITEM_NAME1": "국고채(3년)",
+        "UNIT_NAME": "%",
+        "TIME": "20240105",
+        "DATA_VALUE": "3.156"
+      },
+      {
+        "STAT_CODE": "817Y002",
+        "STAT_NAME": "국고채금리",
+        "ITEM_CODE1": "010200000",
+        "ITEM_NAME1": "국고채(3년)",
+        "UNIT_NAME": "%",
+        "TIME": "20240108",
+        "DATA_VALUE": "3.182"
+      }
+    ]
+  }
+}

--- a/tests/integration/test_bok_live.py
+++ b/tests/integration/test_bok_live.py
@@ -228,3 +228,14 @@ def test_usd_krw_daily_returns_record_batch(live_client: Client) -> None:
 
     assert isinstance(result, RecordBatch)
     assert len(result.items) > 0
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_bok_key")
+def test_bond_yield_3y_daily_returns_record_batch(live_client: Client) -> None:
+    ds = live_client.dataset("bok.bond_yield_3y")
+
+    result = ds.list(start_date="20240102", end_date="20240108", frequency="D")
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) > 0

--- a/tests/unit/providers/bok/test_bok_adapter.py
+++ b/tests/unit/providers/bok/test_bok_adapter.py
@@ -85,6 +85,41 @@ def test_catalogue_includes_usd_krw_daily_dataset() -> None:
     ]
 
 
+def test_catalogue_includes_bond_yield_3y_daily_dataset() -> None:
+    _, dataset, _ = _build_adapter_with_transport([], dataset_key="bond_yield_3y")
+    catalogue = cast(
+        list[dict[str, object]],
+        json.loads(files("kpubdata.providers.bok").joinpath("catalogue.json").read_text()),
+    )
+    bond_yield_3y_entry = next(
+        entry for entry in catalogue if entry["dataset_key"] == "bond_yield_3y"
+    )
+
+    assert dataset.id == "bok.bond_yield_3y"
+    assert dataset.name == "국고채 3년물 수익률 (Korea Treasury Bond 3Y Yield)"
+    assert dataset.description == "Bank of Korea ECOS Korea Treasury Bond 3Y yield historical data"
+    assert dataset.raw_metadata["stat_code"] == "817Y002"
+    assert dataset.raw_metadata["item_code1"] == "010200000"
+    assert dataset.tags == ("finance", "interest-rate", "bond", "treasury")
+    assert dataset.query_support is not None
+    assert dataset.query_support.pagination.value == "offset"
+    assert dataset.query_support.max_page_size == 1000
+    assert bond_yield_3y_entry["query_support"] == {
+        "pagination": "offset",
+        "max_page_size": 1000,
+        "frequency": ["D"],
+    }
+    raw_fields = cast(list[dict[str, object]], dataset.raw_metadata["fields"])
+    assert [field["name"] for field in raw_fields] == [
+        "TIME",
+        "DATA_VALUE",
+        "UNIT_NAME",
+        "STAT_CODE",
+        "ITEM_CODE1",
+        "ITEM_NAME1",
+    ]
+
+
 def test_query_records_returns_single_page_and_sets_next_page() -> None:
     payload = _success_payload(items=[{"id": 1}, {"id": 2}], total_count=5)
     adapter, dataset, transport = _build_adapter_with_transport([FakeResponse(payload)])


### PR DESCRIPTION
## Summary
- add `bok.bond_yield_3y` to the BOK catalogue for ECOS series `817Y002/010200000` with daily query support
- add fixture, unit, contract, and live integration coverage following the merged `bok.usd_krw` pattern
- document the new dataset in `SUPPORTED_DATA.md`

Closes #198