### PR TITLE
fix(lofin): Add URL encoding for filter parameter values (#290)

### DIFF
--- a/src/kpubdata/providers/lofin/adapter.py
+++ b/src/kpubdata/providers/lofin/adapter.py
@@ -10,6 +10,7 @@ import logging
 import ssl
 from collections.abc import Mapping, Sequence
 from typing import NoReturn, cast
+from urllib.parse import quote
 
 from kpubdata.config import KPubDataConfig
 from kpubdata.core.models import DatasetRef, Query, RecordBatch, SchemaDescriptor
@@ -216,7 +217,7 @@ class LofinAdapter:
         )
         if filters:
             for key, value in filters.items():
-                url += f"&{key}={value}"
+                url += f"&{key}={quote(str(value), safe='')}"
         return url
 
     def _request_and_decode(self, url: str, dataset_id: str = "") -> dict[str, object]:


### PR DESCRIPTION
## Summary

Closes #290

로핀(LOFIN) 어댑터의 필터 파라미터 값에 URL 인코딩을 추가하여 한글, 공백, 특수문자가 포함된 경우에도 올바른 요청을 전송하도록 수정했습니다.

## Problem

`src/kpubdata/providers/lofin/adapter.py` 약 219번째 줄에서 필터 값을 URL에 직접 문자열 결합하여 전송:

```python
if filters:
    for key, value in filters.items():
        url += f"&{key}={value}"  # ❌ No URL encoding
```

한글, 공백, 특수문자가 포함된 `value`를 인코딩 없이 전송하면 잘못된 요청이 됩니다.

## Solution

표준 라이브러리 `urllib.parse.quote`를 사용하여 값을 URL 인코딩:

```python
from urllib.parse import quote

if filters:
    for key, value in filters.items():
        url += f"&{key}={quote(str(value), safe='')}"  # ✅ Properly encoded
```

- `key`는 ASCII API 파라미터명이므로 인코딩 불필요
- `value`만 `quote()`로 인코딩 (safe='' 옵션으로 모든 특수문자 인코딩)
- 의존성 추가 불필요 (urllib.parse는 Python 표준 라이브러리)

## Quality Gate

- ✅ `uv run ruff check .` - passed
- ✅ `uv run ruff format --check .` - passed
- ✅ `uv run mypy src` - passed
- ✅ `uv run pytest tests/unit/providers/lofin/` - 7 passed
- ✅ `uv run pytest tests/contract/test_lofin.py` - 16 passed

## Example

**Before:**
```
/api/endpoint?Key=xxx&Type=json&region=서울 강남구
```
→ 잘못된 요청 (공백과 한글 미인코딩)

**After:**
```
/api/endpoint?Key=xxx&Type=json&region=%EC%84%9C%EC%9A%B8%20%EA%B0%95%EB%82%A8%EA%B5%AC
```
→ 올바른 요청 (URL 인코딩 적용)