### PR TITLE
[K-004] sgis: _extract_err_code 중복 제거 (#286)

### DIFF
--- a/src/kpubdata/providers/sgis/adapter.py
+++ b/src/kpubdata/providers/sgis/adapter.py
@@ -326,5 +326,4 @@ class SgisAdapter:
         return load_catalogue("kpubdata.providers.sgis", _SGIS_PROVIDER)
 
 
-
 __all__ = ["SgisAdapter"]

--- a/src/kpubdata/providers/sgis/adapter.py
+++ b/src/kpubdata/providers/sgis/adapter.py
@@ -21,7 +21,7 @@ from kpubdata.exceptions import (
     ServiceUnavailableError,
 )
 from kpubdata.providers._common import build_schema_from_metadata, load_catalogue
-from kpubdata.providers.sgis.auth import SgisAuthClient
+from kpubdata.providers.sgis.auth import SgisAuthClient, _extract_err_code
 from kpubdata.transport.decode import decode_json
 from kpubdata.transport.http import HttpTransport, TransportConfig
 
@@ -325,18 +325,6 @@ class SgisAdapter:
         """기본 카탈로그을 로드해 반환한다."""
         return load_catalogue("kpubdata.providers.sgis", _SGIS_PROVIDER)
 
-
-def _extract_err_code(payload: Mapping[str, object]) -> int | None:
-    """err code에서 필요한 값을 추출한다."""
-    err_obj = payload.get("errCd")
-    if isinstance(err_obj, int):
-        return err_obj
-    if isinstance(err_obj, str):
-        try:
-            return int(err_obj)
-        except ValueError:
-            return None
-    return None
 
 
 __all__ = ["SgisAdapter"]

--- a/src/kpubdata/providers/sgis/auth.py
+++ b/src/kpubdata/providers/sgis/auth.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import NoReturn, cast
@@ -146,7 +147,7 @@ class SgisAuthClient:
         raise ProviderResponseError(message, provider=_SGIS_PROVIDER, provider_code=provider_code)
 
 
-def _extract_err_code(payload: dict[str, object]) -> int | None:
+def _extract_err_code(payload: Mapping[str, object]) -> int | None:
     """err code에서 필요한 값을 추출한다."""
     err_obj = payload.get("errCd")
     if isinstance(err_obj, int):
@@ -172,3 +173,6 @@ def _coerce_epoch(value: object) -> int | None:
 
 
 __all__ = ["SgisAuthClient"]
+
+
+__all__ = ["SgisAuthClient", "_extract_err_code"]


### PR DESCRIPTION
## 요약

`auth.py`와 `adapter.py`에 완전히 동일한 `_extract_err_code` 함수가 두 개 존재하던 문제를 수정합니다.

## 변경 내용

- `auth.py`의 `_extract_err_code` 시그니처를 `dict[str, object]` → `Mapping[str, object]`으로 통일 (adapter.py 버전과 일치)
- `auth.py`에서 `collections.abc.Mapping` import 추가
- `adapter.py`에서 `_extract_err_code`를 `auth.py`로부터 import
- `adapter.py`의 중복 구현 제거

## 검증

- `ruff check` 통과
- `mypy` 통과
- `pytest tests/unit/providers/sgis/` → 15/15 통과

Closes #286