### PR TITLE
feat(kosis): add industrial_production dataset defaults

### DIFF
--- a/SUPPORTED_DATA.md
+++ b/SUPPORTED_DATA.md
@@ -272,6 +272,7 @@
 | 지원 | 테스트 검증 | - | 한국은행 ECOS (`bok`) | `bond_yield_3y` | 국고채 3년물 수익률 | [ECOS](https://ecos.bok.or.kr/api/) 인증키 | [ecos.bok.or.kr](https://ecos.bok.or.kr/api/) | ECOS 통계표 `817Y002`, 항목코드 `010200000`, 일별 데이터 |
 | 지원 | 테스트 검증 | - | 한국은행 ECOS (`bok`) | `usd_krw` | 원/달러 환율 매매기준율 | [ECOS](https://ecos.bok.or.kr/api/) 인증키 | [ecos.bok.or.kr](https://ecos.bok.or.kr/api/) | ECOS 통계표 `731Y003`, 항목코드 `0000003`, 일별 데이터 |
 | 지원 | 실API 검증 | 2025-04-15 | 통계청 KOSIS (`kosis`) | `population_migration` | 시도별 이동자수 | [KOSIS](https://kosis.kr/openapi/index/index.jsp) 인증키 | [kosis.kr](https://kosis.kr/openapi/index/index.jsp) | |
+| 지원 | 실API 검증 | 2026-04-27 | 통계청 KOSIS (`kosis`) | `industrial_production` | 광공업생산지수 | [KOSIS](https://kosis.kr/openapi/index/index.jsp) 인증키 | [kosis.kr](https://kosis.kr/openapi/index/index.jsp) | KOSIS 통계표 `DT_1J22003`, 기본 파라미터 `objL1=T10`, `itmId=T`, `prdSe=M` |
 | 지원 | 실API 검증 | 2025-04-16 | 지방재정365 (`lofin`) | `expenditure_budget` | 세출결산총괄 | [지방재정365](https://www.lofin365.go.kr) 인증키 | [lofin365.go.kr](https://www.lofin365.go.kr) | API 코드: AJGCF |
 | 지원 | 실API 검증 | 2025-04-16 | 지방재정365 (`lofin`) | `revenue_budget` | 세입결산총괄 | [지방재정365](https://www.lofin365.go.kr) 인증키 | [lofin365.go.kr](https://www.lofin365.go.kr) | API 코드: IIBBH |
 | 지원 | 실API 검증 | 2025-04-16 | 지방재정365 (`lofin`) | `expenditure_function` | 기능별세출 | [지방재정365](https://www.lofin365.go.kr) 인증키 | [lofin365.go.kr](https://www.lofin365.go.kr) | API 코드: GGNSE |

--- a/src/kpubdata/providers/kosis/adapter.py
+++ b/src/kpubdata/providers/kosis/adapter.py
@@ -25,8 +25,28 @@ from kpubdata.transport.http import HttpTransport, TransportConfig
 
 logger = logging.getLogger("kpubdata.provider.kosis")
 
+_KOSIS_DEFAULT_QUERY_PARAM_KEYS: tuple[str, ...] = (
+    "objL1",
+    "objL2",
+    "objL3",
+    "objL4",
+    "objL5",
+    "objL6",
+    "objL7",
+    "objL8",
+    "itmId",
+    "prdSe",
+    "newEstPrdCnt",
+    "prdInterval",
+)
+
 
 class KosisAdapter:
+    """KOSIS adapter.
+
+    Query translation merge rule: dataset default_query_params < query.filters (caller wins).
+    """
+
     def __init__(
         self,
         *,
@@ -159,7 +179,7 @@ class KosisAdapter:
         params["endPrdDe"] = end_date
 
         reserved = {key.casefold() for key in params}
-        for key in ("objL1", "objL2", "itmId", "prdSe"):
+        for key in _KOSIS_DEFAULT_QUERY_PARAM_KEYS:
             if key in filters:
                 params[key] = str(filters.pop(key))
 
@@ -188,17 +208,40 @@ class KosisAdapter:
         api_key = self._require_api_key()
         org_id = self._require_dataset_metadata(dataset, "org_id")
         tbl_id = self._require_dataset_metadata(dataset, "tbl_id")
-        return {
+        params = {
             "apiKey": api_key,
             "format": "json",
             "jsonVD": "Y",
             "orgId": org_id,
             "tblId": tbl_id,
-            "objL1": "ALL",
-            "objL2": "ALL",
-            "itmId": "ALL",
-            "prdSe": "M",
         }
+        default_query_params = self._get_default_query_params(dataset)
+        if default_query_params:
+            params.update(default_query_params)
+        else:
+            params.update(
+                {
+                    "objL1": "ALL",
+                    "objL2": "ALL",
+                    "itmId": "ALL",
+                    "prdSe": "M",
+                }
+            )
+        return params
+
+    @staticmethod
+    def _get_default_query_params(dataset: DatasetRef) -> dict[str, str]:
+        raw_defaults = dataset.raw_metadata.get("default_query_params")
+        if not isinstance(raw_defaults, Mapping):
+            return {}
+        typed_defaults = cast(Mapping[str, object], raw_defaults)
+
+        default_query_params: dict[str, str] = {}
+        for key in _KOSIS_DEFAULT_QUERY_PARAM_KEYS:
+            value = typed_defaults.get(key)
+            if value is not None:
+                default_query_params[key] = str(value)
+        return default_query_params
 
     def _compose_url(self, dataset: DatasetRef, params: Mapping[str, str]) -> str:
         base_url = self._require_dataset_metadata(dataset, "base_url")

--- a/src/kpubdata/providers/kosis/catalogue.json
+++ b/src/kpubdata/providers/kosis/catalogue.json
@@ -24,5 +24,42 @@
       {"name": "DT", "title": "값", "type": "string"},
       {"name": "UNIT_NM", "title": "단위", "type": "string"}
     ]
+  },
+  {
+    "dataset_key": "industrial_production",
+    "name": "광공업생산지수 (Industrial Production Index)",
+    "base_url": "https://kosis.kr/openapi/Param/statisticsParameterData.do",
+    "default_operation": "statisticsParameterData",
+    "representation": "api_json",
+    "org_id": "101",
+    "tbl_id": "DT_1J22003",
+    "default_query_params": {
+      "objL1": "T10",
+      "itmId": "T",
+      "prdSe": "M"
+    },
+    "description": "KOSIS industrial production statistics from the Statistics Korea open API (table DT_1J22003)",
+    "tags": ["industry", "production", "index", "statistics"],
+    "source_url": "https://kosis.kr/openapi/Param/statisticsParameterData.do",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000
+    },
+    "fields": [
+      {"name": "PRD_DE", "title": "기간", "type": "string"},
+      {"name": "PRD_SE", "title": "주기구분", "type": "string"},
+      {"name": "C1_OBJ_NM", "title": "분류명", "type": "string"},
+      {"name": "C1", "title": "분류코드", "type": "string"},
+      {"name": "C1_NM", "title": "분류값", "type": "string"},
+      {"name": "ITM_ID", "title": "항목코드", "type": "string"},
+      {"name": "ITM_NM", "title": "항목명", "type": "string"},
+      {"name": "DT", "title": "값", "type": "string"},
+      {"name": "UNIT_NM", "title": "단위", "type": "string"},
+      {"name": "TBL_ID", "title": "테이블ID", "type": "string"},
+      {"name": "TBL_NM", "title": "테이블명", "type": "string"},
+      {"name": "ORG_ID", "title": "기관ID", "type": "string"},
+      {"name": "LST_CHN_DE", "title": "최종변경일", "type": "string"}
+    ]
   }
 ]

--- a/tests/contract/test_kosis.py
+++ b/tests/contract/test_kosis.py
@@ -55,6 +55,20 @@ def _build_adapter(fixture_names: list[str]) -> ProviderAdapter:
     )
 
 
+def _build_adapter_with_transport(
+    fixture_names: list[str],
+) -> tuple[ProviderAdapter, _FixtureTransport]:
+    transport = _FixtureTransport(fixture_names)
+    config = KPubDataConfig(provider_keys={"kosis": "test-key"})
+    module = import_module("kpubdata.providers.kosis.adapter")
+    adapter_class = cast(Callable[..., ProviderAdapter], module.KosisAdapter)
+    adapter = adapter_class(
+        config=config,
+        transport=cast(HttpTransport, cast(object, transport)),
+    )
+    return adapter, transport
+
+
 class TestKosisAdapterContract(ProviderAdapterContract):
     @pytest.fixture()
     def adapter(self) -> ProviderAdapter:
@@ -95,3 +109,20 @@ class TestKosisAdapterContract(ProviderAdapterContract):
 
         with pytest.raises(AuthError):
             _ = adapter.query_records(dataset, Query(start_date="202401", end_date="202401"))
+
+
+def test_industrial_production_query_records_builds_default_param_url_and_parses_fixture() -> None:
+    adapter, transport = _build_adapter_with_transport(["industrial_production_success.json"])
+    dataset = adapter.get_dataset("industrial_production")
+
+    batch = adapter.query_records(dataset, Query(start_date="202401", end_date="202401"))
+
+    request_url = cast(str, transport.calls[0]["url"])
+    assert "tblId=DT_1J22003" in request_url
+    assert "objL1=T10" in request_url
+    assert "itmId=T" in request_url
+    assert "prdSe=M" in request_url
+    assert "objL2=ALL" not in request_url
+    assert len(batch.items) == 1
+    assert batch.items[0]["TBL_ID"] == "DT_1J22003"
+    assert batch.items[0]["C1"] == "T10"

--- a/tests/fixtures/kosis/industrial_production_success.json
+++ b/tests/fixtures/kosis/industrial_production_success.json
@@ -1,0 +1,21 @@
+[
+  {
+    "C1_OBJ_NM": "시도별",
+    "DT": "113.17",
+    "C1": "T10",
+    "PRD_SE": "M",
+    "UNIT_NM_ENG": "2020＝100",
+    "ITM_ID": "T",
+    "TBL_ID": "DT_1J22003",
+    "ITM_NM": "소비자물가지수(총지수)",
+    "TBL_NM": "소비자물가지수(2020＝100)",
+    "PRD_DE": "202401",
+    "LST_CHN_DE": "2024-06-26",
+    "C1_NM_ENG": "whole country",
+    "C1_NM": "전국",
+    "UNIT_NM": "2020＝100",
+    "ITM_NM_ENG": "CPI",
+    "ORG_ID": "101",
+    "C1_OBJ_NM_ENG": "by City"
+  }
+]

--- a/tests/integration/test_kosis_live.py
+++ b/tests/integration/test_kosis_live.py
@@ -10,6 +10,8 @@ Run with:
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from kpubdata.client import Client
@@ -46,7 +48,8 @@ def test_population_migration_raw_returns_list(live_client: Client) -> None:
     )
 
     assert isinstance(result, list)
-    assert len(result) > 0
+    result_list = cast(list[object], result)
+    assert len(result_list) > 0
 
 
 # ---------------------------------------------------------------------------
@@ -143,7 +146,7 @@ def test_dt_is_numeric_string(live_client: Client) -> None:
     for item in result.items[:20]:
         value = str(item["DT"])
         if value != "-":
-            int(value.replace(",", ""))
+            _ = int(value.replace(",", ""))
 
 
 @pytest.mark.integration
@@ -232,5 +235,19 @@ def test_usage_region_ranking(live_client: Client) -> None:
             region_totals[region] = int(str(item["DT"]).replace(",", ""))
 
     assert len(region_totals) > 0
-    top_region = max(region_totals, key=region_totals.get)  # type: ignore[arg-type]
+    top_region = max(region_totals.items(), key=lambda item: item[1])[0]
     assert isinstance(top_region, str)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("require_kosis_key")
+def test_industrial_production_returns_record_batch(live_client: Client) -> None:
+    ds = live_client.dataset("kosis.industrial_production")
+
+    result = ds.list(start_date="202401", end_date="202401")
+
+    assert isinstance(result, RecordBatch)
+    assert len(result.items) > 0
+    assert result.items[0]["TBL_ID"] == "DT_1J22003"
+    assert result.items[0]["C1"] == "T10"
+    assert result.items[0]["ITM_ID"] == "T"

--- a/tests/unit/providers/kosis/test_adapter.py
+++ b/tests/unit/providers/kosis/test_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from importlib.resources import files
 from typing import cast
 
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from kpubdata.config import KPubDataConfig
 from kpubdata.core.models import DatasetRef, Query
 from kpubdata.exceptions import InvalidRequestError
+from kpubdata.providers._common import build_dataset_ref
 from kpubdata.providers.kosis.adapter import KosisAdapter
 from kpubdata.transport.http import HttpTransport
 
@@ -32,14 +34,44 @@ class FakeTransport:
 
 def _build_adapter_with_transport(
     responses: list[FakeResponse],
+    *,
+    dataset_key: str = "population_migration",
 ) -> tuple[KosisAdapter, DatasetRef, FakeTransport]:
     transport = FakeTransport(responses)
     adapter = KosisAdapter(
         config=KPubDataConfig(provider_keys={"kosis": "test-key"}),
         transport=cast(HttpTransport, cast(object, transport)),
     )
-    dataset = adapter.get_dataset("population_migration")
+    dataset = adapter.get_dataset(dataset_key)
     return adapter, dataset, transport
+
+
+def test_catalogue_parses_industrial_production_default_query_params() -> None:
+    _, dataset, _ = _build_adapter_with_transport([], dataset_key="industrial_production")
+    catalogue = cast(
+        list[dict[str, object]],
+        json.loads(files("kpubdata.providers.kosis").joinpath("catalogue.json").read_text()),
+    )
+    entry = next(entry for entry in catalogue if entry["dataset_key"] == "industrial_production")
+
+    assert dataset.id == "kosis.industrial_production"
+    assert dataset.raw_metadata["org_id"] == "101"
+    assert dataset.raw_metadata["tbl_id"] == "DT_1J22003"
+    assert dataset.raw_metadata["default_query_params"] == {
+        "objL1": "T10",
+        "itmId": "T",
+        "prdSe": "M",
+    }
+    assert entry["default_query_params"] == {
+        "objL1": "T10",
+        "itmId": "T",
+        "prdSe": "M",
+    }
+
+
+def test_adapter_docstring_documents_default_query_params_merge_rule() -> None:
+    assert KosisAdapter.__doc__ is not None
+    assert "dataset default_query_params < query.filters (caller wins)" in KosisAdapter.__doc__
 
 
 def test_query_records_missing_start_date_logs_debug(caplog: pytest.LogCaptureFixture) -> None:
@@ -47,7 +79,7 @@ def test_query_records_missing_start_date_logs_debug(caplog: pytest.LogCaptureFi
 
     caplog.set_level(logging.DEBUG, logger="kpubdata.provider.kosis")
     with pytest.raises(InvalidRequestError, match="start_date"):
-        adapter.query_records(dataset, Query(end_date="202401"))
+        _ = adapter.query_records(dataset, Query(end_date="202401"))
 
     record = next(
         record
@@ -71,3 +103,83 @@ def test_query_records_zero_items_logs_debug(caplog: pytest.LogCaptureFixture) -
     assert record.__dict__["page"] is None
     assert record.__dict__["page_size"] == 100
     assert record.__dict__["total_count"] == 0
+
+
+def test_population_migration_keeps_hardcoded_default_query_params() -> None:
+    adapter, dataset, transport = _build_adapter_with_transport([FakeResponse([])])
+
+    batch = adapter.query_records(dataset, Query(start_date="202401", end_date="202401"))
+
+    assert batch.items == []
+    request_url = cast(str, transport.calls[0]["url"])
+    assert "objL1=ALL" in request_url
+    assert "objL2=ALL" in request_url
+    assert "itmId=ALL" in request_url
+    assert "prdSe=M" in request_url
+
+
+def test_query_records_applies_dataset_default_query_params_when_filters_absent() -> None:
+    adapter, dataset, transport = _build_adapter_with_transport(
+        [FakeResponse([])],
+        dataset_key="industrial_production",
+    )
+
+    _ = adapter.query_records(dataset, Query(start_date="202401", end_date="202401"))
+
+    request_url = cast(str, transport.calls[0]["url"])
+    assert "objL1=T10" in request_url
+    assert "itmId=T" in request_url
+    assert "prdSe=M" in request_url
+    assert "objL2=ALL" not in request_url
+
+
+def test_query_records_merges_default_query_params_but_query_filters_win() -> None:
+    adapter, dataset, transport = _build_adapter_with_transport(
+        [FakeResponse([])],
+        dataset_key="industrial_production",
+    )
+
+    _ = adapter.query_records(
+        dataset,
+        Query(
+            start_date="202401",
+            end_date="202401",
+            filters={"objL1": "T20", "itmId": "X", "prdSe": "Q"},
+        ),
+    )
+
+    request_url = cast(str, transport.calls[0]["url"])
+    assert "objL1=T20" in request_url
+    assert "itmId=X" in request_url
+    assert "prdSe=Q" in request_url
+    assert "objL1=T10" not in request_url
+    assert "itmId=T" not in request_url
+
+
+def test_query_records_ignores_non_kosis_default_query_param_keys() -> None:
+    adapter, _, transport = _build_adapter_with_transport([FakeResponse([])])
+    dataset = build_dataset_ref(
+        "kosis",
+        {
+            "dataset_key": "custom_defaults",
+            "name": "Custom Defaults",
+            "representation": "api_json",
+            "base_url": "https://kosis.kr/openapi/Param/statisticsParameterData.do",
+            "org_id": "101",
+            "tbl_id": "DT_1J22003",
+            "default_query_params": {
+                "objL1": "T10",
+                "itmId": "T",
+                "unknown": "ignored",
+                "apiKey": "ignored",
+            },
+        },
+    )
+
+    _ = adapter.query_records(dataset, Query(start_date="202401", end_date="202401"))
+
+    request_url = cast(str, transport.calls[0]["url"])
+    assert "objL1=T10" in request_url
+    assert "itmId=T" in request_url
+    assert "unknown=ignored" not in request_url
+    assert request_url.count("apiKey=") == 1


### PR DESCRIPTION
## Summary
- extend the KOSIS adapter to allowlist and apply dataset-level `default_query_params`, while preserving the legacy `ALL/ALL/ALL/M` fallback for datasets without declared defaults
- add the `kosis.industrial_production` catalogue entry, fixture coverage, contract/unit/live tests, and supported-data documentation
- verify the caller-wins merge rule explicitly in tests and keep the live KOSIS integration green for `DT_1J22003`

Closes #196