### PR TITLE
docs: PR 템플릿에 문서 분류 체크 추가

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,3 +25,4 @@ PR 제목은 Conventional Commits 형식을 권장합니다: feat/fix/docs/refac
 - [ ] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
 - [ ] 커밋 메시지를 영어로 작성했다
 - [ ] 공개 API 변경 시 문서/CHANGELOG를 갱신했다
+- [ ] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다: 제품 계약→PRD, 향후 의도→ROADMAP, 릴리스 변경→CHANGELOG (해당 시)


### PR DESCRIPTION
## 요약

PR 템플릿 체크리스트에 문서 분류 항목을 추가한다. 사용자 노출 기능 변경 시 제품 계약→PRD, 향후 의도→ROADMAP, 릴리스 변경→CHANGELOG로 분류·갱신하도록 유도한다.

## 배경

최근 PRD-코드 정합성 감사에서 사용자 노출 기능이 PRD 갱신 없이 배포된 사례가 확인되었다(Oracle 리뷰 제언). 경량 거버넌스로 문서 드리프트를 예방한다.

## 검증

- 문서 전용 변경(PR 템플릿). 코드/동작 영향 없음.
