### PR TITLE
feat(registry): 등록 시점 capability contract 검증 추가 (#231)

### DIFF
--- a/src/kpubdata/exceptions.py
+++ b/src/kpubdata/exceptions.py
@@ -99,8 +99,17 @@ class ProviderNotRegisteredError(PublicDataError):
     """Provider 키가 레지스트리에 없을 때 발생한다."""
 
 
+class CapabilityContractError(PublicDataError):
+    """Provider 어댑터의 선언된 capability와 실제 동작이 일치하지 않을 때 발생한다.
+
+    예: catalogue의 dataset이 ``LIST``를 선언했지만 ``list_datasets`` 호출이
+    실패하거나, ``operations``가 빈 집합으로 선언된 dataset이 노출되는 경우.
+    """
+
+
 __all__ = [
     "AuthError",
+    "CapabilityContractError",
     "ConfigError",
     "DatasetNotFoundError",
     "InvalidRequestError",

--- a/src/kpubdata/registry.py
+++ b/src/kpubdata/registry.py
@@ -11,7 +11,8 @@ from collections.abc import Iterator
 from threading import RLock
 from typing import Any
 
-from kpubdata.exceptions import ProviderNotRegisteredError
+from kpubdata.core.models import DatasetRef
+from kpubdata.exceptions import CapabilityContractError, ProviderNotRegisteredError
 
 logger = logging.getLogger("kpubdata.registry")
 
@@ -41,9 +42,17 @@ class ProviderRegistry:
             lazy_names = sorted(self._lazy.keys())
         return f"ProviderRegistry(eager={eager_names}, lazy={lazy_names})"
 
-    def register(self, adapter: Any) -> None:
-        """어댑터 인스턴스를 등록한다. 프로토콜 준수 여부를 검증한다."""
+    def register(self, adapter: Any, *, validate_capabilities: bool = True) -> None:
+        """어댑터 인스턴스를 등록한다. 프로토콜 준수 여부를 검증한다.
+
+        ``validate_capabilities=True``(기본값)이면 등록 시점에 ``list_datasets()``를
+        한 번 호출해 어댑터의 catalogue가 실제로 로드되는지, 각 dataset이 비어 있지
+        않은 ``operations`` 집합을 가지는지(즉 catalogue가 "지원" 거짓 표시를
+        하지 않는지)를 fail-fast로 확인한다. 위반 시 ``CapabilityContractError``.
+        """
         self._validate_adapter(adapter)
+        if validate_capabilities:
+            self._validate_capability_contract(adapter)
         provider_name = str(adapter.name).strip().lower()
 
         with self._lock:
@@ -105,6 +114,7 @@ class ProviderRegistry:
         )
         lazy_adapter = factory()
         self._validate_adapter(lazy_adapter)
+        self._validate_capability_contract(lazy_adapter)
         adapter_name = str(lazy_adapter.name).strip().lower()
         if adapter_name != normalized_name:
             raise TypeError(
@@ -155,6 +165,54 @@ class ProviderRegistry:
         ]
         if non_callable:
             raise TypeError(f"Adapter '{name}' has non-callable required methods: {non_callable}")
+
+    @staticmethod
+    def _validate_capability_contract(adapter: Any) -> None:
+        """어댑터의 catalogue가 정직한 capability 선언을 하는지 fail-fast로 검증한다.
+
+        ``list_datasets()`` 호출 자체가 실패하면 catalogue 로딩이 깨진 상태이므로
+        등록 자체를 차단한다. 그리고 노출되는 각 ``DatasetRef``가 비어 있지 않은
+        ``operations`` 집합을 갖는지 확인한다 — 빈 operations는 "이 dataset은
+        아무 일도 못 한다"는 거짓 표시이기 때문이다.
+        """
+        provider_name = str(getattr(adapter, "name", "<unknown>"))
+
+        try:
+            datasets = adapter.list_datasets()
+        except Exception as exc:
+            raise CapabilityContractError(
+                f"Adapter '{provider_name}' failed to enumerate datasets at registration: {exc}",
+                provider=provider_name,
+            ) from exc
+
+        if not isinstance(datasets, list):
+            raise CapabilityContractError(
+                f"Adapter '{provider_name}' list_datasets() must return a list, "
+                f"got {type(datasets).__name__}",
+                provider=provider_name,
+            )
+
+        empty_ops: list[str] = []
+        non_ref: list[str] = []
+        for entry in datasets:
+            if not isinstance(entry, DatasetRef):
+                non_ref.append(repr(entry))
+                continue
+            if not entry.operations:
+                empty_ops.append(entry.id)
+
+        if non_ref:
+            raise CapabilityContractError(
+                f"Adapter '{provider_name}' list_datasets() returned non-DatasetRef entries: "
+                f"{non_ref[:3]}",
+                provider=provider_name,
+            )
+        if empty_ops:
+            raise CapabilityContractError(
+                f"Adapter '{provider_name}' has datasets declaring empty operations: "
+                f"{empty_ops[:5]}. Empty operations is a dishonest capability declaration.",
+                provider=provider_name,
+            )
 
 
 __all__ = ["ProviderRegistry"]

--- a/src/kpubdata/registry.py
+++ b/src/kpubdata/registry.py
@@ -49,13 +49,23 @@ class ProviderRegistry:
         한 번 호출해 어댑터의 catalogue가 실제로 로드되는지, 각 dataset이 비어 있지
         않은 ``operations`` 집합을 가지는지(즉 catalogue가 "지원" 거짓 표시를
         하지 않는지)를 fail-fast로 확인한다. 위반 시 ``CapabilityContractError``.
+
+        이름 충돌 검사는 capability 검증보다 먼저 수행한다 — capability 검증은
+        ``list_datasets()``를 호출해 catalogue 로드 비용(파일 I/O 등)이 들 수
+        있으므로, 어차피 거부될 등록에 그 비용을 지불하지 않는다.
         """
         self._validate_adapter(adapter)
-        if validate_capabilities:
-            self._validate_capability_contract(adapter)
         provider_name = str(adapter.name).strip().lower()
 
         with self._lock:
+            if provider_name in self._adapters or provider_name in self._lazy:
+                raise ValueError(f"Provider '{provider_name}' is already registered")
+
+        if validate_capabilities:
+            self._validate_capability_contract(adapter)
+
+        with self._lock:
+            # capability 검증 동안 다른 스레드가 같은 이름을 등록했을 가능성에 대비해 재확인.
             if provider_name in self._adapters or provider_name in self._lazy:
                 raise ValueError(f"Provider '{provider_name}' is already registered")
             self._adapters[provider_name] = adapter
@@ -210,7 +220,9 @@ class ProviderRegistry:
         if empty_ops:
             raise CapabilityContractError(
                 f"Adapter '{provider_name}' has datasets declaring empty operations: "
-                f"{empty_ops[:5]}. Empty operations is a dishonest capability declaration.",
+                f"{empty_ops[:5]}. An empty operations set is a dishonest capability "
+                "declaration — the dataset claims to be supported but exposes no callable "
+                "operation.",
                 provider=provider_name,
             )
 

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -274,3 +274,114 @@ class TestProviderRegistry:
         reg = ProviderRegistry()
         with pytest.raises(TypeError):
             reg.register(object())  # type: ignore[arg-type]
+
+
+class TestCapabilityContractValidation:
+    """등록 시점 capability 계약 검증(#231)에 대한 테스트."""
+
+    def _ds(self, key: str, *, operations: tuple[str, ...] = ("list", "raw")) -> object:
+        """테스트용 DatasetRef를 만든다."""
+        from kpubdata.core.capability import Operation
+        from kpubdata.core.models import DatasetRef
+        from kpubdata.core.representation import Representation
+
+        return DatasetRef(
+            id=f"fake.{key}",
+            provider="fake",
+            dataset_key=key,
+            name=key,
+            representation=Representation.API_JSON,
+            operations=frozenset(Operation(op) for op in operations),
+        )
+
+    def test_registration_calls_list_datasets_and_passes_for_honest_adapter(self) -> None:
+        """list_datasets가 비어 있지 않고 operations가 채워져 있으면 통과한다."""
+        from kpubdata.registry import ProviderRegistry
+
+        honest = FakeAdapter("honest")
+        honest_datasets = [self._ds("a"), self._ds("b")]
+        honest.list_datasets = lambda: honest_datasets  # type: ignore[method-assign]
+
+        reg = ProviderRegistry()
+        reg.register(honest)  # 예외가 발생하지 않아야 한다.
+        assert "honest" in reg
+
+    def test_registration_rejects_adapter_whose_list_datasets_crashes(self) -> None:
+        """list_datasets가 예외를 던지면 CapabilityContractError로 빠르게 실패한다."""
+        from kpubdata.exceptions import CapabilityContractError
+        from kpubdata.registry import ProviderRegistry
+
+        broken = FakeAdapter("broken")
+
+        def boom() -> list[object]:
+            raise RuntimeError("catalogue not loaded")
+
+        broken.list_datasets = boom  # type: ignore[method-assign]
+
+        reg = ProviderRegistry()
+        with pytest.raises(CapabilityContractError, match="failed to enumerate datasets"):
+            reg.register(broken)
+        assert "broken" not in reg
+
+    def test_registration_rejects_dataset_with_empty_operations(self) -> None:
+        """operations가 빈 집합인 dataset은 "지원 거짓 표시"로 간주해 거부한다."""
+        from kpubdata.exceptions import CapabilityContractError
+        from kpubdata.registry import ProviderRegistry
+
+        dishonest = FakeAdapter("dishonest")
+        dishonest_datasets = [self._ds("a", operations=())]
+        dishonest.list_datasets = lambda: dishonest_datasets  # type: ignore[method-assign]
+
+        reg = ProviderRegistry()
+        with pytest.raises(CapabilityContractError, match="empty operations"):
+            reg.register(dishonest)
+
+    def test_registration_rejects_non_list_return_value(self) -> None:
+        """list_datasets가 list가 아닌 값을 반환하면 거부한다."""
+        from kpubdata.exceptions import CapabilityContractError
+        from kpubdata.registry import ProviderRegistry
+
+        bad_shape = FakeAdapter("bad_shape")
+        bad_shape.list_datasets = lambda: "not a list"  # type: ignore[method-assign,return-value]
+
+        reg = ProviderRegistry()
+        with pytest.raises(CapabilityContractError, match="must return a list"):
+            reg.register(bad_shape)
+
+    def test_registration_rejects_non_dataset_ref_entries(self) -> None:
+        """list_datasets에 DatasetRef가 아닌 엔트리가 섞이면 거부한다."""
+        from kpubdata.exceptions import CapabilityContractError
+        from kpubdata.registry import ProviderRegistry
+
+        adapter = FakeAdapter("mixed")
+        adapter.list_datasets = lambda: [self._ds("ok"), {"not": "a ref"}]  # type: ignore[method-assign]
+
+        reg = ProviderRegistry()
+        with pytest.raises(CapabilityContractError, match="non-DatasetRef entries"):
+            reg.register(adapter)
+
+    def test_validate_capabilities_can_be_disabled(self) -> None:
+        """validate_capabilities=False면 capability 검증을 건너뛴다(deprecation 경로용)."""
+        from kpubdata.registry import ProviderRegistry
+
+        adapter = FakeAdapter("legacy")
+        adapter.list_datasets = lambda: [self._ds("a", operations=())]  # type: ignore[method-assign]
+
+        reg = ProviderRegistry()
+        reg.register(adapter, validate_capabilities=False)  # 예외가 없어야 한다.
+        assert "legacy" in reg
+
+    def test_lazy_registration_also_validates_capabilities_on_materialization(self) -> None:
+        """lazy 등록도 materialize 시점에 capability 검증을 거친다."""
+        from kpubdata.exceptions import CapabilityContractError
+        from kpubdata.registry import ProviderRegistry
+
+        def factory() -> FakeAdapter:
+            a = FakeAdapter("lazy_bad")
+            a.list_datasets = lambda: [self._ds("a", operations=())]  # type: ignore[method-assign]
+            return a
+
+        reg = ProviderRegistry()
+        reg.register_lazy("lazy_bad", factory)
+        with pytest.raises(CapabilityContractError):
+            reg.get("lazy_bad")

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -385,3 +385,24 @@ class TestCapabilityContractValidation:
         reg.register_lazy("lazy_bad", factory)
         with pytest.raises(CapabilityContractError):
             reg.get("lazy_bad")
+
+    def test_duplicate_name_short_circuits_before_capability_validation(self) -> None:
+        """이미 등록된 이름이면 capability 검증(잠재적으로 비싼 catalogue 로드)을 건너뛴다."""
+        from kpubdata.registry import ProviderRegistry
+
+        reg = ProviderRegistry()
+        reg.register(FakeAdapter("dup_provider"))
+
+        call_count = {"n": 0}
+        second = FakeAdapter("dup_provider")
+
+        def expensive_list() -> list[object]:
+            call_count["n"] += 1
+            return []
+
+        second.list_datasets = expensive_list  # type: ignore[method-assign]
+
+        with pytest.raises(ValueError, match="already registered"):
+            reg.register(second)
+        # capability 검증이 이름 충돌 검사 뒤에 일어났다면 list_datasets는 호출되지 않아야 한다.
+        assert call_count["n"] == 0


### PR DESCRIPTION
## Summary

Closes #231.

ProviderAdapter 등록 시점에 catalogue가 capability를 정직하게 선언했는지 fail-fast로 확인합니다. 첫 호출까지 기다리지 않고 등록 단계에서 \`CapabilityContractError\`로 명확하게 실패합니다.

### 등록 시점에 잡히는 위반
- \`list_datasets()\` 자체가 예외 raise (catalogue 로드 실패).
- \`list_datasets()\` 반환값이 \`list\`가 아님.
- list 안에 \`DatasetRef\`가 아닌 엔트리 혼재.
- DatasetRef의 \`operations\`가 빈 집합 — \"지원\"을 선언했지만 가능한 작업이 0개라는 부정직한 표시.

eager(\`register\`)와 lazy(\`register_lazy\` → \`get\` materialize) 두 경로 모두 검증을 거칩니다. 옵트아웃 플래그(\`register(adapter, validate_capabilities=False)\`)도 제공해 deprecation/legacy-import 윈도에서 임시 비활성화 가능.

### 새 예외
- \`kpubdata.exceptions.CapabilityContractError\` (PublicDataError 서브클래스). 위반된 provider 이름을 context로 운반.

### 비파괴성
모든 내장 provider(datago/seoul/kosis/bok/krx/law/localdata/lofin/semas/sgis)는 이미 catalogue 엔트리마다 비어 있지 않은 operations를 선언하고 있어 영향 없음 — 기존 965건의 unit+contract 테스트가 그대로 통과합니다.

## Test plan
- [x] 신규 7건 (\`TestCapabilityContractValidation\`): 정직한 어댑터 통과, list_datasets 크래시 거부, 빈 operations 거부, 비-list 반환 거부, 비-DatasetRef 엔트리 거부, validate_capabilities=False 옵트아웃, lazy materialize 검증.
- [x] \`pytest tests/unit tests/contract\` 965 passed (회귀 없음).
- [x] \`ruff check .\` / \`ruff format --check .\` / \`mypy src\` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)