### PR TITLE
feat(datago): 식약처 DUR 병용금기 데이터셋 추가

### DIFF
--- a/SUPPORTED_DATA.md
+++ b/SUPPORTED_DATA.md
@@ -35,6 +35,7 @@
 | 지원 | 실API 검증 | 2026-04-21 | 공공데이터포털 (`datago`) | `air_quality` | 대기오염정보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
 | 지원 | 실API 검증 | 2026-04-21 | 공공데이터포털 (`datago`) | `bus_arrival` | 경기도 버스도착정보 조회서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 경기도 v2 endpoint (`getBusArrivalListv2`) + 자체 envelope (`msgHeader`/`msgBody`) |
 | 지원 | 실API 검증 | 2026-04-21 | 공공데이터포털 (`datago`) | `hospital_info` | 병원정보서비스 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | |
+| 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `dur_usjnt_taboo` | 의약품 안전사용서비스 DUR 병용금기 품목정보 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr/15059486](https://www.data.go.kr/data/15059486/openapi.do) | 식품의약품안전처 제공, 이용허락범위 제한 없음, DURPrdlstInfoService03 / `getUsjntTabooInfoList03`, [#92](https://github.com/yeongseon/kpubdata/issues/92) |
 | 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `building_title` | 건축물대장 표제부 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 건축물대장정보 서비스 v2 / `getBrTitleInfo` |
 | 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `building_recap_title` | 건축물대장 총괄표제부 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 건축물대장정보 서비스 v2 / `getBrRecapTitleInfo` |
 | 지원 | 테스트 검증 | - | 공공데이터포털 (`datago`) | `building_floor` | 건축물대장 층별개요 | [공공데이터포털](https://www.data.go.kr) 서비스키 | [data.go.kr](https://www.data.go.kr) | 건축물대장정보 서비스 v2 / `getBrFlrOulnInfo` |

--- a/plans/issue-92-datago-dur-usjnt-taboo.md
+++ b/plans/issue-92-datago-dur-usjnt-taboo.md
@@ -1,0 +1,27 @@
+# Data.go.kr DUR Co-use Taboo Plan (Issue #92)
+
+## Scope
+- Add only the data.go.kr `getUsjntTabooInfoList03` operation as `datago.dur_usjnt_taboo`.
+- Keep the implementation metadata-driven through the existing `DataGoAdapter`.
+- Do not add other DUR operations, shared DUR abstractions, or public API changes.
+- Update fixture, unit, contract, and support-status documentation in the same change.
+
+## Touched modules
+- `src/kpubdata/providers/datago/catalogue.json`
+- `tests/fixtures/datago/success_dur_usjnt_taboo.json`
+- `tests/unit/providers/datago/test_fixtures.py`
+- `tests/contract/test_datago.py`
+- `SUPPORTED_DATA.md`
+
+## Risks
+- The official API supports both XML and JSON, but this change only proves the existing JSON envelope path through a sanitized fixture.
+- `SUPPORTED_DATA.md` must remain conservative: this is test-verified only, not real-API verified.
+- The operation-specific fields are provider-native and should not be normalized into broader DUR semantics.
+
+## Validation steps
+1. `uv run ruff check .`
+2. `uv run ruff format --check .`
+3. `uv run mypy src`
+4. `uv run pytest`
+5. `git diff --stat`
+6. `git diff`

--- a/src/kpubdata/providers/datago/catalogue.json
+++ b/src/kpubdata/providers/datago/catalogue.json
@@ -86,6 +86,23 @@
     }
   },
   {
+    "dataset_key": "dur_usjnt_taboo",
+    "name": "의약품 안전사용서비스 DUR 병용금기 품목정보 (DUR Co-use Taboo)",
+    "base_url": "http://apis.data.go.kr/1471000/DURPrdlstInfoService03",
+    "default_operation": "getUsjntTabooInfoList03",
+    "representation": "api_json",
+    "service_key_param": "serviceKey",
+    "format_param": "type",
+    "description": "MFDS DUR co-use taboo drug product information",
+    "tags": ["healthcare", "medicine", "dur", "mfds"],
+    "source_url": "https://www.data.go.kr/data/15059486/openapi.do",
+    "operations": ["list", "raw"],
+    "query_support": {
+      "pagination": "offset",
+      "max_page_size": 1000
+    }
+  },
+  {
     "dataset_key": "building_title",
     "name": "건축물대장 표제부 (Building Title Info)",
     "base_url": "http://apis.data.go.kr/1613000/BldRgstService_v2",

--- a/tests/contract/test_datago.py
+++ b/tests/contract/test_datago.py
@@ -6,6 +6,7 @@ from typing import cast
 import pytest
 
 from kpubdata.config import KPubDataConfig
+from kpubdata.core.capability import Operation, PaginationMode
 from kpubdata.core.models import DatasetRef, Query
 from kpubdata.providers.datago.adapter import DataGoAdapter
 from kpubdata.transport.http import HttpTransport
@@ -74,3 +75,28 @@ class TestDataGoAdapterContract(ProviderAdapterContract):
     @pytest.fixture()
     def raw_operation(self) -> tuple[str, dict[str, object]]:
         return ("getVilageFcst", {})
+
+
+def test_dur_usjnt_taboo_dataset_contract_metadata() -> None:
+    adapter = _build_adapter(["success_dur_usjnt_taboo.json"])
+
+    dataset = adapter.get_dataset("dur_usjnt_taboo")
+
+    assert dataset.id == "datago.dur_usjnt_taboo"
+    assert Operation.LIST in dataset.operations
+    assert Operation.RAW in dataset.operations
+    assert dataset.query_support is not None
+    assert dataset.query_support.pagination is PaginationMode.OFFSET
+
+
+def test_dur_usjnt_taboo_dataset_contract_query_and_raw() -> None:
+    adapter = _build_adapter(["success_dur_usjnt_taboo.json", "success_dur_usjnt_taboo.json"])
+    dataset = adapter.get_dataset("dur_usjnt_taboo")
+
+    batch = adapter.query_records(dataset, Query(filters={"itemName": "샘플"}))
+    raw = adapter.call_raw(dataset, "getUsjntTabooInfoList03", {"itemName": "샘플"})
+
+    assert batch.dataset is dataset
+    assert len(batch.items) == 2
+    assert all(isinstance(item, dict) for item in batch.items)
+    assert raw is not None

--- a/tests/fixtures/datago/success_dur_usjnt_taboo.json
+++ b/tests/fixtures/datago/success_dur_usjnt_taboo.json
@@ -1,0 +1,33 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "00",
+      "resultMsg": "NORMAL SERVICE."
+    },
+    "body": {
+      "items": {
+        "item": [
+          {
+            "ITEM_SEQ": "200000001",
+            "ITEM_NAME": "샘플정A",
+            "ENTP_NAME": "샘플제약",
+            "MIXTURE_ITEM_SEQ": "200000002",
+            "MIXTURE_ITEM_NAME": "샘플캡슐B",
+            "PROHBT_CONTENT": "병용금기 대표 샘플"
+          },
+          {
+            "ITEM_SEQ": "200000003",
+            "ITEM_NAME": "샘플정C",
+            "ENTP_NAME": "예시제약",
+            "MIXTURE_ITEM_SEQ": "200000004",
+            "MIXTURE_ITEM_NAME": "샘플주사D",
+            "PROHBT_CONTENT": "병용금기 대표 샘플"
+          }
+        ]
+      },
+      "numOfRows": 2,
+      "pageNo": 1,
+      "totalCount": 2
+    }
+  }
+}

