### PR TITLE
fix: validate cache TTL environment value

### DIFF
--- a/src/kpubdata/client.py
+++ b/src/kpubdata/client.py
@@ -13,6 +13,7 @@ from kpubdata.catalog import Catalog
 from kpubdata.config import KPubDataConfig
 from kpubdata.core.dataset import Dataset
 from kpubdata.core.protocol import ProviderAdapter
+from kpubdata.exceptions import ConfigError
 from kpubdata.providers.manifest import BUILTIN_PROVIDERS
 from kpubdata.registry import ProviderRegistry
 from kpubdata.transport.cache import ResponseCache
@@ -276,4 +277,7 @@ def _resolve_cache_ttl(ttl_override: object) -> int:
     raw_ttl = os.environ.get("KPUBDATA_CACHE_TTL")
     if raw_ttl is None or raw_ttl == "":
         return 86400
-    return int(raw_ttl)
+    try:
+        return int(raw_ttl)
+    except ValueError as exc:
+        raise ConfigError(f"KPUBDATA_CACHE_TTL must be an integer, got {raw_ttl!r}") from exc

--- a/tests/unit/providers/bok/test_bok_adapter.py
+++ b/tests/unit/providers/bok/test_bok_adapter.py
@@ -159,7 +159,9 @@ def test_catalogue_includes_usd_krw_daily_dataset() -> None:
     _, dataset, _ = _build_adapter_with_transport([], dataset_key="usd_krw")
     catalogue = cast(
         list[dict[str, object]],
-        json.loads(files("kpubdata.providers.bok").joinpath("catalogue.json").read_text()),
+        json.loads(
+            files("kpubdata.providers.bok").joinpath("catalogue.json").read_text(encoding="utf-8")
+        ),
     )
     usd_krw_entry = next(entry for entry in catalogue if entry["dataset_key"] == "usd_krw")
 
