### PR TITLE
fix(bok): RESULT 필드 있으면 CODE 값과 무관하게 항상 오류 처리

### DIFF
--- a/src/kpubdata/providers/bok/adapter.py
+++ b/src/kpubdata/providers/bok/adapter.py
@@ -282,7 +282,7 @@ class BokAdapter:
         return body_dict, items
 
     def _raise_for_result(self, payload: Mapping[str, object], dataset_id: str) -> None:
-        """raise for result과 관련된 값을 계산하거나 조회한다."""
+        """RESULT 필드를 검사하고 오류인 경우 예외를 발생시킨다."""
         result_obj = payload.get("RESULT")
         if not isinstance(result_obj, dict):
             return
@@ -290,16 +290,13 @@ class BokAdapter:
         result_dict = cast(dict[str, object], result_obj)
         code_raw = result_dict.get("CODE")
         message_raw = result_dict.get("MESSAGE")
-        code = code_raw if isinstance(code_raw, str) else "ERROR"
+        code = code_raw if isinstance(code_raw, str) else "UNKNOWN"
         message = message_raw if isinstance(message_raw, str) else "Provider returned error"
         logger.debug(
             "BOK ECOS result",
             extra={"result_code": code, "result_msg": message, "dataset_id": dataset_id},
         )
-
-        if code != "ERROR":
-            return
-
+        # RESULT 필드가 있으면 항상 오류 — BOK ECOS는 성공 시 RESULT 없이 응답
         self._raise_for_result_code(code, message, dataset_id)
 
     def _raise_for_result_code(self, code: str, msg: str, dataset_id: str) -> NoReturn:

--- a/tests/unit/providers/bok/test_bok_adapter.py
+++ b/tests/unit/providers/bok/test_bok_adapter.py
@@ -15,7 +15,7 @@ import pytest
 
 from kpubdata.config import KPubDataConfig
 from kpubdata.core.models import DatasetRef, Query
-from kpubdata.exceptions import InvalidRequestError
+from kpubdata.exceptions import AuthError, InvalidRequestError, ProviderResponseError
 from kpubdata.providers.bok.adapter import BokAdapter
 from kpubdata.transport.http import HttpTransport
 
@@ -430,3 +430,39 @@ def test_query_records_zero_items_logs_debug(caplog: pytest.LogCaptureFixture) -
     assert record.__dict__["page"] == 1
     assert record.__dict__["page_size"] == 10
     assert record.__dict__["total_count"] == 0
+
+
+# test raise for result returns none when no result field 테스트가 검증하는 시나리오를 설명한다.
+def test_raise_for_result_returns_none_when_no_result_field() -> None:
+    """RESULT 필드 없는 정상 응답에서 _raise_for_result가 None을 반환하는지 검증한다."""
+    adapter, dataset, _ = _build_adapter_with_transport([])
+    result = adapter._raise_for_result({"StatisticSearch": {}}, dataset.id)
+    assert result is None
+
+
+# test raise for result raises on non error code in result field 테스트가 검증하는 시나리오를 설명한다.
+def test_raise_for_result_raises_on_non_error_code_in_result_field() -> None:
+    """RESULT에 ERROR 외 코드가 있는 경우에도 예외가 발생하는지 검증한다."""
+    adapter, dataset, _ = _build_adapter_with_transport([])
+    # 이전 구현: ERROR 외 코드는 성공으로 처리해 예외 미발생
+    # 수정 후: RESULT 필드 있으면 항상 오류 처리
+    with pytest.raises(ProviderResponseError):
+        adapter._raise_for_result({"RESULT": {"CODE": "INFO-100", "MESSAGE": "경고"}}, dataset.id)
+
+
+# test raise for result raises when result code absent 테스트가 검증하는 시나리오를 설명한다.
+def test_raise_for_result_raises_when_result_code_absent() -> None:
+    """RESULT가 있지만 CODE 필드가 없는 예외 케이스를 오류로 처리하는지 검증한다."""
+    adapter, dataset, _ = _build_adapter_with_transport([])
+    with pytest.raises(ProviderResponseError):
+        adapter._raise_for_result({"RESULT": {"MESSAGE": "코드 없음"}}, dataset.id)
+
+
+# test raise for result raises auth error on auth message 테스트가 검증하는 시나리오를 설명한다.
+def test_raise_for_result_raises_auth_error_on_auth_message() -> None:
+    """RESULT CODE=ERROR에 인증 메시지일 때 AuthError가 발생하는지 검증한다."""
+    adapter, dataset, _ = _build_adapter_with_transport([])
+    with pytest.raises(AuthError):
+        adapter._raise_for_result(
+            {"RESULT": {"CODE": "ERROR", "MESSAGE": "인증키가 유효하지 않습니다."}}, dataset.id
+        )


### PR DESCRIPTION
## 개요

`BokAdapter._raise_for_result`에서 `RESULT.CODE != 'ERROR'`이면 오류를 무시하던 버그를 수정합니다. BOK ECOS API는 성공 응답에 `RESULT` 필드를 포함하지 않으므로, `RESULT`가 존재하면 항상 오류로 처리해야 합니다.

## 원인

```python
# 수정 전 — ERROR 외 코드는 성공으로 처리
code = code_raw if isinstance(code_raw, str) else "ERROR"  # None → "ERROR" 폴백 (혼란스러움)
if code != "ERROR":
    return  # INFO-100 등 비-ERROR 코드 조용히 무시됨
```

**두 가지 버그:**
1. `CODE`가 없으면 → `code = "ERROR"` → 실제로 raise 발생 (의도치 않은 동작)
2. `CODE`가 `"INFO-100"` 등이면 → `code != "ERROR"` → 오류 무시

## 수정 내용

- `if code != "ERROR": return` 가드 제거
- `None` 폴백을 `"ERROR"` → `"UNKNOWN"`으로 변경 (의미 명확화)
- `RESULT` 필드가 있으면 항상 오류로 처리 (BOK ECOS 계약에 부합)
- 회귀 방지 테스트 4개 추가

## 테스트

```
tests/unit/providers/bok/test_bok_adapter.py  12 passed
```

Closes #284