### PR TITLE
fix(sgis): remove duplicate __all__ in auth.py

### DIFF
--- a/src/kpubdata/providers/sgis/auth.py
+++ b/src/kpubdata/providers/sgis/auth.py
@@ -172,7 +172,4 @@ def _coerce_epoch(value: object) -> int | None:
     return None
 
 
-__all__ = ["SgisAuthClient"]
-
-
 __all__ = ["SgisAuthClient", "_extract_err_code"]


### PR DESCRIPTION
K-004(#294) 머지 시 `_extract_err_code`를 `__all__`에 추가하면서 기존 `__all__`을 제거하지 않아 중복 정의가 발생. 두 번째 정의만 유효하고 첫 번째는 무효이므로 첫 번째를 제거합니다.

Closes: 코드 정합성 수정 (이슈 없음)