### PR TITLE
chore: 이슈/PR 템플릿 및 Dependabot 설정 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: 버그 리포트
+description: 예상과 다르게 동작하는 문제를 신고합니다
+title: "[Bug] "
+labels: ["type:bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        버그를 신고해 주셔서 감사합니다. 재현에 필요한 정보를 최대한 채워주세요.
+  - type: textarea
+    id: summary
+    attributes:
+      label: 문제 요약
+      description: 무엇이 잘못되었나요?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 재현 절차
+      description: 문제를 재현하는 최소 코드 예시 또는 단계별 절차
+      placeholder: |
+        ```python
+        from kpubdata import Client
+        client = Client.from_env()
+        ...
+        ```
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 기대 동작
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 실제 동작 / 오류 로그(traceback)
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: provider
+    attributes:
+      label: 관련 provider (해당 시)
+      placeholder: "예) datago, kosis, seoul"
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: 실행 환경
+      description: OS, Python 버전, kpubdata 버전
+      placeholder: |
+        - OS: Ubuntu 24.04
+        - Python: 3.12
+        - kpubdata: x.y.z
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 질문 / 토론
+    url: https://github.com/yeongseon/kpubdata/discussions
+    about: 버그·기능 제안이 아닌 사용법 질문이나 아이디어 토론은 여기서 나눠주세요.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,20 @@
+name: 문서 개선
+description: 문서 오류, 누락, 개선 사항을 신고합니다
+title: "[Docs] "
+labels: ["type:docs"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: 문서 위치
+      description: 파일 경로 또는 URL
+      placeholder: "예) README.md, docs/product-family-architecture.md"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: 문제 / 개선 제안
+      description: 무엇이 부정확하거나 부족한가요? 어떻게 바뀌면 좋을까요?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: 기능 제안
+description: 새로운 기능이나 개선을 제안합니다 (신규 provider는 별도 템플릿 사용)
+title: "[Feature] "
+labels: ["type:feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 새로운 공공데이터 provider adapter 제안은 **New Provider Adapter** 템플릿을 사용해주세요.
+  - type: textarea
+    id: problem
+    attributes:
+      label: 해결하려는 문제
+      description: 어떤 불편이나 한계를 해결하려는 건가요?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 제안 내용
+      description: 원하는 동작이나 API를 설명하세요.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 대안 검토
+      description: 고려한 다른 방법이 있다면 적어주세요.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+PR 제목은 Conventional Commits 형식을 권장합니다: feat/fix/docs/refactor/test/chore
+예) feat: add KOSIS provider adapter
+-->
+
+## 요약
+<!-- 이 PR이 무엇을, 왜 바꾸는지 1~3문장으로 설명하세요. -->
+
+## 변경 내용
+<!-- 주요 변경 사항을 항목으로 나열하세요. -->
+-
+
+## 관련 이슈
+<!-- 예) Closes #123, Refs #456 -->
+
+## 검증
+<!-- 어떻게 검증했는지 구체적으로 적으세요. -->
+- [ ] Ruff lint / format 통과
+- [ ] mypy 타입 체크 통과
+- [ ] 테스트 통과 (`pytest`)
+- [ ] 문서 변경 시 docs strict 빌드 통과 (해당 시)
+- [ ] 신규 provider adapter는 계약/통합 테스트를 포함 (해당 시)
+
+## 체크리스트
+- [ ] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
+- [ ] 커밋 메시지를 영어로 작성했다
+- [ ] 공개 API 변경 시 문서/CHANGELOG를 갱신했다

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
## 요약
저장소 거버넌스 표준화를 위해 이슈/PR 템플릿과 Dependabot 설정을 추가합니다. (프로젝트 관리 감사 후속 작업)

## 변경 내용
- `.github/PULL_REQUEST_TEMPLATE.md`: 요약·검증·체크리스트
- `.github/ISSUE_TEMPLATE/`: 버그 리포트 / 기능 제안 / 문서 개선 Issue Form + `config.yml`(빈 이슈 비활성화, Discussions 링크). 기존 New Provider Adapter 템플릿 유지
- `.github/dependabot.yml`: pip · github-actions 주간 업데이트

## 검증
- 모든 YAML `yaml.safe_load` 통과 ✅
- 라벨은 저장소 기존 라벨(`type:bug`/`type:feature`/`type:docs`)만 참조 ✅