@@ -205,7 +207,9 @@ def test_catalogue_includes_bond_yield_3y_daily_dataset() -> None:
     _, dataset, _ = _build_adapter_with_transport([], dataset_key="bond_yield_3y")
     catalogue = cast(
         list[dict[str, object]],
-        json.loads(files("kpubdata.providers.bok").joinpath("catalogue.json").read_text()),
+        json.loads(
+            files("kpubdata.providers.bok").joinpath("catalogue.json").read_text(encoding="utf-8")
+        ),
     )
     bond_yield_3y_entry = next(
         entry for entry in catalogue if entry["dataset_key"] == "bond_yield_3y"
@@ -253,7 +257,9 @@ def test_catalogue_includes_money_supply_monthly_dataset() -> None:
     _, dataset, _ = _build_adapter_with_transport([], dataset_key="money_supply")
     catalogue = cast(
         list[dict[str, object]],
-        json.loads(files("kpubdata.providers.bok").joinpath("catalogue.json").read_text()),
+        json.loads(
+            files("kpubdata.providers.bok").joinpath("catalogue.json").read_text(encoding="utf-8")
+        ),
     )
     money_supply_entry = next(
         entry for entry in catalogue if entry["dataset_key"] == "money_supply"

--- a/tests/unit/providers/kosis/test_adapter.py
+++ b/tests/unit/providers/kosis/test_adapter.py
@@ -140,7 +140,9 @@ def test_catalogue_parses_industrial_production_default_query_params() -> None:
     _, dataset, _ = _build_adapter_with_transport([], dataset_key="industrial_production")
     catalogue = cast(
         list[dict[str, object]],
-        json.loads(files("kpubdata.providers.kosis").joinpath("catalogue.json").read_text()),
+        json.loads(
+            files("kpubdata.providers.kosis").joinpath("catalogue.json").read_text(encoding="utf-8")
+        ),
     )
     entry = next(entry for entry in catalogue if entry["dataset_key"] == "industrial_production")
 

--- a/tests/unit/transport/test_cache.py
+++ b/tests/unit/transport/test_cache.py
@@ -15,7 +15,7 @@ import httpx
 import pytest
 
 from kpubdata.client import Client
-from kpubdata.exceptions import TransportError
+from kpubdata.exceptions import ConfigError, TransportError
 from kpubdata.transport.cache import ResponseCache, make_cache_key
 from kpubdata.transport.http import HttpTransport, TransportConfig
 
@@ -366,3 +366,115 @@ def test_client_from_env_explicit_cache_false_disables_env_cache(
     transport_config = cast(TransportConfig, client.__dict__["_transport_config"])
 
     assert transport_config.cache is None
+
+
+# test client from env invalid cache ttl raises config error 테스트가 검증하는 시나리오를 설명한다.
+def test_client_from_env_invalid_cache_ttl_raises_config_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    test client from env invalid cache ttl raises config error 시나리오를 검증한다.
+
+    매개변수:
+        monkeypatch (pytest.MonkeyPatch): 호출자가 제공하는 입력 값이다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        잘못된 KPUBDATA_CACHE_TTL 값이 ConfigError로 보고되는지 확인한다.
+    """
+    monkeypatch.setenv("KPUBDATA_CACHE_TTL", "abc")
+
+    with pytest.raises(ConfigError) as exc_info:
+        Client.from_env()
+
+    error = exc_info.value
+    assert "KPUBDATA_CACHE_TTL" in str(error)
+    assert "integer" in str(error)
+    assert "'abc'" in str(error)
+    assert isinstance(error.__cause__, ValueError)
+
+
+# test client from env invalid cache ttl explicit override takes priority 테스트가 검증하는 시나리오를 설명한다.
+def test_client_from_env_invalid_cache_ttl_explicit_override_takes_priority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    test client from env invalid cache ttl explicit override takes priority 시나리오를 검증한다.
+
+    매개변수:
+        monkeypatch (pytest.MonkeyPatch): 호출자가 제공하는 입력 값이다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        명시적 override가 환경변수보다 우선 적용되는지 확인한다.
+    """
+    monkeypatch.setenv("KPUBDATA_CACHE_TTL", "abc")
+
+    client = Client.from_env(cache_ttl_seconds=30)
+    transport_config = cast(TransportConfig, client.__dict__["_transport_config"])
+
+    assert transport_config.cache_ttl_seconds == 30
+
+
+# test client from env missing cache ttl uses default 테스트가 검증하는 시나리오를 설명한다.
+def test_client_from_env_missing_cache_ttl_uses_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    test client from env missing cache ttl uses default 시나리오를 검증한다.
+
+    매개변수:
+        monkeypatch (pytest.MonkeyPatch): 호출자가 제공하는 입력 값이다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        환경변수가 없을 때 기본값 86400이 사용되는지 확인한다.
+    """
+    monkeypatch.delenv("KPUBDATA_CACHE_TTL", raising=False)
+
+    client = Client.from_env()
+    transport_config = cast(TransportConfig, client.__dict__["_transport_config"])
+
+    assert transport_config.cache_ttl_seconds == 86400
+
+
+# test client from env empty cache ttl uses default 테스트가 검증하는 시나리오를 설명한다.
+def test_client_from_env_empty_cache_ttl_uses_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    test client from env empty cache ttl uses default 시나리오를 검증한다.
+
+    매개변수:
+        monkeypatch (pytest.MonkeyPatch): 호출자가 제공하는 입력 값이다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        환경변수가 빈 문자열일 때 기본값 86400이 사용되는지 확인한다.
+    """
+    monkeypatch.setenv("KPUBDATA_CACHE_TTL", "")
+
+    client = Client.from_env()
+    transport_config = cast(TransportConfig, client.__dict__["_transport_config"])
+
+    assert transport_config.cache_ttl_seconds == 86400


### PR DESCRIPTION
## 요약

`KPUBDATA_CACHE_TTL` 환경변수에 정수가 아닌 값이 설정된 경우 일반 `ValueError` 대신 `ConfigError`를 발생시키도록 수정했습니다.

전체 테스트 검증 중 발견된 Windows cp949 환경의 UTF-8 catalogue 파일 읽기 문제도 함께 해결했습니다.

## 변경 내용

* `KPUBDATA_CACHE_TTL` 값을 정수로 변환할 수 없을 때 `ConfigError` 발생
* 오류 메시지에 환경변수 이름과 잘못된 입력값 포함
* `raise ... from exc`를 사용해 원본 `ValueError` 예외 체인 보존
* 환경변수 미설정·빈 문자열의 기본값 `86400` 유지
* 명시적 `cache_ttl_seconds` override 우선순위 유지
* BOK catalogue 테스트 3곳에 `encoding="utf-8"` 명시
* KOSIS catalogue 테스트 1곳에 `encoding="utf-8"` 명시
* catalogue 데이터와 기존 assertion은 변경하지 않음

## 관련 이슈

Closes #277

## 검증

* [x] Ruff lint / format 통과
* [x] mypy 타입 체크 통과
* [x] 테스트 통과 (`1021 passed`)
* [x] 문서 변경 시 docs strict 빌드 통과
* [x] 신규 provider adapter는 계약/통합 테스트를 포함 (해당 없음)

추가 실행 결과:

* `uv run pytest tests/unit/transport/test_cache.py` — 14 passed
* `uv run pytest tests/unit/providers/bok/test_bok_adapter.py tests/unit/providers/kosis/test_adapter.py` — 24 passed
* `uv run pytest` — 1021 passed
* `uv run ruff check .` — passed
* `uv run ruff format --check .` — passed
* `uv run mypy src` — passed
* `uv run python -m build` — passed
* `uv run mkdocs build --strict` — passed

## 체크리스트

* [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
* [x] 커밋 메시지를 영어로 작성했다
* [x] 공개 API 변경 시 문서/CHANGELOG를 갱신했다 (공개 API 변경 없음)
* [x] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다: 제품 계약→PRD, 향후 의도→ROADMAP, 릴리스 변경→CHANGELOG (문서 변경이 필요한 공개 계약 변경 없음)
