### PR TITLE
fix: roll back failed provider scaffolds

### DIFF
--- a/src/kpubdata/scaffold.py
+++ b/src/kpubdata/scaffold.py
@@ -12,6 +12,7 @@ contract test — 을 한 번에 만들어주어 첫 PR을 작성하기 위한 �
 
 from __future__ import annotations
 
+import errno
 import json
 import keyword
 import re
@@ -285,6 +286,33 @@ def test_{provider_name}_seed_dataset_metadata() -> None:
 '''
 
 
+def _cleanup_empty_directories(dirs: list[Path]) -> list[str]:
+    """깊은 디렉터리부터 순서대로 비어 있으면 제거한다.
+
+    이번 호출에서 새로 생성한 leaf 디렉터리를 cleanup하기 위한 helper.
+    호출 전부터 존재했거나 파일이 남아 있는 디렉터리는 삭제하지 않는다.
+
+    정상적으로 무시하는 상황:
+        - 디렉터리가 이미 존재하지 않음 (FileNotFoundError)
+        - 디렉터리가 비어 있지 않음 (errno.ENOTEMPTY)
+
+    반환값:
+        실제 삭제 실패의 오류 메시지 목록.
+    """
+    errors: list[str] = []
+    for directory in reversed(dirs):
+        try:
+            directory.rmdir()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            if exc.errno == errno.ENOTEMPTY:
+                pass
+            else:
+                errors.append(f"{directory}: {type(exc).__name__}: {exc}")
+    return errors
+
+
 def scaffold_provider(
     name: str,
     *,
@@ -336,14 +364,61 @@ def scaffold_provider(
                 "Pass overwrite=True (or --force) to replace."
             )
 
+    provider_dir_existed = provider_dir.exists()
+    fixture_dir_existed = fixture_dir.exists()
+    contract_test_parent_existed = contract_test_path.parent.exists()
+
     provider_dir.mkdir(parents=True, exist_ok=True)
     fixture_dir.mkdir(parents=True, exist_ok=True)
     contract_test_path.parent.mkdir(parents=True, exist_ok=True)
 
-    created: list[Path] = []
-    for path, content in files.items():
-        path.write_text(content, encoding="utf-8")
-        created.append(path)
+    created_directories: list[Path] = []
+    if not provider_dir_existed:
+        created_directories.append(provider_dir)
+    if not fixture_dir_existed:
+        created_directories.append(fixture_dir)
+    if not contract_test_parent_existed:
+        created_directories.append(contract_test_path.parent)
+
+    existing_contents: dict[Path, bytes] = {}
+    new_files: set[Path] = set()
+    attempted: list[Path] = []
+
+    for path in files:
+        if path.exists():
+            existing_contents[path] = path.read_bytes()
+        else:
+            new_files.add(path)
+
+    try:
+        for path, content in files.items():
+            attempted.append(path)
+            path.write_text(content, encoding="utf-8")
+    except Exception as original_exc:
+        rollback_errors: list[str] = []
+
+        for path in reversed(attempted):
+            if path in existing_contents:
+                try:
+                    path.write_bytes(existing_contents[path])
+                except OSError as exc:
+                    rollback_errors.append(f"{path}: {type(exc).__name__}: {exc}")
+            else:
+                try:
+                    path.unlink(missing_ok=True)
+                except OSError as exc:
+                    rollback_errors.append(f"{path}: {type(exc).__name__}: {exc}")
+
+        dir_errors = _cleanup_empty_directories(created_directories)
+        rollback_errors.extend(dir_errors)
+
+        if rollback_errors:
+            details = "; ".join(rollback_errors)
+            raise RuntimeError(
+                f"scaffold failed and rollback was incomplete: {details}"
+            ) from original_exc
+
+        raise
 
     return ScaffoldResult(
         provider_dir=provider_dir,
@@ -353,7 +428,7 @@ def scaffold_provider(
         fixture_dir=fixture_dir,
         fixture_path=fixture_path,
         contract_test_path=contract_test_path,
-        created=tuple(created),
+        created=tuple(files.keys()),
     )
 
 

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -139,6 +139,177 @@ class TestScaffoldProvider:
             scaffold_provider("ok_name", repo_root=repo, dataset_key="class")
 
 
+class TestScaffoldRollback:
+    def test_new_scaffold_failure_rolls_back_all_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = _shared_repo_root(tmp_path)
+
+        write_count = 0
+        original_write_text = Path.write_text
+
+        def failing_write_text(self: Path, content: str, *, encoding: str = "utf-8") -> None:
+            nonlocal write_count
+            write_count += 1
+            if write_count == 3:
+                raise OSError("Simulated disk error")
+            original_write_text(self, content, encoding=encoding)
+
+        monkeypatch.setattr(Path, "write_text", failing_write_text)
+
+        with pytest.raises(OSError, match="Simulated disk error"):
+            scaffold_provider("rollback_test", repo_root=repo, dataset_key="sample")
+
+        for path in [
+            repo / "src" / "kpubdata" / "providers" / "rollback_test" / "__init__.py",
+            repo / "src" / "kpubdata" / "providers" / "rollback_test" / "adapter.py",
+            repo / "src" / "kpubdata" / "providers" / "rollback_test" / "catalogue.json",
+            repo / "tests" / "fixtures" / "rollback_test" / "success_sample.json",
+            repo / "tests" / "contract" / "test_rollback_test.py",
+        ]:
+            assert not path.exists(), f"File should be rolled back: {path}"
+
+        provider_dir = repo / "src" / "kpubdata" / "providers" / "rollback_test"
+        fixture_dir = repo / "tests" / "fixtures" / "rollback_test"
+        contract_test_dir = repo / "tests" / "contract"
+
+        assert not provider_dir.exists() or not list(provider_dir.iterdir())
+        assert not fixture_dir.exists() or not list(fixture_dir.iterdir())
+        assert contract_test_dir.exists()
+
+        result = scaffold_provider("rollback_test", repo_root=repo, dataset_key="sample")
+        assert result.adapter_path.exists()
+        assert result.contract_test_path.exists()
+
+    def test_overwrite_failure_restores_original_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = _shared_repo_root(tmp_path)
+        original_result = scaffold_provider(
+            "overwrite_rollback", repo_root=repo, dataset_key="first"
+        )
+
+        original_init_bytes = original_result.init_path.read_bytes()
+        original_adapter_bytes = original_result.adapter_path.read_bytes()
+
+        original_result.catalogue_path.write_text('["custom content"]', encoding="utf-8")
+        original_result.fixture_path.write_text('{"custom": "fixture"}', encoding="utf-8")
+
+        write_count = 0
+        original_write_text = Path.write_text
+
+        def failing_write_text(self: Path, content: str, *, encoding: str = "utf-8") -> None:
+            nonlocal write_count
+            write_count += 1
+            if write_count == 2:
+                raise OSError("Simulated overwrite error")
+            original_write_text(self, content, encoding=encoding)
+
+        monkeypatch.setattr(Path, "write_text", failing_write_text)
+
+        with pytest.raises(OSError, match="Simulated overwrite error"):
+            scaffold_provider(
+                "overwrite_rollback", repo_root=repo, dataset_key="second", overwrite=True
+            )
+
+        assert original_result.init_path.exists()
+        assert original_result.adapter_path.exists()
+        assert original_result.catalogue_path.exists()
+        assert original_result.fixture_path.exists()
+        assert original_result.contract_test_path.exists()
+
+        assert original_result.init_path.read_bytes() == original_init_bytes, (
+            "First written file should be restored"
+        )
+        assert original_result.adapter_path.read_bytes() == original_adapter_bytes, (
+            "Second file should be unchanged"
+        )
+
+        catalogue_text = original_result.catalogue_path.read_text(encoding="utf-8")
+        assert catalogue_text == '["custom content"]', (
+            "catalogue was not attempted, should keep user modification"
+        )
+
+        fixture_text = original_result.fixture_path.read_text(encoding="utf-8")
+        assert fixture_text == '{"custom": "fixture"}', (
+            "fixture was not attempted, should keep user modification"
+        )
+
+        provider_dir = repo / "src" / "kpubdata" / "providers" / "overwrite_rollback"
+        fixture_dir = repo / "tests" / "fixtures" / "overwrite_rollback"
+
+        assert provider_dir.exists()
+        assert fixture_dir.exists()
+
+    def test_rollback_failure_reports_incomplete_rollback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = _shared_repo_root(tmp_path)
+        scaffold_provider("rollback_fail", repo_root=repo, dataset_key="first")
+
+        original_write_text = Path.write_text
+        original_write_bytes = Path.write_bytes
+
+        write_count = 0
+        rollback_count = 0
+
+        def failing_write_text(self: Path, content: str, *, encoding: str = "utf-8") -> None:
+            nonlocal write_count
+            write_count += 1
+            if write_count == 2:
+                raise OSError("simulated scaffold write failure")
+            original_write_text(self, content, encoding=encoding)
+
+        def failing_write_bytes(self: Path, content: bytes) -> None:
+            nonlocal rollback_count
+            rollback_count += 1
+            if rollback_count == 1:
+                raise OSError("simulated rollback failure")
+            original_write_bytes(self, content)
+
+        monkeypatch.setattr(Path, "write_text", failing_write_text)
+        monkeypatch.setattr(Path, "write_bytes", failing_write_bytes)
+
+        with pytest.raises(RuntimeError, match="rollback was incomplete") as exc_info:
+            scaffold_provider("rollback_fail", repo_root=repo, dataset_key="second", overwrite=True)
+
+        assert "simulated rollback failure" in str(exc_info.value)
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, OSError)
+        assert "simulated scaffold write failure" in str(exc_info.value.__cause__)
+
+    def test_nonempty_provider_dir_is_not_reported_as_rollback_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = _shared_repo_root(tmp_path)
+
+        write_count = 0
+        original_write_text = Path.write_text
+
+        def failing_write_text(self: Path, content: str, *, encoding: str = "utf-8") -> None:
+            nonlocal write_count
+            write_count += 1
+            if write_count == 2:
+                (
+                    repo / "src" / "kpubdata" / "providers" / "nonempty_test" / "other.txt"
+                ).write_text("other file", encoding="utf-8")
+                raise OSError("Simulated scaffold failure")
+            original_write_text(self, content, encoding=encoding)
+
+        monkeypatch.setattr(Path, "write_text", failing_write_text)
+
+        with pytest.raises(OSError, match="Simulated scaffold failure"):
+            scaffold_provider("nonempty_test", repo_root=repo, dataset_key="sample")
+
+        provider_dir = repo / "src" / "kpubdata" / "providers" / "nonempty_test"
+        assert provider_dir.exists()
+        assert (provider_dir / "other.txt").exists()
+        assert (provider_dir / "other.txt").read_text(encoding="utf-8") == "other file"
+
+        result = scaffold_provider("nonempty_test", repo_root=repo, dataset_key="sample")
+        assert result.adapter_path.exists()
+
+
 class TestScaffoldCli:
     def test_cli_subcommand_creates_files(
         self,


### PR DESCRIPTION
## 요약

Provider scaffold 파일 생성 도중 오류가 발생하면 일부 파일만 남거나 기존 파일 일부만 덮어써지는 문제를 수정했습니다.

실패 시 이번 호출에서 발생한 변경을 되돌려, `scaffold_provider()` 실행 전 상태를 최대한 보존하도록 rollback 처리를 추가했습니다.

## 변경 내용

* 신규 scaffold 생성 중 실패한 경우 이번 호출에서 생성한 파일 삭제
* `overwrite=True` 실행 중 실패한 경우 기존 파일을 원본 bytes로 복원
* 실제로 쓰기를 시도한 파일만 역순으로 rollback
* 실패한 현재 파일이 부분 생성된 경우에도 cleanup 대상에 포함
* 이번 호출에서 새로 만든 빈 leaf 디렉터리 정리
* 비어 있지 않은 디렉터리와 기존 공유 디렉터리는 보존
* rollback 성공 시 최초 예외의 타입과 메시지를 그대로 재발생
* rollback 자체가 실패하면 `RuntimeError`로 불완전 상태 보고
* 최초 scaffold 오류를 exception cause로 보존

추가한 회귀 테스트:

* 신규 scaffold 중간 실패 시 파일과 빈 디렉터리 rollback
* `overwrite=True` 실패 시 기존 파일 byte-for-byte 복원
* 파일 복원 중 rollback 실패 시 불완전 상태 보고
* 비어 있지 않은 provider 디렉터리 보존

## 관련 이슈

Closes #281

## 검증

* [x] Ruff lint / format 통과
* [x] mypy 타입 체크 통과
* [x] Issue #281 단위 테스트 통과 (`16 passed`)
* [x] 패키지 빌드 통과
* [x] 문서 strict 빌드 통과
* [x] 신규 provider adapter는 계약/통합 테스트를 포함 (해당 없음)

실행 결과:

* `uv run --frozen pytest tests/unit/test_scaffold.py` — 16 passed
* `uv run --frozen ruff check .` — passed
* `uv run --frozen ruff format --check .` — passed
* `uv run --frozen mypy src` — passed
* `uv run --frozen python -m build` — passed
* `uv run --frozen mkdocs build --strict` — passed
* `uv run --frozen pytest` — 1017 passed, 4 failed, 98 deselected

전체 테스트의 실패 4건은 Windows 기본 cp949 인코딩으로 UTF-8 catalogue 파일을 읽으면서 발생하는 기존 문제이며, 이번 PR의 변경 파일 및 scaffold 기능과는 관련이 없습니다.

실패 테스트:

* `tests/unit/providers/bok/test_bok_adapter.py::test_catalogue_includes_usd_krw_daily_dataset`
* `tests/unit/providers/bok/test_bok_adapter.py::test_catalogue_includes_bond_yield_3y_daily_dataset`
* `tests/unit/providers/bok/test_bok_adapter.py::test_catalogue_includes_money_supply_monthly_dataset`
* `tests/unit/providers/kosis/test_adapter.py::test_catalogue_parses_industrial_production_default_query_params`

## 체크리스트

* [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
* [x] 커밋 메시지를 영어로 작성했다
* [x] 공개 API 변경 시 문서/CHANGELOG를 갱신했다 (공개 API 변경 없음)
* [x] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다 (별도 문서 변경이 필요한 계약 변경 없음)
