### PR TITLE
docs: GitHub Pages 사이트 설정 (MkDocs Material)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mkdocs-material pymdown-extensions
+      - run: mkdocs build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ Thumbs.db
 .sisyphus/
 .playwright-mcp/
 tmp/
+site/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,44 @@
+# KPubData
+
+**한국 공공데이터 접근 프레임워크**
+
+KPubData는 한국 공공데이터(data.go.kr 등)의 파편화된 API를 하나의 일관된 인터페이스로 통합하는 Python 프레임워크입니다.
+
+## 특징
+
+- 🏛️ **다기관 통합** — 공공데이터포털, 한국은행, 통계청, 서울시 등 8개 기관 지원
+- 🔌 **Dialect 아키텍처** — 핵심은 작고 안정적으로, 기관별 차이는 어댑터가 처리
+- 🐍 **Pythonic API** — `snake_case`, 타입 힌트, 직관적 메서드명
+- 🚪 **Raw 비상구** — 표준화된 접근과 원본 API 직접 호출을 모두 지원
+- 📊 **pandas 통합** — 조회 결과를 DataFrame으로 즉시 변환
+
+## 설치
+
+```bash
+pip install kpubdata
+```
+
+## 빠른 예제
+
+```python
+from kpubdata import Client
+
+client = Client.from_env()
+
+# 데이터셋 탐색
+for ds in client.datasets.search("예보"):
+    print(ds.id, ds.name)
+
+# 데이터 조회
+ds = client.dataset("datago.village_fcst")
+result = ds.list(base_date="20250401", base_time="0500", nx="55", ny="127")
+
+for item in result.items:
+    print(item)
+```
+
+## 다음 단계
+
+- [빠른 시작 가이드](quickstart.md) — 설치부터 첫 조회까지
+- [CLI 사용법](cli.md) — 터미널에서 바로 사용하기
+- [Cookbook](cookbook/getting-started.md) — 실전 예제 모음

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,73 @@
+site_name: KPubData
+site_url: https://yeongseon.github.io/kpubdata
+site_description: 한국 공공데이터 접근 프레임워크
+repo_url: https://github.com/yeongseon/kpubdata
+repo_name: yeongseon/kpubdata
+
+theme:
+  name: material
+  language: ko
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: 다크 모드로 전환
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: 라이트 모드로 전환
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.expand
+    - content.code.copy
+    - search.suggest
+
+plugins:
+  - search
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - toc:
+      permalink: true
+
+nav:
+  - 홈: index.md
+  - 빠른 시작: quickstart.md
+  - CLI: cli.md
+  - 캐싱: caching.md
+  - 로깅: logging.md
+  - Cookbook:
+      - 시작하기: cookbook/getting-started.md
+      - 데이터셋 탐색: cookbook/discovery.md
+      - Raw 접근: cookbook/raw-access.md
+  - Providers:
+      - 공공데이터포털 (datago): providers/datago.md
+      - 서울 열린데이터광장: providers/seoul.md
+      - 통계청 KOSIS: providers/kosis.md
+      - 한국은행 BOK: providers/bok.md
+  - 아키텍처:
+      - 시스템 구조: architecture-diagrams.md
+      - Product Family: product-family-architecture.md
+      - datago API 참고: datago-api-reference.md
+  - ADR:
+      - "0001: Dialect 아키텍처": adrs/0001-dialect-inspired-architecture.md
+      - "0002: UX 표준화": adrs/0002-standardize-ux-not-native-shape.md
+  - 튜토리얼:
+      - AI 에이전트 워크플로우: tutorial-ai-agent-workflow.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ dev = [
   "ruff>=0.5,<1",
   "xmltodict>=0.13,<1",
 ]
+docs = [
+  "mkdocs-material>=9.5,<10",
+  "pymdown-extensions>=10,<11",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/kpubdata"]


### PR DESCRIPTION
## Summary

- MkDocs Material 테마로 문서 사이트 구성
- GitHub Actions 워크플로우로 main push 시 자동 배포
- `https://yeongseon.github.io/kpubdata` 에서 접근 가능

## 머지 후 필요한 작업

Settings → Pages → Source를 **"GitHub Actions"**로 변경 (한 번만)

## 변경 파일

- `mkdocs.yml` — 사이트 설정 (테마, nav, 플러그인)
- `docs/index.md` — 랜딩 페이지
- `.github/workflows/docs.yml` — 빌드/배포 워크플로우
- `pyproject.toml` — `[docs]` optional dependency 추가
- `.gitignore` — `site/` 제외