### PR TITLE
[K-005] core: _dataclass 헬퍼 중복 제거 (#287)

### DIFF
--- a/src/kpubdata/core/capability.py
+++ b/src/kpubdata/core/capability.py
@@ -22,7 +22,7 @@ def _dataclass(
 
     def _decorate(cls: type[_T]) -> type[_T]:
         """대상 클래스에 dataclass 옵션을 적용해 반환한다."""
-        return _stdlib_dataclass(slots=slots, frozen=frozen)(cls)
+        return _stdlib_dataclass(slots=slots, frozen=frozen)(cls)  # pyright: ignore[reportCallIssue]
 
     return _decorate
 

--- a/src/kpubdata/core/models.py
+++ b/src/kpubdata/core/models.py
@@ -2,34 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
-from dataclasses import dataclass as _stdlib_dataclass
+from collections.abc import Iterator
 from dataclasses import field
 from importlib import import_module
 from types import MappingProxyType
-from typing import TypeVar
 
-from typing_extensions import dataclass_transform
-
-from kpubdata.core.capability import Operation, QuerySupport
+from kpubdata.core.capability import Operation, QuerySupport, _dataclass
 from kpubdata.core.representation import Representation
-
-_T = TypeVar("_T")
-
-
-@dataclass_transform()
-def _dataclass(
-    *,
-    slots: bool = False,
-    frozen: bool = False,
-) -> Callable[[type[_T]], type[_T]]:
-    """고정 옵션으로 ``dataclasses.dataclass``를 적용하는 데코레이터를 반환한다."""
-
-    def _decorate(cls: type[_T]) -> type[_T]:
-        """대상 클래스에 dataclass 옵션을 적용해 반환한다."""
-        return _stdlib_dataclass(slots=slots, frozen=frozen)(cls)  # pyright: ignore[reportCallIssue]
-
-    return _decorate
 
 
 def _empty_proxy() -> MappingProxyType[str, object]:


### PR DESCRIPTION
## 요약

`core/capability.py`와 `core/models.py`에 `_dataclass` 헬퍼 함수가 동일하게 두 벌 정의되어 있던 문제를 수정합니다.

## 변경 내용

### capability.py
- `_dataclass` 내부 `_decorate` 반환에 `# pyright: ignore[reportCallIssue]` 주석 추가 (models.py 버전과 통일)

### models.py
- `_dataclass` 함수 정의 제거
- `capability.py`에서 `_dataclass` import로 교체
- 더 이상 불필요한 import 제거: `dataclasses.dataclass as _stdlib_dataclass`, `typing.TypeVar`, `typing_extensions.dataclass_transform`, `collections.abc.Callable`

## 검증

- `ruff check` 통과
- `mypy` 통과
- `pytest tests/unit/` → 766/766 통과

Closes #287