### PR TITLE
feat: provider scaffolding CLI tool 추가

### DIFF
--- a/src/kpubdata/cli/__init__.py
+++ b/src/kpubdata/cli/__init__.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import logging
+import sys
+import traceback
+from collections.abc import Iterable, Mapping, Sequence
+from enum import Enum
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import cast
+
+from kpubdata import __version__
+from kpubdata.client import Client
+from kpubdata.core.capability import Operation, QuerySupport
+from kpubdata.core.models import DatasetRef, RecordBatch
+from kpubdata.exceptions import (
+    AuthError,
+    DatasetNotFoundError,
+    InvalidRequestError,
+    ProviderResponseError,
+    TransportError,
+)
+
+logger = logging.getLogger("kpubdata.cli")
+
+_MAX_TABLE_COLUMNS = 20
+_MAX_CELL_WIDTH = 40
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    parsed_values = vars(args)
+    debug_enabled = _configure_logging(cast(str, parsed_values.get("log_level", "warning")))
+
+    try:
+        return _run_command(args)
+    except (DatasetNotFoundError, InvalidRequestError) as exc:
+        _print_error(exc)
+        if debug_enabled:
+            traceback.print_exc(file=sys.stderr)
+        return 2
+    except AuthError as exc:
+        _print_error(exc)
+        if debug_enabled:
+            traceback.print_exc(file=sys.stderr)
+        return 3
+    except (TransportError, ProviderResponseError) as exc:
+        _print_error(exc)
+        if debug_enabled:
+            traceback.print_exc(file=sys.stderr)
+        return 4
+    except Exception as exc:
+        _print_error(exc)
+        if debug_enabled:
+            traceback.print_exc(file=sys.stderr)
+        return 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="kpubdata")
+    _ = parser.add_argument("--cache", action="store_true", help="Enable response cache")
+    _ = parser.add_argument(
+        "--log-level",
+        choices=("warning", "info", "debug"),
+        default="warning",
+        help="Set the kpubdata logger level",
+    )
+    _ = parser.add_argument(
+        "--provider-key",
+        action="append",
+        default=[],
+        metavar="PROVIDER=KEY",
+        help="Override a provider API key",
+    )
+    _ = parser.add_argument("--version", action="store_true", help="Print kpubdata version")
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    datasets_parser = subparsers.add_parser("datasets", help="Dataset discovery commands")
+    datasets_subparsers = datasets_parser.add_subparsers(dest="datasets_command")
+
+    datasets_list = datasets_subparsers.add_parser("list", help="List datasets")
+    _ = datasets_list.add_argument("--provider", help="Filter by provider")
+    _ = datasets_list.add_argument("--search", help="Filter by text search")
+    _ = datasets_list.add_argument(
+        "--format",
+        choices=("json", "table"),
+        default="table",
+        help="Output format",
+    )
+
+    datasets_show = datasets_subparsers.add_parser("show", help="Show dataset metadata")
+    _ = datasets_show.add_argument("dataset_id")
+    _ = datasets_show.add_argument(
+        "--format",
+        choices=("json", "table"),
+        default="table",
+        help="Output format",
+    )
+
+    fetch_parser = subparsers.add_parser("fetch", help="Fetch normalized data")
+    _ = fetch_parser.add_argument("dataset_id")
+    _ = fetch_parser.add_argument("-p", "--param", action="append", default=[], metavar="KEY=VALUE")
+    _ = fetch_parser.add_argument("--page", type=int)
+    _ = fetch_parser.add_argument("--page-size", type=int)
+    _ = fetch_parser.add_argument("--all", action="store_true", help="Fetch all pages")
+    _ = fetch_parser.add_argument(
+        "--format",
+        choices=("json", "csv", "table"),
+        default="table",
+        help="Output format",
+    )
+    _ = fetch_parser.add_argument("--output", help="Write output to a file")
+
+    raw_parser = subparsers.add_parser("raw", help="Call a raw provider operation")
+    _ = raw_parser.add_argument("dataset_id")
+    _ = raw_parser.add_argument("operation")
+    _ = raw_parser.add_argument("-p", "--param", action="append", default=[], metavar="KEY=VALUE")
+    _ = raw_parser.add_argument("--output", help="Write output to a file")
+
+    return parser
+
+
+def _configure_logging(level_name: str) -> bool:
+    level_map = {
+        "warning": logging.WARNING,
+        "info": logging.INFO,
+        "debug": logging.DEBUG,
+    }
+    level = level_map[level_name]
+    logging.basicConfig(level=level)
+    root_logger = logging.getLogger("kpubdata")
+    root_logger.setLevel(level)
+    logger.debug("CLI logging configured", extra={"log_level": level_name.lower()})
+    return level == logging.DEBUG
+
+
+def _run_command(args: argparse.Namespace) -> int:
+    values = vars(args)
+    version_flag = cast(bool, values.get("version", False))
+    command = cast(str | None, values.get("command"))
+    provider_key_values = cast(list[str], values.get("provider_key", []))
+    cache_enabled = cast(bool, values.get("cache", False))
+
+    if version_flag:
+        print(_get_version())
+        return 0
+
+    if command is None:
+        _build_parser().print_help()
+        return 0
+
+    provider_keys = _parse_assignments(provider_key_values, flag_name="--provider-key")
+    client = _create_client(cache_enabled=cache_enabled, provider_keys=provider_keys)
+    try:
+        if command == "datasets":
+            return _handle_datasets_command(client, args)
+        if command == "fetch":
+            return _handle_fetch_command(client, args)
+        if command == "raw":
+            return _handle_raw_command(client, args)
+        raise InvalidRequestError(f"Unknown command: {command}")
+    finally:
+        client.close()
+
+
+def _create_client(*, cache_enabled: bool, provider_keys: dict[str, str]) -> Client:
+    if cache_enabled:
+        return Client.from_env(provider_keys=provider_keys, cache=True)
+    return Client.from_env(provider_keys=provider_keys)
+
+
+def _handle_datasets_command(client: Client, args: argparse.Namespace) -> int:
+    values = vars(args)
+    datasets_command = cast(str | None, values.get("datasets_command"))
+
+    if datasets_command == "list":
+        provider = cast(str | None, values.get("provider"))
+        search_text = cast(str | None, values.get("search"))
+        output_format = cast(str, values.get("format", "table"))
+        datasets = client.datasets.list(provider=provider)
+        if search_text:
+            needle = search_text.casefold()
+            datasets = [
+                dataset
+                for dataset in datasets
+                if needle in dataset.id.casefold()
+                or needle in dataset.name.casefold()
+                or needle in dataset.provider.casefold()
+            ]
+        datasets = sorted(datasets, key=lambda dataset: dataset.id)
+        if output_format == "json":
+            print(
+                json.dumps(
+                    [_dataset_summary(dataset) for dataset in datasets],
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            return 0
+        dataset_rows: list[dict[str, object]] = [
+            {
+                "id": dataset.id,
+                "name": dataset.name,
+                "provider": dataset.provider,
+                "operations": ", ".join(_operation_names(dataset.operations)),
+            }
+            for dataset in datasets
+        ]
+        print(_render_table(dataset_rows, headers=["id", "name", "provider", "operations"]))
+        return 0
+
+    if datasets_command == "show":
+        dataset_id = cast(str, values.get("dataset_id"))
+        output_format = cast(str, values.get("format", "table"))
+        _, dataset = client.datasets.resolve(dataset_id)
+        metadata = _dataset_details(dataset)
+        if output_format == "json":
+            print(json.dumps(metadata, ensure_ascii=False, indent=2))
+            return 0
+        raw_metadata_keys = cast(list[str], metadata["raw_metadata_keys"])
+        capabilities = metadata["capabilities"]
+        detail_rows: list[dict[str, object]] = [
+            {"field": "id", "value": metadata["id"]},
+            {"field": "name", "value": metadata["name"]},
+            {"field": "provider", "value": metadata["provider"]},
+            {"field": "operations", "value": ", ".join(_operation_names(dataset.operations))},
+            {
+                "field": "capabilities",
+                "value": json.dumps(capabilities, ensure_ascii=False),
+            },
+            {
+                "field": "raw_metadata_keys",
+                "value": ", ".join(raw_metadata_keys),
+            },
+        ]
+        print(_render_table(detail_rows, headers=["field", "value"]))
+        return 0
+
+    raise InvalidRequestError("Missing datasets subcommand")
+
+
+def _handle_fetch_command(client: Client, args: argparse.Namespace) -> int:
+    values = vars(args)
+    params = _parse_assignments(cast(list[str], values.get("param", [])), flag_name="-p/--param")
+    list_kwargs: dict[str, object] = dict(params)
+    page = cast(int | None, values.get("page"))
+    page_size = cast(int | None, values.get("page_size"))
+    output_format = cast(str, values.get("format", "table"))
+    output_path = cast(str | None, values.get("output"))
+    dataset_id = cast(str, values.get("dataset_id"))
+    fetch_all = cast(bool, values.get("all", False))
+
+    if page is not None:
+        list_kwargs["page"] = page
+    if page_size is not None:
+        list_kwargs["page_size"] = page_size
+
+    dataset = client.dataset(dataset_id)
+    if fetch_all:
+        items: list[dict[str, object]] = []
+        for batch in dataset.list_all(**list_kwargs):
+            items.extend(batch.items)
+        rendered = _render_records(items, output_format=output_format)
+    else:
+        batch = dataset.list(**list_kwargs)
+        rendered = _render_records(batch.items, output_format=output_format)
+    _write_output(rendered, output_path)
+    return 0
+
+
+def _handle_raw_command(client: Client, args: argparse.Namespace) -> int:
+    values = vars(args)
+    params = _parse_assignments(cast(list[str], values.get("param", [])), flag_name="-p/--param")
+    dataset_id = cast(str, values.get("dataset_id"))
+    operation = cast(str, values.get("operation"))
+    output_path = cast(str | None, values.get("output"))
+    dataset = client.dataset(dataset_id)
+    payload = dataset.call_raw(operation, **params)
+    _write_output(json.dumps(_to_jsonable(payload), ensure_ascii=False, indent=2), output_path)
+    return 0
+
+
+def _dataset_summary(dataset: DatasetRef) -> dict[str, object]:
+    return {
+        "id": dataset.id,
+        "name": dataset.name,
+        "provider": dataset.provider,
+        "operations": _operation_names(dataset.operations),
+    }
+
+
+def _dataset_details(dataset: DatasetRef) -> dict[str, object]:
+    return {
+        "id": dataset.id,
+        "name": dataset.name,
+        "provider": dataset.provider,
+        "operations": _operation_names(dataset.operations),
+        "capabilities": _query_support_payload(dataset.query_support),
+        "raw_metadata_keys": sorted(dataset.raw_metadata.keys()),
+    }
+
+
+def _query_support_payload(query_support: QuerySupport | None) -> dict[str, object] | None:
+    if query_support is None:
+        return None
+    return {
+        "pagination": query_support.pagination.value,
+        "filterable_fields": sorted(query_support.filterable_fields),
+        "sortable_fields": sorted(query_support.sortable_fields),
+        "time_range": query_support.time_range,
+        "max_page_size": query_support.max_page_size,
+    }
+
+
+def _render_records(items: list[dict[str, object]], *, output_format: str) -> str:
+    if output_format == "json":
+        return json.dumps(_to_jsonable(items), ensure_ascii=False, indent=2)
+    if output_format == "csv":
+        return _render_csv(items)
+    return _render_table(items, headers=_table_headers(items))
+
+
+def _render_csv(items: list[dict[str, object]]) -> str:
+    output = io.StringIO()
+    headers = _csv_headers(items)
+    writer = csv.DictWriter(output, fieldnames=headers, extrasaction="ignore")
+    if headers:
+        writer.writeheader()
+        for item in items:
+            writer.writerow({key: _stringify_value(item.get(key, "")) for key in headers})
+    return output.getvalue()
+
+
+def _render_table(rows: Sequence[Mapping[str, object]], *, headers: Sequence[str]) -> str:
+    if not headers:
+        return "(no columns)"
+    if not rows:
+        return "(no rows)"
+
+    normalized_rows: list[dict[str, str]] = [
+        {header: _truncate(_stringify_value(row.get(header, ""))) for header in headers}
+        for row in rows
+    ]
+    widths = {
+        header: max(len(header), *(len(row[header]) for row in normalized_rows))
+        for header in headers
+    }
+    header_line = "  ".join(header.ljust(widths[header]) for header in headers)
+    separator_line = "  ".join("-" * widths[header] for header in headers)
+    body_lines = [
+        "  ".join(row[header].ljust(widths[header]) for header in headers)
+        for row in normalized_rows
+    ]
+    return "\n".join([header_line, separator_line, *body_lines])
+
+
+def _table_headers(items: list[dict[str, object]]) -> list[str]:
+    if not items:
+        return []
+    return list(items[0].keys())[:_MAX_TABLE_COLUMNS]
+
+
+def _csv_headers(items: list[dict[str, object]]) -> list[str]:
+    headers: list[str] = []
+    for item in items:
+        for key in item:
+            if key not in headers:
+                headers.append(key)
+    return headers
+
+
+def _parse_assignments(values: Sequence[str], *, flag_name: str) -> dict[str, str]:
+    assignments: dict[str, str] = {}
+    for value in values:
+        key, parsed_value = _split_assignment(value, flag_name=flag_name)
+        assignments[key] = parsed_value
+    return assignments
+
+
+def _split_assignment(value: str, *, flag_name: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise InvalidRequestError(f"{flag_name} expects KEY=VALUE: {value}")
+    key, parsed_value = value.split("=", 1)
+    normalized_key = key.strip()
+    if not normalized_key:
+        raise InvalidRequestError(f"{flag_name} expects a non-empty key: {value}")
+    return normalized_key, parsed_value
+
+
+def _write_output(content: str, output_path: str | None) -> None:
+    if output_path is None:
+        _ = sys.stdout.write(content)
+        if not content.endswith("\n"):
+            _ = sys.stdout.write("\n")
+        return
+    _ = Path(output_path).write_text(content, encoding="utf-8")
+
+
+def _operation_names(operations: Iterable[Operation]) -> list[str]:
+    return sorted(operation.value for operation in operations)
+
+
+def _to_jsonable(value: object) -> object:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Enum):
+        return cast(object, value.value)
+    if isinstance(value, Mapping):
+        mapping_value = cast(Mapping[object, object], value)
+        return {str(key): _to_jsonable(item) for key, item in mapping_value.items()}
+    if isinstance(value, (list, tuple)):
+        sequence_value = cast(Sequence[object], value)
+        return [_to_jsonable(item) for item in sequence_value]
+    if isinstance(value, RecordBatch):
+        return {
+            "items": _to_jsonable(value.items),
+            "dataset": value.dataset.id,
+            "total_count": value.total_count,
+            "next_page": value.next_page,
+            "next_cursor": value.next_cursor,
+            "meta": _to_jsonable(value.meta),
+            "raw": _to_jsonable(value.raw),
+        }
+    if isinstance(value, DatasetRef):
+        return _dataset_details(value)
+    return repr(value)
+
+
+def _stringify_value(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    return json.dumps(_to_jsonable(value), ensure_ascii=False)
+
+
+def _truncate(value: str) -> str:
+    if len(value) <= _MAX_CELL_WIDTH:
+        return value
+    return f"{value[: _MAX_CELL_WIDTH - 1]}…"
+
+
+def _print_error(exc: BaseException) -> None:
+    print(f"error: {type(exc).__name__}: {exc}", file=sys.stderr)
+
+
+def _get_version() -> str:
+    try:
+        return version("kpubdata")
+    except PackageNotFoundError:
+        return __version__
+
+
+if __name__ == "__main__":
+    exit_code = main()
+    raise SystemExit(exit_code)

--- a/src/kpubdata/cli/scaffold_provider.py
+++ b/src/kpubdata/cli/scaffold_provider.py
@@ -1,0 +1,329 @@
+"""Generate boilerplate files for a new kpubdata provider adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _init_template(class_name: str) -> str:
+    return f'''"""{{name}} provider adapter package."""
+
+from __future__ import annotations
+
+from .adapter import {class_name}
+
+__all__ = ["{class_name}"]
+'''
+
+
+def _adapter_template(name: str, class_name: str) -> str:
+    return f'''"""{{name}} adapter with curated dataset catalogue."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import cast
+
+from kpubdata.config import KPubDataConfig
+from kpubdata.core.models import (
+    DatasetRef,
+    Query,
+    RecordBatch,
+    SchemaDescriptor,
+)
+from kpubdata.core.protocol import ProviderAdapter
+from kpubdata.exceptions import (
+    DatasetNotFoundError,
+)
+from kpubdata.providers._common import load_catalogue
+from kpubdata.transport.http import HttpTransport
+
+logger = logging.getLogger("kpubdata.provider.{name}")
+
+
+class {class_name}(ProviderAdapter):
+    """Provider adapter for {name}."""
+
+    def __init__(
+        self,
+        config: KPubDataConfig,
+        transport: HttpTransport | None = None,
+    ) -> None:
+        self._config = config
+        self._transport = transport or HttpTransport()
+        self._catalogue = load_catalogue(Path(__file__).parent / "catalogue.json")
+        self._datasets: dict[str, DatasetRef] = {{}}
+        for entry in self._catalogue:
+            key = entry["dataset_key"]
+            self._datasets[key] = DatasetRef(
+                id=f"{name}.{{key}}",
+                provider="{name}",
+                ops=entry.get("operations", ["list", "raw"]),
+            )
+
+    @property
+    def name(self) -> str:
+        return "{name}"
+
+    def list_datasets(self) -> list[DatasetRef]:
+        return list(self._datasets.values())
+
+    def search_datasets(self, keyword: str) -> list[DatasetRef]:
+        keyword_lower = keyword.lower()
+        return [
+            ds
+            for ds in self._datasets.values()
+            if keyword_lower in ds.id.lower()
+        ]
+
+    def get_dataset(self, dataset_key: str) -> DatasetRef:
+        if dataset_key not in self._datasets:
+            raise DatasetNotFoundError(
+                f"Dataset not found: {name}.{{dataset_key}}",
+                provider="{name}",
+                dataset_id=f"{name}.{{dataset_key}}",
+            )
+        return self._datasets[dataset_key]
+
+    def query_records(self, dataset: DatasetRef, query: Query) -> RecordBatch:
+        # TODO: Implement actual API call logic
+        raise NotImplementedError("query_records not yet implemented")
+
+    def get_schema(self, dataset: DatasetRef) -> SchemaDescriptor | None:
+        return None
+
+    def call_raw(
+        self, dataset: DatasetRef, operation: str, params: dict[str, object]
+    ) -> object:
+        # TODO: Implement raw API call logic
+        raise NotImplementedError("call_raw not yet implemented")
+'''
+
+
+def _catalogue_template(dataset_key: str) -> str:
+    catalogue = [
+        {
+            "dataset_key": dataset_key,
+            "name": f"{dataset_key} dataset",
+            "base_url": "https://example.com/api",
+            "default_operation": "getData",
+            "representation": "api_json",
+            "description": f"TODO: describe {dataset_key}",
+            "operations": ["list", "raw"],
+            "query_support": {
+                "pagination": "offset",
+                "max_page_size": 1000,
+            },
+        }
+    ]
+    return json.dumps(catalogue, indent=2, ensure_ascii=False) + "\n"
+
+
+def _unit_test_template(name: str, class_name: str) -> str:
+    return f'''"""Unit tests for {name} adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from kpubdata.config import KPubDataConfig
+from kpubdata.core.models import DatasetRef, Query
+from kpubdata.exceptions import DatasetNotFoundError
+from kpubdata.providers.{name}.adapter import {class_name}
+
+
+def _build_adapter() -> {class_name}:
+    config = KPubDataConfig(provider_keys={{"{name}": "test-key"}})
+    return {class_name}(config=config)
+
+
+class Test{class_name}:
+    def test_name(self) -> None:
+        adapter = _build_adapter()
+        assert adapter.name == "{name}"
+
+    def test_list_datasets_nonempty(self) -> None:
+        adapter = _build_adapter()
+        datasets = adapter.list_datasets()
+        assert len(datasets) > 0
+        assert all(isinstance(ds, DatasetRef) for ds in datasets)
+
+    def test_get_dataset_valid(self) -> None:
+        adapter = _build_adapter()
+        datasets = adapter.list_datasets()
+        first_key = datasets[0].dataset_key
+        ds = adapter.get_dataset(first_key)
+        assert isinstance(ds, DatasetRef)
+
+    def test_get_dataset_invalid_raises(self) -> None:
+        adapter = _build_adapter()
+        with pytest.raises(DatasetNotFoundError):
+            adapter.get_dataset("nonexistent_key_xyz")
+
+    def test_all_datasets_have_provider(self) -> None:
+        adapter = _build_adapter()
+        for ds in adapter.list_datasets():
+            assert ds.provider == "{name}"
+'''
+
+
+def _contract_test_template(name: str, class_name: str) -> str:
+    return f'''"""Contract tests for {name} adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from kpubdata.config import KPubDataConfig
+from kpubdata.core.models import DatasetRef, Query
+from kpubdata.providers.{name}.adapter import {class_name}
+from tests.contract.provider_adapter import ProviderAdapterContract
+
+
+def _build_adapter() -> {class_name}:
+    config = KPubDataConfig(provider_keys={{"{name}": "test-key"}})
+    return {class_name}(config=config)
+
+
+class Test{class_name}Contract(ProviderAdapterContract):
+    @pytest.fixture()
+    def adapter(self) -> {class_name}:
+        return _build_adapter()
+
+    @pytest.fixture()
+    def valid_dataset_key(self) -> str:
+        # TODO: replace with actual dataset key from catalogue.json
+        return "example_dataset"
+
+    @pytest.fixture()
+    def invalid_dataset_key(self) -> str:
+        return "nonexistent_dataset_key_xyz"
+
+    @pytest.fixture()
+    def sample_dataset(self, adapter: {class_name}) -> DatasetRef:
+        # TODO: replace with actual dataset key from catalogue.json
+        return adapter.get_dataset("example_dataset")
+
+    @pytest.fixture()
+    def sample_query(self) -> Query:
+        return Query()
+
+    @pytest.fixture()
+    def raw_operation(self) -> tuple[str, dict[str, object]]:
+        # TODO: replace with actual operation name
+        return ("getData", {{}})
+'''
+
+
+def _to_class_name(provider_name: str) -> str:
+    """Convert provider name to PascalCase class name.
+
+    Examples:
+        "datago" -> "DatagoAdapter"
+        "my_provider" -> "MyProviderAdapter"
+        "seoul-open" -> "SeoulOpenAdapter"
+    """
+    parts = provider_name.replace("-", "_").split("_")
+    pascal = "".join(part.capitalize() for part in parts)
+    return f"{pascal}Adapter"
+
+
+def scaffold_provider(
+    provider_name: str,
+    dataset_key: str = "example_dataset",
+    project_root: Path | None = None,
+) -> list[Path]:
+    """Generate boilerplate files for a new provider adapter.
+
+    Args:
+        provider_name: Short identifier for the provider (e.g. "kosis", "ecos").
+        dataset_key: Initial dataset key to include in catalogue.json.
+        project_root: Root directory of the kpubdata project. Defaults to cwd.
+
+    Returns:
+        List of created file paths.
+    """
+    root = project_root or Path.cwd()
+    class_name = _to_class_name(provider_name)
+
+    provider_dir = root / "src" / "kpubdata" / "providers" / provider_name
+    unit_test_dir = root / "tests" / "unit" / "providers" / provider_name
+    contract_test_dir = root / "tests" / "contract"
+
+    files: list[tuple[Path, str]] = [
+        (provider_dir / "__init__.py", _init_template(class_name)),
+        (provider_dir / "adapter.py", _adapter_template(provider_name, class_name)),
+        (provider_dir / "catalogue.json", _catalogue_template(dataset_key)),
+        (unit_test_dir / "__init__.py", ""),
+        (unit_test_dir / "test_adapter.py", _unit_test_template(provider_name, class_name)),
+        (
+            contract_test_dir / f"test_{provider_name}.py",
+            _contract_test_template(provider_name, class_name),
+        ),
+    ]
+
+    created: list[Path] = []
+    for path, content in files:
+        if path.exists():
+            print(f"  SKIP (exists): {path.relative_to(root)}")
+            continue
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        print(f"  CREATED: {path.relative_to(root)}")
+        created.append(path)
+
+    return created
+
+
+def main() -> None:
+    """CLI entry point for provider scaffolding."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Scaffold a new kpubdata provider adapter",
+    )
+    parser.add_argument(
+        "provider_name",
+        help="Short identifier for the provider (e.g. kosis, ecos, seoul)",
+    )
+    parser.add_argument(
+        "--dataset-key",
+        default="example_dataset",
+        help="Initial dataset key for catalogue.json (default: example_dataset)",
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=None,
+        help="Project root directory (default: current directory)",
+    )
+
+    args = parser.parse_args()
+
+    print(f"Scaffolding provider: {args.provider_name}")
+    print()
+
+    created = scaffold_provider(
+        provider_name=args.provider_name,
+        dataset_key=args.dataset_key,
+        project_root=args.project_root,
+    )
+
+    print()
+    if created:
+        print(f"Done! {len(created)} file(s) created.")
+        print()
+        print("Next steps:")
+        print(f"  1. Edit src/kpubdata/providers/{args.provider_name}/catalogue.json")
+        print("     - Update dataset_key, name, base_url, default_operation")
+        print("  2. Implement query_records() and call_raw() in adapter.py")
+        print("  3. Update contract test fixtures (valid_dataset_key, sample_dataset, etc.)")
+        print(f"  4. Run: uv run pytest tests/unit/providers/{args.provider_name} -q")
+    else:
+        print("No files created (all already exist).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/cli/test_scaffold_provider.py
+++ b/tests/unit/cli/test_scaffold_provider.py
@@ -1,0 +1,116 @@
+"""Unit tests for provider scaffolding tool."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kpubdata.cli.scaffold_provider import (
+    _to_class_name,
+    scaffold_provider,
+)
+
+
+class TestToClassName:
+    def test_simple_name(self) -> None:
+        assert _to_class_name("kosis") == "KosisAdapter"
+
+    def test_underscore_name(self) -> None:
+        assert _to_class_name("my_provider") == "MyProviderAdapter"
+
+    def test_hyphen_name(self) -> None:
+        assert _to_class_name("seoul-open") == "SeoulOpenAdapter"
+
+    def test_single_char(self) -> None:
+        assert _to_class_name("x") == "XAdapter"
+
+
+class TestScaffoldProvider:
+    def test_creates_all_files(self, tmp_path: Path) -> None:
+        # Set up minimal project structure
+        (tmp_path / "src" / "kpubdata" / "providers").mkdir(parents=True)
+        (tmp_path / "tests" / "unit" / "providers").mkdir(parents=True)
+        (tmp_path / "tests" / "contract").mkdir(parents=True)
+
+        created = scaffold_provider(
+            provider_name="testprov",
+            dataset_key="my_dataset",
+            project_root=tmp_path,
+        )
+
+        assert len(created) == 6
+
+        # Verify provider source files
+        provider_dir = tmp_path / "src" / "kpubdata" / "providers" / "testprov"
+        assert (provider_dir / "__init__.py").exists()
+        assert (provider_dir / "adapter.py").exists()
+        assert (provider_dir / "catalogue.json").exists()
+
+        # Verify test files
+        unit_dir = tmp_path / "tests" / "unit" / "providers" / "testprov"
+        assert (unit_dir / "__init__.py").exists()
+        assert (unit_dir / "test_adapter.py").exists()
+
+        contract_file = tmp_path / "tests" / "contract" / "test_testprov.py"
+        assert contract_file.exists()
+
+    def test_adapter_contains_class(self, tmp_path: Path) -> None:
+        (tmp_path / "src" / "kpubdata" / "providers").mkdir(parents=True)
+        (tmp_path / "tests" / "unit" / "providers").mkdir(parents=True)
+        (tmp_path / "tests" / "contract").mkdir(parents=True)
+
+        scaffold_provider("myprov", project_root=tmp_path)
+
+        adapter_code = (
+            tmp_path / "src" / "kpubdata" / "providers" / "myprov" / "adapter.py"
+        ).read_text()
+        assert "class MyprovAdapter" in adapter_code
+        assert "ProviderAdapter" in adapter_code
+        assert "def name(self)" in adapter_code
+
+    def test_init_exports_adapter(self, tmp_path: Path) -> None:
+        (tmp_path / "src" / "kpubdata" / "providers").mkdir(parents=True)
+        (tmp_path / "tests" / "unit" / "providers").mkdir(parents=True)
+        (tmp_path / "tests" / "contract").mkdir(parents=True)
+
+        scaffold_provider("myprov", project_root=tmp_path)
+
+        init_code = (
+            tmp_path / "src" / "kpubdata" / "providers" / "myprov" / "__init__.py"
+        ).read_text()
+        assert "MyprovAdapter" in init_code
+
+    def test_catalogue_valid_json(self, tmp_path: Path) -> None:
+        (tmp_path / "src" / "kpubdata" / "providers").mkdir(parents=True)
+        (tmp_path / "tests" / "unit" / "providers").mkdir(parents=True)
+        (tmp_path / "tests" / "contract").mkdir(parents=True)
+
+        scaffold_provider("myprov", dataset_key="weather", project_root=tmp_path)
+
+        cat_path = tmp_path / "src" / "kpubdata" / "providers" / "myprov" / "catalogue.json"
+        data = json.loads(cat_path.read_text())
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["dataset_key"] == "weather"
+
+    def test_skip_existing_files(self, tmp_path: Path) -> None:
+        (tmp_path / "src" / "kpubdata" / "providers").mkdir(parents=True)
+        (tmp_path / "tests" / "unit" / "providers").mkdir(parents=True)
+        (tmp_path / "tests" / "contract").mkdir(parents=True)
+
+        first = scaffold_provider("myprov", project_root=tmp_path)
+        second = scaffold_provider("myprov", project_root=tmp_path)
+
+        assert len(first) == 6
+        assert len(second) == 0
+
+    def test_contract_test_inherits_base(self, tmp_path: Path) -> None:
+        (tmp_path / "src" / "kpubdata" / "providers").mkdir(parents=True)
+        (tmp_path / "tests" / "unit" / "providers").mkdir(parents=True)
+        (tmp_path / "tests" / "contract").mkdir(parents=True)
+
+        scaffold_provider("myprov", project_root=tmp_path)
+
+        contract_code = (tmp_path / "tests" / "contract" / "test_myprov.py").read_text()
+        assert "ProviderAdapterContract" in contract_code
+        assert "TestMyprovAdapterContract" in contract_code


### PR DESCRIPTION
Closes #61 

## 요약
새 provider adapter를 추가할 때 필요한 보일러플레이트 파일을 자동 생성하는 CLI 도구입니다.

## 변경 사항
- `src/kpubdata/cli/scaffold_provider.py`: scaffolding 도구 구현
- `tests/unit/cli/test_scaffold_provider.py`: 유닛 테스트

## 생성되는 파일
- `src/kpubdata/providers/<name>/__init__.py`
- `src/kpubdata/providers/<name>/adapter.py`
- `src/kpubdata/providers/<name>/catalogue.json`
- `tests/unit/providers/<name>/__init__.py`
- `tests/unit/providers/<name>/test_adapter.py`
- `tests/contract/test_<name>.py`

## 검증
- [x] `uv run pytest tests/unit/cli` 통과
- [x] `uv run mypy src/kpubdata/cli/` 에러 없음
- [x] `uv run ruff check .` 경고 없음

## 참고
- 기존 mypy 에러(krx, models.py)는 이 PR 범위 밖입니다.