### PR TITLE
refactor: catalog 검색 indexed scorer 도입 (#232)

### DIFF
--- a/src/kpubdata/catalog.py
+++ b/src/kpubdata/catalog.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import builtins
 import logging
+import re
 import unicodedata
+from dataclasses import dataclass
 from difflib import SequenceMatcher
 from typing import cast
 
@@ -18,46 +20,137 @@ logger = logging.getLogger("kpubdata.catalog")
 # Minimum relevance score (0.0–1.0) for a dataset to appear in search results.
 _DEFAULT_SCORE_THRESHOLD = 0.5
 
+# Token-overlap scoring band — always strictly less than the substring 1.0 score
+# so that exact substring matches keep their ranking priority.
+_TOKEN_OVERLAP_FLOOR = 0.7
+_TOKEN_OVERLAP_CEIL = 0.95
+
+# Unicode word tokens (letters, digits, underscore). Identifier-like tokens such
+# as ``village_fcst`` remain a single token, which matches how dataset_key
+# strings are written in provider catalogues.
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
 
 def _normalize(text: str) -> str:
     """NFC-normalize, strip, and casefold a string for search comparison."""
     return unicodedata.normalize("NFC", text).strip().casefold()
 
 
-def _score_dataset(needle: str, dataset: DatasetRef) -> float:
-    """Score a dataset against a search term.
+def _tokenize(text: str) -> frozenset[str]:
+    """Split *text* into a deterministic set of normalized word tokens."""
+    if not text:
+        return frozenset()
+    return frozenset(_TOKEN_RE.findall(_normalize(text)))
 
-    Returns a relevance score between 0.0 and 1.0.  An exact substring
-    match in any searchable field yields 1.0.  Otherwise the best
-    ``SequenceMatcher`` ratio across fields is returned.
 
-    Searchable fields: name, description, tags, id.
+@dataclass(slots=True, frozen=True)
+class _IndexedItem:
+    """Pre-computed search payload for a single dataset.
+
+    Bundles a :class:`DatasetRef` with its normalized field strings and a
+    deterministic token set, so that :class:`Catalog.search` can score each
+    item without recomputing per-call normalization work.
     """
-    needle_lower = _normalize(needle)
-    if not needle_lower:
+
+    dataset: DatasetRef
+    fields: tuple[str, ...]
+    tokens: frozenset[str]
+
+
+def _build_index(datasets: builtins.list[DatasetRef]) -> builtins.list[_IndexedItem]:
+    """Materialize an in-memory search index over *datasets*.
+
+    Each item exposes normalized field strings (name, description, tags, id,
+    dataset_key, provider) and the union of word tokens extracted from those
+    fields. Building the index is O(n) over the candidate set and runs once
+    per search call.
+    """
+    index: builtins.list[_IndexedItem] = []
+    for dataset in datasets:
+        field_sources: builtins.list[str] = [
+            dataset.name,
+            dataset.id,
+            dataset.dataset_key,
+            dataset.provider,
+        ]
+        if dataset.description:
+            field_sources.append(dataset.description)
+        field_sources.extend(dataset.tags)
+
+        normalized_fields: builtins.list[str] = []
+        tokens: set[str] = set()
+        for source in field_sources:
+            normalized = _normalize(source)
+            normalized_fields.append(normalized)
+            tokens.update(_TOKEN_RE.findall(normalized))
+
+        index.append(
+            _IndexedItem(
+                dataset=dataset,
+                fields=tuple(normalized_fields),
+                tokens=frozenset(tokens),
+            )
+        )
+    return index
+
+
+def _score_indexed(
+    needle: str,
+    needle_tokens: frozenset[str],
+    item: _IndexedItem,
+) -> float:
+    """Score *item* against a pre-normalized query and its token set.
+
+    Scoring layers, in priority order:
+
+    1. **Exact substring** in any indexed field → ``1.0``.
+    2. **Token overlap** = matched query tokens / total query tokens, mapped
+       into ``[_TOKEN_OVERLAP_FLOOR, _TOKEN_OVERLAP_CEIL]`` so that token
+       evidence never outranks a substring match.
+    3. **Fuzzy fallback** via ``SequenceMatcher`` ratio across fields.
+
+    The final score is ``max(layer 2, layer 3)`` when layer 1 misses, which
+    preserves prior recall (fuzzy results are never dropped) while letting
+    token evidence promote near-threshold matches.
+    """
+    if not needle:
         return 1.0
 
-    fields: builtins.list[str] = []
-    fields.append(_normalize(dataset.name))
-    if dataset.description:
-        fields.append(_normalize(dataset.description))
-    for tag in dataset.tags:
-        fields.append(_normalize(tag))
-    fields.append(_normalize(dataset.id))
-
-    # Fast path: exact substring match → score 1.0
-    for text in fields:
-        if needle_lower in text:
+    for text in item.fields:
+        if needle in text:
             return 1.0
 
-    # Slow path: fuzzy matching via SequenceMatcher
-    best: float = 0.0
-    for text in fields:
-        ratio = SequenceMatcher(None, needle_lower, text).ratio()
-        if ratio > best:
-            best = ratio
+    overlap_score = 0.0
+    if needle_tokens:
+        matched = len(needle_tokens & item.tokens)
+        if matched:
+            ratio = matched / len(needle_tokens)
+            overlap_score = (
+                _TOKEN_OVERLAP_FLOOR + (_TOKEN_OVERLAP_CEIL - _TOKEN_OVERLAP_FLOOR) * ratio
+            )
 
-    return best
+    fuzzy_score = 0.0
+    for text in item.fields:
+        candidate = SequenceMatcher(None, needle, text).ratio()
+        if candidate > fuzzy_score:
+            fuzzy_score = candidate
+
+    return max(overlap_score, fuzzy_score)
+
+
+def _score_dataset(needle: str, dataset: DatasetRef) -> float:
+    """Score a single dataset against *needle* (public-internal helper).
+
+    Retained for callers that want to score one dataset without materializing
+    a full index. Internally builds a one-shot index entry so behavior stays
+    aligned with :class:`Catalog.search`.
+    """
+    needle_normalized = _normalize(needle)
+    if not needle_normalized:
+        return 1.0
+    needle_tokens = frozenset(_TOKEN_RE.findall(needle_normalized))
+    index = _build_index([dataset])
+    return _score_indexed(needle_normalized, needle_tokens, index[0])
 
 
 class Catalog:
@@ -116,12 +209,16 @@ class Catalog:
             extra={"text": text, "provider_filter": provider, "threshold": threshold},
         )
         candidates = self.list(provider=provider)
+        index = _build_index(candidates)
+
+        needle_normalized = _normalize(text)
+        needle_tokens = frozenset(_TOKEN_RE.findall(needle_normalized))
 
         scored: builtins.list[tuple[float, DatasetRef]] = []
-        for dataset in candidates:
-            score = _score_dataset(text, dataset)
+        for item in index:
+            score = _score_indexed(needle_normalized, needle_tokens, item)
             if score >= threshold:
-                scored.append((score, dataset))
+                scored.append((score, item.dataset))
 
         # Sort by score descending, then by id for stable ordering
         scored.sort(key=lambda pair: (-pair[0], pair[1].id))

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -315,3 +315,258 @@ class TestScoreDataset:
         result = catalog.search("Mock")
         assert len(result) == 1
         adapter.search_datasets.assert_not_called()
+
+
+class TestCatalogIndexedScorer:
+    """Tests for the indexed scorer introduced in the catalog search refactor."""
+
+    @staticmethod
+    def _make_ref(
+        provider: str,
+        key: str,
+        name: str,
+        *,
+        description: str | None = None,
+        tags: tuple[str, ...] = (),
+    ) -> DatasetRef:
+        return DatasetRef(
+            id=f"{provider}.{key}",
+            provider=provider,
+            dataset_key=key,
+            name=name,
+            representation=Representation.API_JSON,
+            operations=frozenset({Operation.LIST}),
+            description=description,
+            tags=tags,
+        )
+
+    def _build_catalog(self) -> Catalog:
+        reg = ProviderRegistry()
+        reg.register(
+            StubAdapter(
+                "weather",
+                [
+                    self._make_ref(
+                        "weather",
+                        "village_fcst",
+                        "동네예보",
+                        description="기상청 단기예보 조회 서비스",
+                        tags=("weather", "forecast", "기상"),
+                    ),
+                    self._make_ref(
+                        "weather",
+                        "marine_fcst",
+                        "해양예보",
+                        description="기상청 해양예보 서비스",
+                        tags=("weather", "marine"),
+                    ),
+                ],
+            )
+        )
+        reg.register(
+            StubAdapter(
+                "finance",
+                [
+                    self._make_ref(
+                        "finance",
+                        "base_rate",
+                        "기준금리",
+                        description="한국은행 기준금리",
+                        tags=("economy", "rate"),
+                    ),
+                ],
+            )
+        )
+        return Catalog(reg)
+
+    def test_token_overlap_ranks_full_match_above_partial(self) -> None:
+        """A dataset matching both query tokens outranks one matching only one."""
+        catalog = self._build_catalog()
+        # 'marine weather' is not a contiguous substring of any field, so both
+        # datasets fall through the substring layer. marine_fcst tags contain
+        # both 'marine' and 'weather' (2/2 → ceil score), while village_fcst
+        # tags contain only 'weather' (1/2 → mid-band score).
+        result = catalog.search("marine weather", threshold=0.6)
+        keys = [ref.dataset_key for ref in result]
+        assert "marine_fcst" in keys and "village_fcst" in keys
+        assert keys.index("marine_fcst") < keys.index("village_fcst")
+
+    def test_provider_name_is_searchable(self) -> None:
+        """Searching by provider name returns that provider's datasets."""
+        catalog = self._build_catalog()
+        result = catalog.search("finance")
+        assert len(result) == 1
+        assert result[0].provider == "finance"
+
+    def test_dataset_key_is_searchable_as_single_token(self) -> None:
+        """Identifier-style dataset_key remains a single token (no underscore split)."""
+        catalog = self._build_catalog()
+        # threshold=0.9 filters out fuzzy noise from sibling keys that share
+        # the '_fcst' suffix; only the exact substring hit on village_fcst
+        # (score 1.0) qualifies.
+        result = catalog.search("village_fcst", threshold=0.9)
+        assert len(result) == 1
+        assert result[0].dataset_key == "village_fcst"
+
+    def test_substring_outranks_token_overlap(self) -> None:
+        """An exact substring hit (score 1.0) always sorts above token-overlap hits."""
+        catalog = self._build_catalog()
+        # 'forecast' appears as a substring in the 'forecast' tag on village_fcst
+        # (score 1.0) and is also a query token. marine_fcst lacks the
+        # 'forecast' tag, so it can only earn a token-overlap or fuzzy score.
+        result = catalog.search("forecast", threshold=0.5)
+        assert result, "expected at least one result"
+        assert result[0].dataset_key == "village_fcst"
+
+    def test_no_result_for_long_meaningless_query(self) -> None:
+        """A long random query stays below threshold (no spurious fuzzy hits)."""
+        catalog = self._build_catalog()
+        result = catalog.search("qzxvbnmqzxvbnmqzxvbnm_no_such_dataset_anywhere")
+        assert result == []
+
+    def test_case_insensitive_token_match(self) -> None:
+        """Token overlap is computed on casefolded text."""
+        catalog = self._build_catalog()
+        # 'MARINE' is uppercase but should match 'marine' tag (substring path).
+        result = catalog.search("MARINE")
+        assert len(result) == 1
+        assert result[0].dataset_key == "marine_fcst"
+
+    def test_mixed_korean_and_ascii_tokenization(self) -> None:
+        """Korean and ASCII tokens coexist in a single query."""
+        catalog = self._build_catalog()
+        # '기상청 forecast' — '기상청' substring hits the description of
+        # village_fcst; 'forecast' substring hits its tag. Both pass via the
+        # substring layer; result is non-empty and stably ordered.
+        result = catalog.search("기상청 forecast", threshold=0.5)
+        assert any(r.dataset_key == "village_fcst" for r in result)
+
+    def test_provider_filter_applies_before_indexing(self) -> None:
+        """Provider filter narrows candidates; cross-provider matches are excluded."""
+        catalog = self._build_catalog()
+        # '한국은행' appears only in the finance dataset's description; with
+        # provider='weather' the candidate pool excludes finance entirely.
+        result = catalog.search("한국은행", provider="weather")
+        assert result == []
+
+    def test_empty_query_returns_all_candidates(self) -> None:
+        """An empty query yields score 1.0 for every dataset (existing contract)."""
+        catalog = self._build_catalog()
+        result = catalog.search("")
+        assert len(result) == 3
+
+    def test_threshold_above_one_returns_empty(self) -> None:
+        """Threshold > 1.0 excludes everything (token overlap caps below 1.0)."""
+        catalog = self._build_catalog()
+        # A query that hits only via token overlap (no substring): pick a query
+        # token that appears only as a token (e.g. provider name as a token).
+        # With threshold=1.01 nothing can pass.
+        result = catalog.search("forecast", threshold=1.01)
+        assert result == []
+
+
+class TestIndexedScorerHelpers:
+    """Direct tests for the indexed scorer building blocks."""
+
+    @staticmethod
+    def _ref(
+        name: str,
+        *,
+        description: str | None = None,
+        tags: tuple[str, ...] = (),
+    ) -> DatasetRef:
+        return DatasetRef(
+            id="prov.key",
+            provider="prov",
+            dataset_key="key",
+            name=name,
+            representation=Representation.API_JSON,
+            operations=frozenset({Operation.LIST}),
+            description=description,
+            tags=tags,
+        )
+
+    def test_tokenize_splits_on_non_word_chars(self) -> None:
+        from kpubdata.catalog import _tokenize
+
+        assert _tokenize("Hello, World!") == frozenset({"hello", "world"})
+
+    def test_tokenize_keeps_underscore_identifier_intact(self) -> None:
+        from kpubdata.catalog import _tokenize
+
+        assert _tokenize("village_fcst") == frozenset({"village_fcst"})
+
+    def test_tokenize_korean_word(self) -> None:
+        from kpubdata.catalog import _tokenize
+
+        assert _tokenize("기상청 예보") == frozenset({"기상청", "예보"})
+
+    def test_tokenize_empty_returns_empty_set(self) -> None:
+        from kpubdata.catalog import _tokenize
+
+        assert _tokenize("") == frozenset()
+        assert _tokenize("   ") == frozenset()
+
+    def test_build_index_includes_provider_and_dataset_key(self) -> None:
+        from kpubdata.catalog import _build_index
+
+        ref = self._ref("Name", tags=("alpha",), description="desc")
+        index = _build_index([ref])
+        assert len(index) == 1
+        item = index[0]
+        assert "prov" in item.tokens
+        assert "key" in item.tokens
+        assert "name" in item.tokens
+        assert "alpha" in item.tokens
+        assert "desc" in item.tokens
+
+    def test_score_indexed_substring_returns_one(self) -> None:
+        from kpubdata.catalog import _build_index, _score_indexed, _tokenize
+
+        ref = self._ref("Hello World")
+        item = _build_index([ref])[0]
+        score = _score_indexed("hello", _tokenize("hello"), item)
+        assert score == 1.0
+
+    def test_score_indexed_token_overlap_band(self) -> None:
+        """Token overlap score stays strictly below 1.0 and within the band."""
+        from kpubdata.catalog import (
+            _TOKEN_OVERLAP_CEIL,
+            _TOKEN_OVERLAP_FLOOR,
+            _build_index,
+            _score_indexed,
+            _tokenize,
+        )
+
+        ref = self._ref("Apple Banana", description="fruit basket")
+        item = _build_index([ref])[0]
+        # Query token 'apple' is a substring of 'apple banana' → returns 1.0.
+        # To force the token-overlap branch we need a query whose tokens match
+        # item tokens exactly but whose normalized form is NOT a substring of
+        # any field. 'banana apple' has both tokens; ' apple banana' contains
+        # both as a substring. Use a query that is not contiguous in any field.
+        query = "banana zzz"
+        score = _score_indexed(query, _tokenize(query), item)
+        # 1/2 of query tokens matched ('banana') → expect floor + 0.5 * (ceil-floor)
+        expected = _TOKEN_OVERLAP_FLOOR + 0.5 * (_TOKEN_OVERLAP_CEIL - _TOKEN_OVERLAP_FLOOR)
+        assert score == pytest.approx(expected)
+        assert score < 1.0
+        assert _TOKEN_OVERLAP_FLOOR <= score <= _TOKEN_OVERLAP_CEIL
+
+    def test_score_indexed_full_token_overlap_below_substring_score(self) -> None:
+        """Even 100% token overlap stays below substring score (1.0)."""
+        from kpubdata.catalog import (
+            _TOKEN_OVERLAP_CEIL,
+            _build_index,
+            _score_indexed,
+            _tokenize,
+        )
+
+        ref = self._ref("Apple Banana")
+        item = _build_index([ref])[0]
+        # 'banana apple' tokens fully overlap but the literal string is not a
+        # contiguous substring of 'apple banana'.
+        query = "banana apple"
+        score = _score_indexed(query, _tokenize(query), item)
+        assert score == pytest.approx(_TOKEN_OVERLAP_CEIL)
+        assert score < 1.0


### PR DESCRIPTION
## 개요

Catalog 검색을 indexed scorer 기반 구조로 refactor합니다.

기존 `_score_dataset`이 매 dataset마다 텍스트 정규화를 반복하던 구조를,
`Catalog.search` 시작 시 한 번 `_build_index`로 모든 후보를 정규화·토큰화하고
`_score_indexed`가 인덱스 위에서 채점하는 구조로 분리합니다.

## 변경 사항

- `src/kpubdata/catalog.py`
  - `_IndexedItem` (frozen dataclass) 추가 — `DatasetRef` + 사전 정규화된 필드 + 토큰 집합
  - `_tokenize(text)` 추가 — `re.compile(r"\w+", re.UNICODE)` 기준 단순 토큰화 (`village_fcst`는 단일 토큰 유지)
  - `_build_index(datasets)` 추가 — search 시작 시 1회 호출
  - `_score_indexed(needle, needle_tokens, item)` 추가 — 점수 layering
    1. substring 매치 → `1.0` (기존 동작 보존)
    2. token overlap → `[0.7, 0.95]` 구간 (substring보다 항상 낮음)
    3. `SequenceMatcher` ratio fuzzy fallback (기존 동작 보존)
  - 검색 필드에 `dataset_key`, `provider` 명시적 포함
  - `_score_dataset` 시그니처 유지 (내부적으로 1-item 인덱스로 위임)
  - `Catalog.search` / `Catalog.list` / `Catalog.resolve` 공개 시그니처 변경 없음
- `tests/unit/test_catalog.py`
  - `TestCatalogIndexedScorer` 추가: token-overlap ranking, provider 검색, dataset_key 토큰 매치, substring 우선순위, 긴 무의미 쿼리 회귀, 한영 혼합 토큰화, provider 필터, 빈 쿼리, threshold > 1.0
  - `TestIndexedScorerHelpers` 추가: `_tokenize` 단위 테스트, `_build_index` 필드 커버리지, `_score_indexed` 점수 구간 검증

## Backward compatibility

- `Catalog.search(text, *, provider=None, threshold=0.5)` 시그니처 동일
- `_DEFAULT_SCORE_THRESHOLD = 0.5` 동일
- substring 매치는 그대로 `1.0`, 빈 쿼리는 그대로 `1.0`
- 동률 시 `id` asc 정렬 동일
- 기존 `_score_dataset` 직접 호출 호환 (테스트 import 유지)
- token-overlap 시그널은 점수를 올리기만 할 뿐 내리지 않음 → 기존 threshold를 통과하던 결과가 누락되는 경우 없음

## 의도된 동작 변경

- 다토큰 쿼리(예: `"marine weather"`)에서 substring으로는 매치되지 않지만 토큰이 일부 일치하는 경우, threshold(0.5) 근처에서 새로 결과가 포함될 수 있습니다.
- 누락 케이스는 없으며 ranking은 substring(1.0) > token overlap(≤0.95) > fuzzy 순서로 유지됩니다.

## Out of scope (follow-up 후보)

- TF-IDF / BM25 정식 도입 (새 dependency 필요)
- CLI `_handle_datasets_command`의 자체 substring 검색을 `Catalog.search`로 위임
- inverted index 캐싱 (현재는 per-call 인덱스)

## 검증

- `uv run ruff check .` → All checks passed!
- `uv run ruff format --check .` → 129 files already formatted
- `uv run mypy src` → Success: no issues found in 42 source files
- `uv run pytest` → 950 passed, 98 deselected
- 신규 catalog 테스트: 18개 추가, 총 44개 통과

## 새 dependency / 외부 파일 변경

- 새 dependency 없음 (`re`, `dataclasses`는 표준 라이브러리)
- `pyproject.toml`, `uv.lock`, provider catalogue JSON, 문서 변경 없음
- API key/token/secret 추가 없음
- 새 `# type: ignore` 추가 없음

Refs #232