--- a/tests/unit/providers/datago/test_fixtures.py
+++ b/tests/unit/providers/datago/test_fixtures.py
@@ -75,6 +75,32 @@ def test_fixture_bus_arrival_v2_list_normalizes_msg_body_list() -> None:
     assert batch.total_count is None
 
 
+def test_fixture_dur_usjnt_taboo_parses() -> None:
+    adapter, dataset = _build_real_estate_adapter("success_dur_usjnt_taboo.json", "dur_usjnt_taboo")
+
+    batch = adapter.query_records(dataset, Query())
+
+    assert len(batch.items) == 2
+    assert batch.items[0]["ITEM_NAME"] == "샘플정A"
+    assert "MIXTURE_ITEM_NAME" in batch.items[0]
+    assert "PROHBT_CONTENT" in batch.items[0]
+    assert batch.total_count == 2
+
+
+def test_fixture_dur_usjnt_taboo_call_raw_returns_full_envelope() -> None:
+    adapter, dataset = _build_real_estate_adapter("success_dur_usjnt_taboo.json", "dur_usjnt_taboo")
+    expected = load_json_fixture("success_dur_usjnt_taboo.json")
+
+    payload = adapter.call_raw(dataset, "getUsjntTabooInfoList03", {"itemName": "샘플"})
+
+    assert payload == expected
+    payload_dict = cast(dict[str, object], payload)
+    response = payload_dict["response"]
+    assert isinstance(response, dict)
+    assert "header" in response
+    assert "body" in response
+
+
 def test_fixture_single_page(configured_adapter: AdapterFactory) -> None:
     adapter, dataset, _ = configured_adapter(["success_single_page.json"])
 


### PR DESCRIPTION
## 요약

- data.go.kr 식품의약품안전처 DUR `getUsjntTabooInfoList03` operation을 `datago.dur_usjnt_taboo` 데이터셋으로 추가했습니다.
- 표준 data.go.kr JSON 응답 envelope에 맞춘 최소 sanitized fixture를 추가했습니다.
- fixture 기반 list parsing 및 raw envelope 반환에 대한 unit test를 추가했습니다.
- 새 데이터셋의 `LIST`/`RAW` capability와 pagination metadata를 확인하는 focused contract test를 추가했습니다.
- `SUPPORTED_DATA.md`에는 실API 검증이 아닌 `테스트 검증` 상태로 보수적으로 반영했습니다.
- 작업 범위와 리스크를 정리한 plan 문서를 추가했습니다.

## 작업 범위

이 PR은 식품의약품안전처 의약품안전사용서비스(DUR)품목정보 OpenAPI 중 `getUsjntTabooInfoList03` operation만 `datago.dur_usjnt_taboo`로 등록합니다.

전체 DUR API surface를 한 번에 구현하지는 않았습니다. 나머지 DUR operation들은 동일한 catalogue/fixture/test 패턴으로 후속 PR에서 확장할 수 있습니다.

## 출처

- 제공기관: 식품의약품안전처
- 포털: 공공데이터포털(data.go.kr)
- API: 식품의약품안전처_의약품안전사용서비스(DUR)품목정보
- Operation: `getUsjntTabooInfoList03`
- 이용허락범위: 제한 없음

## 검증

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src`
- [x] `uv run pytest` — `898 passed, 98 deselected`

## 참고

- API key, service key, token, credential이 포함된 요청 URL은 커밋하지 않았습니다.
- fixture는 테스트 목적의 최소 sanitized sample입니다.
- 이 PR은 `getUsjntTabooInfoList03`만 다루며, 전체 DUR API를 모두 지원한다고 표시하지 않습니다.

Refs #92
