### PR TITLE
ci: add mkdocs build --strict to CI quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,20 @@ jobs:
         with:
           name: dist
           path: dist/
+
+  docs:
+    name: Docs Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install docs dependencies
+        run: pip install mkdocs-material pymdown-extensions
+
+      - name: Build docs (strict)
+        run: mkdocs build --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install mkdocs-material pymdown-extensions
-      - run: mkdocs build
+      - run: mkdocs build --strict
       - uses: actions/upload-pages-artifact@v3
         with:
           path: site

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ uv run ruff format --check .
 uv run mypy src
 uv run pytest
 uv run python -m build
+mkdocs build --strict
 ```
 
 ## Adapter work rules


### PR DESCRIPTION
## Summary
- CI에서 PR마다 `mkdocs build --strict` 실행하여 mermaid 문법 에러, 깨진 링크 등 사전 차단
- docs deploy workflow도 `--strict` 플래그 추가
- AGENTS.md 퀄리티 게이트 목록에 `mkdocs build --strict` 추가

## Why
PR #212에서 mermaid 11.x 에러가 라이브 사이트까지 나간 적 있음. CI에서 잡았어야 했음.