### PR TITLE
fix(kosis): _raise_for_error_payload 반환 타입 NoReturn → None 수정

### DIFF
--- a/src/kpubdata/providers/kosis/adapter.py
+++ b/src/kpubdata/providers/kosis/adapter.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import NoReturn, cast
+from typing import cast
 from urllib.parse import urlencode
 
 from kpubdata.config import KPubDataConfig
@@ -308,9 +308,11 @@ class KosisAdapter:
         payload_items = cast(list[object], payload)
         return [cast(dict[str, object], item) for item in payload_items if isinstance(item, dict)]
 
-    def _raise_for_error_payload(self, payload: Mapping[str, object], dataset_id: str) -> NoReturn:
-        """raise for error payload과 관련된 값을 계산하거나 조회한다."""
+    def _raise_for_error_payload(self, payload: Mapping[str, object], dataset_id: str) -> None:
+        """에러 페이로드를 검사하고 에러가 있으면 예외를 발생시킨다."""
         code_raw = payload.get("err")
+        if code_raw is None:
+            return  # "err" 필드 없음 = 정상 응답
         message_raw = payload.get("errMsg")
         code = code_raw if isinstance(code_raw, str) else None
         message = message_raw if isinstance(message_raw, str) else "KOSIS returned an error"

--- a/tests/unit/providers/kosis/test_adapter.py
+++ b/tests/unit/providers/kosis/test_adapter.py
@@ -15,7 +15,7 @@ import pytest
 
 from kpubdata.config import KPubDataConfig
 from kpubdata.core.models import DatasetRef, Query
-from kpubdata.exceptions import InvalidRequestError
+from kpubdata.exceptions import AuthError, InvalidRequestError, ProviderResponseError
 from kpubdata.providers._common import build_dataset_ref
 from kpubdata.providers.kosis.adapter import KosisAdapter
 from kpubdata.transport.http import HttpTransport
@@ -370,3 +370,36 @@ def test_query_records_ignores_non_kosis_default_query_param_keys() -> None:
     assert "itmId=T" in request_url
     assert "unknown=ignored" not in request_url
     assert request_url.count("apiKey=") == 1
+
+
+# test raise for error payload returns none when err field absent 테스트가 검증하는 시나리오를 설명한다.
+def test_raise_for_error_payload_returns_none_when_err_field_absent() -> None:
+    """에러 필드 없는 딕셔너리 페이로드에서 _raise_for_error_payload가 None을 반환하는지 검증한다."""
+    adapter, dataset, _ = _build_adapter_with_transport([])
+    # 에러 없는 딕셔너리 — 예외 없이 반환돼야 한다 (이전 구현은 항상 ProviderResponseError 발생)
+    result = adapter._raise_for_error_payload({"some_field": "some_value"}, dataset.id)
+    assert result is None
+
+
+# test raise for error payload raises auth error on code 30 테스트가 검증하는 시나리오를 설명한다.
+def test_raise_for_error_payload_raises_auth_error_on_code_30() -> None:
+    """err=30 페이로드에서 AuthError가 발생하는지 검증한다."""
+    adapter, dataset, _ = _build_adapter_with_transport([])
+    with pytest.raises(AuthError):
+        adapter._raise_for_error_payload({"err": "30", "errMsg": "인증키 오류"}, dataset.id)
+
+
+# test raise for error payload raises invalid request error on code 10 테스트가 검증하는 시나리오를 설명한다.
+def test_raise_for_error_payload_raises_invalid_request_error_on_code_10() -> None:
+    """err=10 페이로드에서 InvalidRequestError가 발생하는지 검증한다."""
+    adapter, dataset, _ = _build_adapter_with_transport([])
+    with pytest.raises(InvalidRequestError):
+        adapter._raise_for_error_payload({"err": "10", "errMsg": "잘못된 요청"}, dataset.id)
+
+
+# test raise for error payload raises provider response error on unknown code 테스트가 검증하는 시나리오를 설명한다.
+def test_raise_for_error_payload_raises_provider_response_error_on_unknown_code() -> None:
+    """알 수 없는 err 코드 페이로드에서 ProviderResponseError가 발생하는지 검증한다."""
+    adapter, dataset, _ = _build_adapter_with_transport([])
+    with pytest.raises(ProviderResponseError):
+        adapter._raise_for_error_payload({"err": "99", "errMsg": "기타 오류"}, dataset.id)


### PR DESCRIPTION
## 개요

`KosisAdapter._raise_for_error_payload`의 반환 타입이 `NoReturn`으로 잘못 선언되어 있어, `err` 필드가 없는 정상 응답 딕셔너리를 받으면 불필요하게 `ProviderResponseError`를 발생시키는 버그를 수정합니다.

## 원인

```python
# 수정 전 — err 필드 없을 때 항상 raise
def _raise_for_error_payload(...) -> NoReturn:
    code_raw = payload.get("err")
    ...
    if code == "30": raise AuthError(...)
    if code == "10": raise InvalidRequestError(...)
    raise ProviderResponseError(...)  # code가 None이어도 항상 실행됨
```

- `code_raw`가 `None`이면 → `code = None` → 분기 미통과 → `ProviderResponseError` 발생
- `call_raw`에서 dict 응답을 에러 없이 반환하려 해도 예외가 발생함

## 수정 내용

- `-> NoReturn` → `-> None`으로 반환 타입 수정
- `err` 필드 없을 때 조기 반환 추가
- 사용하지 않는 `NoReturn` import 제거
- 회귀 방지 테스트 4개 추가

## 테스트

```
tests/unit/providers/kosis/test_adapter.py  12 passed
```

Closes #283