### PR TITLE
docs(adapters): localdata/semas/lofin datago API 키 공유 설계 명시화

### DIFF
--- a/src/kpubdata/providers/localdata/adapter.py
+++ b/src/kpubdata/providers/localdata/adapter.py
@@ -179,7 +179,10 @@ class LocaldataAdapter:
         return payload
 
     def _require_api_key(self) -> str:
-        """필수 API 키을 읽고 없으면 예외를 발생시킨다."""
+        """공공데이터포털(data.go.kr) API 키를 읽고 없으면 예외를 발생시킨다.
+        localdata · semas · lofin 어댓터는 모두 data.go.kr 인증 시스템을 공유하며
+        단일 provider_key("datago")로 관리하는 것이 의도된 설계다.
+        """
         return self._config.require_provider_key("datago")
 
     def _build_request_url(self, dataset: DatasetRef, operation: str | None = None) -> str:

--- a/src/kpubdata/providers/lofin/adapter.py
+++ b/src/kpubdata/providers/lofin/adapter.py
@@ -182,7 +182,10 @@ class LofinAdapter:
         return payload
 
     def _require_api_key(self) -> str:
-        """필수 API 키을 읽고 없으면 예외를 발생시킨다."""
+        """공공데이터포털(data.go.kr) API 키를 읽고 없으면 예외를 발생시킨다.
+        localdata · semas · lofin 어댓터는 모두 data.go.kr 인증 시스템을 공유하며
+        단일 provider_key("datago")로 관리하는 것이 의도된 설계다.
+        """
         return self._config.require_provider_key("datago")
 
     def _build_request_url(

--- a/src/kpubdata/providers/semas/adapter.py
+++ b/src/kpubdata/providers/semas/adapter.py
@@ -183,7 +183,10 @@ class SemasAdapter:
         return payload
 
     def _require_api_key(self) -> str:
-        """필수 API 키을 읽고 없으면 예외를 발생시킨다."""
+        """공공데이터포털(data.go.kr) API 키를 읽고 없으면 예외를 발생시킨다.
+        localdata · semas · lofin 어댓터는 모두 data.go.kr 인증 시스템을 공유하며
+        단일 provider_key("datago")로 관리하는 것이 의도된 설계다.
+        """
         return self._config.require_provider_key("datago")
 
     def _build_request_url(self, dataset: DatasetRef, operation: str | None = None) -> str:


### PR DESCRIPTION
## 개요

`localdata`, `semas`, `lofin` 세 어댑터의 `_require_api_key`가 모두 `provider_key("datago")`를 사용합니다. 이것이 의도된 설계인지 불분명해 혼란을 야기할 수 있습니다.

## 변경 내용

세 어댑터의 `_require_api_key` docstring을 아래 내용으로 명확히 수정:
> localdata · semas · lofin 어댑터는 모두 data.go.kr 인증 시스템을 공유하며, 단일 provider_key("datago")로 관리하는 것이 의도된 설계다.

## 근거

공공데이터포털(data.go.kr)은 단일 인증 게이트웨이를 통해 여러 공공데이터 API를 제공합니다. 세 어댑터가 동일한 API 키를 사용하는 것은 플랫폼 설계에 따른 올바른 동작입니다.

Closes #285