### PR TITLE
[K-006] krx: O(N) API 호출 동작 문서화 (#288)

### DIFF
--- a/src/kpubdata/providers/krx/adapter.py
+++ b/src/kpubdata/providers/krx/adapter.py
@@ -304,8 +304,26 @@ class KrxAdapter:
         end_date: str,
         market: str,
     ) -> pd.DataFrame:
-        """market valuation by day 데이터를 조회해 반환한다."""
+        """날짜별 시장 PER/PBR/배당수익률을 조회해 DataFrame으로 반환한다.
+
+        .. warning::
+            이 메서드는 start_date~end_date 범위의 **달력상 모든 날짜**마다
+            ``pykrx.stock.get_market_fundamental_by_ticker`` API를 개별 호출한다.
+            호출 횟수는 O(N_days) 이므로 날짜 범위가 길수록 네트워크 요청이 많아진다.
+            예: 1년 조회 ≈ 365회 호출. 거래일(영업일)만 필터링하지 않으므로
+            주말·공휴일은 빈 응답을 반환하지만 호출 자체는 발생한다.
+        """
         rows: list[dict[str, object]] = []
+        total_days = len(
+            pd.date_range(start=pd.Timestamp(start_date), end=pd.Timestamp(end_date), freq="D")
+        )
+        if total_days > 90:  # noqa: PLR2004
+            logger.warning(
+                "KRX market_valuation: 날짜 범위 %d일 → API %d회 호출 예정",
+                total_days,
+                total_days,
+                extra={"provider": "krx", "dataset_id": "krx.market_valuation"},
+            )
         for day in pd.date_range(
             start=pd.Timestamp(start_date), end=pd.Timestamp(end_date), freq="D"
         ):


### PR DESCRIPTION
## 요약

`_fetch_market_valuation_by_day` 메서드가 날짜 범위의 모든 달력 날짜마다 별도의 pykrx API를 호출하는 O(N) 동작을 문서화합니다.

## 변경 내용

### adapter.py — `_fetch_market_valuation_by_day`

1. **docstring에 `.. warning::` 블록 추가**: 호출 횟수가 O(N_days)임을 명시하고, 주말/공휴일에도 API 호출이 발생함을 안내
2. **런타임 `logger.warning` 추가**: 날짜 범위가 90일 초과 시 "KRX market_valuation: N일 → API N회 호출 예정" 경고 출력 (로거를 켠 사용자에게 비용 가시화)

## 검증

- `ruff check` 통과
- `mypy` 통과
- `pytest tests/unit/providers/krx/` → 37/37 통과

Closes #288