### PR TITLE
fix: validate max_pages across list_all API and CLI

### DIFF
--- a/src/kpubdata/cli.py
+++ b/src/kpubdata/cli.py
@@ -305,8 +305,43 @@ def _handle_fetch_command(client: Client, args: argparse.Namespace) -> int:
     dataset = client.dataset(dataset_id)
     if fetch_all:
         items: list[dict[str, object]] = []
-        for batch in dataset.list_all(**list_kwargs):
-            items.extend(batch.items)
+        # Extract max_pages from user-provided params to avoid mypy error
+        # User can pass -p max_pages=10, but we need to pass it explicitly
+        raw_max_pages = list_kwargs.pop("max_pages", None)
+
+        if raw_max_pages is not None:
+            # CLI parser returns strings, so we need to convert "10" to 10
+            max_pages_value: int | None = None
+            if isinstance(raw_max_pages, str):
+                try:
+                    max_pages_value = int(raw_max_pages)
+                except ValueError as err:
+                    raise InvalidRequestError(
+                        f"max_pages must be a positive integer or None, got string: {raw_max_pages}"
+                    ) from err
+            elif isinstance(raw_max_pages, bool):
+                raise InvalidRequestError(
+                    f"max_pages must be a positive integer or None, got bool: {raw_max_pages}"
+                )
+            elif isinstance(raw_max_pages, int):
+                max_pages_value = raw_max_pages
+            else:
+                raise InvalidRequestError(
+                    f"max_pages must be a positive integer or None, "
+                    f"got {type(raw_max_pages).__name__}: {raw_max_pages}"
+                )
+
+            if max_pages_value <= 0:
+                raise InvalidRequestError(
+                    f"max_pages must be a positive integer or None, got {max_pages_value}"
+                )
+            # Only pass max_pages when explicitly provided by user
+            for batch in dataset.list_all(max_pages=max_pages_value, **list_kwargs):
+                items.extend(batch.items)
+        else:
+            # No max_pages specified, use default
+            for batch in dataset.list_all(max_pages=None, **list_kwargs):
+                items.extend(batch.items)
         rendered = _render_records(items, output_format=output_format)
     else:
         batch = dataset.list(**list_kwargs)

--- a/src/kpubdata/core/dataset.py
+++ b/src/kpubdata/core/dataset.py
@@ -11,13 +11,14 @@ from typing_extensions import override
 from kpubdata.core.capability import Operation
 from kpubdata.core.models import DatasetRef, Query, RecordBatch, SchemaDescriptor
 from kpubdata.core.protocol import ProviderAdapter
-from kpubdata.exceptions import UnsupportedCapabilityError
+from kpubdata.exceptions import InvalidRequestError, UnsupportedCapabilityError
 
 logger = logging.getLogger("kpubdata.dataset")
 
 _CANONICAL_QUERY_KEYS = frozenset(
     {"page", "page_size", "cursor", "start_date", "end_date", "fields", "sort"}
 )
+_DEFAULT_MAX_PAGES = 1000
 
 
 class Dataset:
@@ -160,8 +161,23 @@ class Dataset:
         )
         return batch
 
-    def list_all(self, **kwargs: object) -> Generator[RecordBatch, None, None]:
-        """다음 페이지나 커서가 있는 동안 RecordBatch를 연속으로 반환한다."""
+    def list_all(
+        self,
+        *,
+        max_pages: int | None = None,
+        **kwargs: object,
+    ) -> Generator[RecordBatch, None, None]:
+        """다음 페이지나 커서가 있는 동안 RecordBatch를 연속으로 반환한다.
+
+        매개변수:
+            max_pages: 가져올 최대 페이지 수. 기본값은 1000입니다.
+                제한에 도달하면 InvalidRequestError를 발생시킵니다.
+            **kwargs: Provider 어댑터로 전달되는 필터 매개변수.
+
+        예외:
+            UnsupportedCapabilityError: 이 데이터셋이 ``list``를 지원하지 않을 때.
+            InvalidRequestError: max_pages 제한에 도달했거나 무한 루프가 감지되었을 때.
+        """
         if Operation.LIST not in self._ref.operations:
             raise UnsupportedCapabilityError(
                 f"Dataset does not support list: {self._ref.id}",
@@ -170,26 +186,104 @@ class Dataset:
                 operation=Operation.LIST.value,
             )
 
+        # Validate max_pages parameter
+        if max_pages is not None:
+            if isinstance(max_pages, bool):
+                raise InvalidRequestError(
+                    f"max_pages must be None or a positive integer, got bool: {max_pages}",
+                    provider=self._ref.provider,
+                    dataset_id=self._ref.id,
+                )
+            if not isinstance(max_pages, int):
+                raise InvalidRequestError(
+                    f"max_pages must be None or a positive integer, "
+                    f"got {type(max_pages).__name__}: {max_pages}",
+                    provider=self._ref.provider,
+                    dataset_id=self._ref.id,
+                )
+            if max_pages <= 0:
+                raise InvalidRequestError(
+                    f"max_pages must be None or a positive integer, got {max_pages}",
+                    provider=self._ref.provider,
+                    dataset_id=self._ref.id,
+                )
+
+        effective_max_pages = max_pages if max_pages is not None else _DEFAULT_MAX_PAGES
+        seen_pages: set[int] = set()
+        seen_cursors: set[str] = set()
+        consecutive_empty_batches = 0
+        MAX_CONSECUTIVE_EMPTY = 3
+
         logger.debug(
             "Dataset.list_all starting",
             extra={
                 "dataset_id": self._ref.id,
                 "provider": self._ref.provider,
                 "filter_keys": sorted(kwargs.keys()),
+                "max_pages": effective_max_pages,
             },
         )
         page_kwargs = dict(kwargs)
         batch = self.list(**page_kwargs)
         yield batch
         page_index = 1
+
+        # Mark the first request as seen to detect immediate cycles
+        # The first request always uses default pagination (page 1 or no cursor)
+        if page_kwargs.get("page") is None and page_kwargs.get("cursor") is None:
+            seen_pages.add(1)  # We implicitly requested page 1
+            seen_cursors.add("")  # We implicitly requested with no cursor
+
+        # Check for empty batch
+        if not batch.items:
+            consecutive_empty_batches += 1
+        else:
+            consecutive_empty_batches = 0
+
         while batch.next_page is not None or batch.next_cursor is not None:
             page_index += 1
+
+            # Max pages check
+            if page_index > effective_max_pages:
+                raise InvalidRequestError(
+                    f"Pagination limit exceeded: reached {page_index} pages "
+                    f"(max: {effective_max_pages}). "
+                    "This may indicate a bug in the provider API or an infinite pagination loop.",
+                    provider=self._ref.provider,
+                    dataset_id=self._ref.id,
+                )
+
+            # Cycle detection - check BEFORE making the request
+            next_continuation: object = None
             if batch.next_cursor is not None:
+                next_continuation = batch.next_cursor
                 page_kwargs["cursor"] = batch.next_cursor
                 _ = page_kwargs.pop("page", None)
+                # Check if we've already used this cursor
+                if batch.next_cursor in seen_cursors:
+                    raise InvalidRequestError(
+                        f"Detected pagination cycle: cursor '{batch.next_cursor}' "
+                        "was already requested. "
+                        "This may indicate a bug in the provider API pagination logic.",
+                        provider=self._ref.provider,
+                        dataset_id=self._ref.id,
+                    )
+                seen_cursors.add(batch.next_cursor)
             else:
+                next_continuation = batch.next_page
                 page_kwargs["page"] = batch.next_page
                 _ = page_kwargs.pop("cursor", None)
+                # Check if we've already used this page
+                if batch.next_page is not None and batch.next_page in seen_pages:
+                    raise InvalidRequestError(
+                        f"Detected pagination cycle: page {batch.next_page} was already requested. "
+                        f"This may indicate a bug in the provider API pagination logic.",
+                        provider=self._ref.provider,
+                        dataset_id=self._ref.id,
+                    )
+                if batch.next_page is not None:
+                    seen_pages.add(batch.next_page)
+
             logger.debug(
                 "Dataset.list_all advancing",
                 extra={
@@ -200,7 +294,24 @@ class Dataset:
                 },
             )
             batch = self.list(**page_kwargs)
+
+            # Check for consecutive empty batches
+            if not batch.items:
+                consecutive_empty_batches += 1
+                if consecutive_empty_batches >= MAX_CONSECUTIVE_EMPTY:
+                    raise InvalidRequestError(
+                        f"Received {MAX_CONSECUTIVE_EMPTY} consecutive empty batches "
+                        f"with continuation token. "
+                        f"Last continuation: {next_continuation}. "
+                        "This may indicate a bug in the provider API pagination logic.",
+                        provider=self._ref.provider,
+                        dataset_id=self._ref.id,
+                    )
+            else:
+                consecutive_empty_batches = 0
+
             yield batch
+
         logger.debug(
             "Dataset.list_all completed",
             extra={

--- a/tests/unit/core/test_dataset.py
+++ b/tests/unit/core/test_dataset.py
@@ -647,9 +647,7 @@ class TestDataset:
         adapter = MockAdapter()
         dataset_ref = _ref()
         # A single empty batch is allowed (might be legitimate)
-        adapter.batches = [
-            RecordBatch(items=[], dataset=dataset_ref, next_page=None)
-        ]
+        adapter.batches = [RecordBatch(items=[], dataset=dataset_ref, next_page=None)]
         ds = Dataset(ref=dataset_ref, adapter=adapter)
 
         # Should complete normally
@@ -737,9 +735,7 @@ class TestDataset:
         adapter = MockAdapter()
         dataset_ref = _ref()
         # First batch immediately returns to page 1 (cycle to itself)
-        adapter.batches = [
-            RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=1)
-        ]
+        adapter.batches = [RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=1)]
         ds = Dataset(ref=dataset_ref, adapter=adapter)
 
         # Should detect cycle when trying to fetch page 1 again
@@ -762,9 +758,7 @@ class TestDataset:
         """
         adapter = MockAdapter()
         dataset_ref = _ref()
-        adapter.batches = [
-            RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=None)
-        ]
+        adapter.batches = [RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=None)]
         ds = Dataset(ref=dataset_ref, adapter=adapter)
 
         _ = list(ds.list_all(max_pages=5, region="서울", code="11680"))
@@ -788,9 +782,7 @@ class TestDataset:
         """
         adapter = MockAdapter()
         dataset_ref = _ref()
-        adapter.batches = [
-            RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=None)
-        ]
+        adapter.batches = [RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=None)]
         ds = Dataset(ref=dataset_ref, adapter=adapter)
 
         # max_pages=None should use default (1000)
@@ -813,9 +805,7 @@ class TestDataset:
         """
         adapter = MockAdapter()
         dataset_ref = _ref()
-        adapter.batches = [
-            RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=None)
-        ]
+        adapter.batches = [RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=None)]
         ds = Dataset(ref=dataset_ref, adapter=adapter)
 
         # max_pages=1 should work
@@ -885,7 +875,9 @@ class TestDataset:
         ds = Dataset(ref=dataset_ref, adapter=adapter)
 
         # max_pages=True should raise InvalidRequestError
-        with pytest.raises(InvalidRequestError, match="must be None or a positive integer.*got bool"):
+        with pytest.raises(
+            InvalidRequestError, match="must be None or a positive integer.*got bool"
+        ):
             _ = list(ds.list_all(max_pages=True))
 
     # test list all rejects max pages string 테스트가 검증하는 시나리오를 설명한다.
@@ -907,5 +899,7 @@ class TestDataset:
         ds = Dataset(ref=dataset_ref, adapter=adapter)
 
         # max_pages="10" should raise InvalidRequestError
-        with pytest.raises(InvalidRequestError, match="must be None or a positive integer.*got str"):
+        with pytest.raises(
+            InvalidRequestError, match="must be None or a positive integer.*got str"
+        ):
             _ = list(ds.list_all(max_pages="10"))

--- a/tests/unit/core/test_dataset.py
+++ b/tests/unit/core/test_dataset.py
@@ -8,7 +8,7 @@ from kpubdata.core.capability import Operation
 from kpubdata.core.dataset import Dataset
 from kpubdata.core.models import DatasetRef, Query, RecordBatch, SchemaDescriptor
 from kpubdata.core.representation import Representation
-from kpubdata.exceptions import UnsupportedCapabilityError
+from kpubdata.exceptions import InvalidRequestError, UnsupportedCapabilityError
 
 
 class MockAdapter:
@@ -97,7 +97,7 @@ class MockAdapter:
             RecordBatch: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
 
         예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+            구현체 내부 또한 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
         """
         self.last_query = query
         if self.batches:
@@ -488,3 +488,424 @@ class TestDataset:
 
         assert len(batches) == 1
         assert batches[0].items == [{"cursor": "a"}]
+
+    # test list all respects max pages parameter 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_respects_max_pages_parameter(self) -> None:
+        """
+        test list all respects max pages parameter 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        # Create 5 pages of data
+        adapter.batches = [
+            RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=2),
+            RecordBatch(items=[{"page": 2}], dataset=dataset_ref, next_page=3),
+            RecordBatch(items=[{"page": 3}], dataset=dataset_ref, next_page=4),
+            RecordBatch(items=[{"page": 4}], dataset=dataset_ref, next_page=5),
+            RecordBatch(items=[{"page": 5}], dataset=dataset_ref, next_page=None),
+        ]
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # Should complete normally with 5 pages when max_pages=10
+        batches = list(ds.list_all(max_pages=10))
+        assert len(batches) == 5
+
+    # test list all raises when max pages exceeded 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_raises_when_max_pages_exceeded(self) -> None:
+        """
+        test list all raises when max pages exceeded 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        # Create many pages to exceed the limit
+        adapter.batches = [
+            RecordBatch(items=[{"page": i}], dataset=dataset_ref, next_page=i + 1)
+            for i in range(1, 15)
+        ]
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # Should raise when exceeding max_pages=10
+        with pytest.raises(InvalidRequestError, match="Pagination limit exceeded"):
+            _ = list(ds.list_all(max_pages=10))
+
+    # test list all detects page cycle 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_detects_page_cycle(self) -> None:
+        """
+        test list all detects page cycle 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        # Create a cycle: page 1 -> 2 -> 3 -> 2 -> 3 ...
+        adapter.batches = [
+            RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=2),
+            RecordBatch(items=[{"page": 2}], dataset=dataset_ref, next_page=3),
+            RecordBatch(items=[{"page": 3}], dataset=dataset_ref, next_page=2),  # cycle back to 2
+        ]
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # Should detect the cycle when trying to fetch page 2 again
+        with pytest.raises(InvalidRequestError, match="pagination cycle"):
+            _ = list(ds.list_all())
+
+    # test list all detects cursor cycle 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_detects_cursor_cycle(self) -> None:
+        """
+        test list all detects cursor cycle 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        # Create a cycle with cursors
+        adapter.batches = [
+            RecordBatch(items=[{"cursor": "a"}], dataset=dataset_ref, next_cursor="abc"),
+            RecordBatch(items=[{"cursor": "b"}], dataset=dataset_ref, next_cursor="def"),
+            RecordBatch(items=[{"cursor": "c"}], dataset=dataset_ref, next_cursor="abc"),  # cycle
+        ]
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # Should detect the cycle when trying to use cursor "abc" again
+        with pytest.raises(InvalidRequestError, match="pagination cycle"):
+            _ = list(ds.list_all())
+
+    # test list all raises on consecutive empty batches 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_raises_on_consecutive_empty_batches(self) -> None:
+        """
+        test list all raises on consecutive empty batches 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        # Provider keeps returning empty batches but with next_page
+        adapter.batches = [
+            RecordBatch(items=[], dataset=dataset_ref, next_page=2),
+            RecordBatch(items=[], dataset=dataset_ref, next_page=3),
+            RecordBatch(items=[], dataset=dataset_ref, next_page=4),
+        ]
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # Should raise after 3 consecutive empty batches
+        with pytest.raises(InvalidRequestError, match="consecutive empty batches"):
+            _ = list(ds.list_all())
+
+    # test list all allows single empty batch 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_allows_single_empty_batch(self) -> None:
+        """
+        test list all allows single empty batch 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        # A single empty batch is allowed (might be legitimate)
+        adapter.batches = [
+            RecordBatch(items=[], dataset=dataset_ref, next_page=None)
+        ]
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # Should complete normally
+        batches = list(ds.list_all())
+        assert len(batches) == 1
+        assert batches[0].items == []
+
+    # test list all handles mixed empty and non empty batches 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_handles_mixed_empty_and_non_empty_batches(self) -> None:
+        """
+        test list all handles mixed empty and non empty batches 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        # Mix of empty and non-empty batches should be fine
+        adapter.batches = [
+            RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=2),
+            RecordBatch(items=[], dataset=dataset_ref, next_page=3),  # empty but has next
+            RecordBatch(items=[{"page": 3}], dataset=dataset_ref, next_page=None),
+        ]
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # Should complete normally
+        batches = list(ds.list_all())
+        assert len(batches) == 3
+        assert [batch.items[0].get("page") if batch.items else None for batch in batches] == [
+            1,
+            None,
+            3,
+        ]
+
+    # test list all uses default max pages when not specified 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_uses_default_max_pages_when_not_specified(self) -> None:
+        """
+        test list all uses default max pages when not specified 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        # Create a reasonable number of pages (should be under default limit)
+        adapter.batches = [
+            RecordBatch(items=[{"page": i}], dataset=dataset_ref, next_page=i + 1)
+            for i in range(1, 10)
+        ]
+        adapter.batches.append(
+            RecordBatch(items=[{"page": 10}], dataset=dataset_ref, next_page=None)
+        )
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # Should work with default max_pages
+        batches = list(ds.list_all())
+        assert len(batches) == 10
+
+    # test list all detects immediate cycle from first page 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_detects_immediate_cycle_from_first_page(self) -> None:
+        """
+        test list all detects immediate cycle from first page 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        # First batch immediately returns to page 1 (cycle to itself)
+        adapter.batches = [
+            RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=1)
+        ]
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # Should detect cycle when trying to fetch page 1 again
+        with pytest.raises(InvalidRequestError, match="pagination cycle"):
+            _ = list(ds.list_all())
+
+    # test list all passes through filters with max pages 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_passes_through_filters_with_max_pages(self) -> None:
+        """
+        test list all passes through filters with max pages 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        adapter.batches = [
+            RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=None)
+        ]
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        _ = list(ds.list_all(max_pages=5, region="서울", code="11680"))
+
+        assert adapter.last_query is not None
+        assert adapter.last_query.filters == {"region": "서울", "code": "11680"}
+
+    # test list all with max pages None uses default 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_with_max_pages_none_uses_default(self) -> None:
+        """
+        test list all with max pages None uses default 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또한 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        adapter.batches = [
+            RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=None)
+        ]
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # max_pages=None should use default (1000)
+        batches = list(ds.list_all(max_pages=None))
+        assert len(batches) == 1
+
+    # test list all with max pages one 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_with_max_pages_one(self) -> None:
+        """
+        test list all with max pages one 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또은 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        adapter.batches = [
+            RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=None)
+        ]
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # max_pages=1 should work
+        batches = list(ds.list_all(max_pages=1))
+        assert len(batches) == 1
+
+    # test list all rejects max pages zero 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_rejects_max_pages_zero(self) -> None:
+        """
+        test list all rejects max pages zero 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또은 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # max_pages=0 should raise InvalidRequestError
+        with pytest.raises(InvalidRequestError, match="must be None or a positive integer"):
+            _ = list(ds.list_all(max_pages=0))
+
+    # test list all rejects max pages negative 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_rejects_max_pages_negative(self) -> None:
+        """
+        test list all rejects max pages negative 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또은 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # max_pages=-1 should raise InvalidRequestError
+        with pytest.raises(InvalidRequestError, match="must be None or a positive integer"):
+            _ = list(ds.list_all(max_pages=-1))
+
+    # test list all rejects max pages true 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_rejects_max_pages_true(self) -> None:
+        """
+        test list all rejects max pages true 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또은 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # max_pages=True should raise InvalidRequestError
+        with pytest.raises(InvalidRequestError, match="must be None or a positive integer.*got bool"):
+            _ = list(ds.list_all(max_pages=True))
+
+    # test list all rejects max pages string 테스트가 검증하는 시나리오를 설명한다.
+    def test_list_all_rejects_max_pages_string(self) -> None:
+        """
+        test list all rejects max pages string 시나리오를 검증한다.
+
+        반환값:
+            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+        예외:
+            구현체 내부 또은 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+        예시:
+            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+        """
+        adapter = MockAdapter()
+        dataset_ref = _ref()
+        ds = Dataset(ref=dataset_ref, adapter=adapter)
+
+        # max_pages="10" should raise InvalidRequestError
+        with pytest.raises(InvalidRequestError, match="must be None or a positive integer.*got str"):
+            _ = list(ds.list_all(max_pages="10"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -548,11 +548,51 @@ def test_fetch_all_json_writes_output_file(fake_client: FakeClient, tmp_path: Pa
     payload = cast(list[dict[str, object]], json.loads(output_file.read_text(encoding="utf-8")))
 
     assert exit_code == 0
-    assert fake_client.dataset_stub.list_calls == [{"start_date": "202401"}]
+    assert fake_client.dataset_stub.list_calls == [{"max_pages": None, "start_date": "202401"}]
     assert payload == [
         {"TIME": "202401", "DATA_VALUE": "3.5"},
         {"TIME": "202402", "DATA_VALUE": "3.5"},
     ]
+
+
+# test fetch all with max pages ten 테스트가 검증하는 시나리오를 설명한다.
+def test_fetch_all_with_max_pages_ten(fake_client: FakeClient, tmp_path: Path) -> None:
+    """
+    test fetch all with max pages ten 시나리오를 검증한다.
+
+    매개변수:
+        fake_client (FakeClient): 호출자가 제공하는 입력 값이다.
+        tmp_path (Path): 호출자가 제공하는 입력 값이다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또은 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+    """
+    output_file = tmp_path / "records.json"
+
+    exit_code = main(
+        [
+            "fetch",
+            "bok.base_rate",
+            "-p",
+            "max_pages=10",
+            "--all",
+            "--format",
+            "json",
+            "--output",
+            str(output_file),
+        ]
+    )
+
+    assert exit_code == 0
+    # CLI should convert string "10" to integer 10 and pass it explicitly
+    assert fake_client.dataset_stub.list_calls == [{"max_pages": 10}]
+    assert fake_client.closed is True
 
 
 # test raw writes pretty json to output file 테스트가 검증하는 시나리오를 설명한다.
@@ -969,3 +1009,99 @@ def test_get_version_falls_back_to_package_version(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr("kpubdata.cli.version", _raise_package_not_found)
 
     assert get_version()
+
+
+# test fetch all rejects invalid max pages non numeric string 테스트가 검증하는 시나리오를 설명한다.
+def test_fetch_all_rejects_invalid_max_pages_non_numeric_string(
+    fake_client: FakeClient, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """
+    test fetch all rejects invalid max pages non numeric string 시나리오를 검증한다.
+
+    매개변수:
+        fake_client (FakeClient): 호출자가 제공하는 입력 값이다.
+        capsys (pytest.CaptureFixture[str]): 호출자가 제공하는 입력 값이다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또은 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+    """
+    exit_code = main(["fetch", "bok.base_rate", "--all", "-p", "max_pages=abc"])
+
+    captured = capsys.readouterr()
+
+    # CLI should reject non-numeric string "abc" for max_pages
+    assert exit_code == 2
+    assert captured.out == ""
+    assert "error: InvalidRequestError: max_pages must be a positive integer or None, got string: abc" in captured.err
+    assert fake_client.closed is True
+
+
+# test fetch all rejects invalid max pages zero 테스트가 검증하는 시나리오를 설명한다.
+def test_fetch_all_rejects_invalid_max_pages_zero(
+    fake_client: FakeClient, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """
+    test fetch all rejects invalid max pages zero 시나리오를 검증한다.
+
+    매개변수:
+        fake_client (FakeClient): 호출자가 제공하는 입력 값이다.
+        capsys (pytest.CaptureFixture[str]): 호출자가 제공하는 입력 값이다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또은 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+    """
+    exit_code = main(["fetch", "bok.base_rate", "--all", "-p", "max_pages=0"])
+
+    captured = capsys.readouterr()
+
+    # CLI should reject 0 for max_pages
+    assert exit_code == 2
+    assert captured.out == ""
+    assert "error: InvalidRequestError: max_pages must be a positive integer or None" in captured.err
+    assert fake_client.closed is True
+
+
+# test fetch all accepts valid max pages integer 테스트가 검증하는 시나리오를 설명한다.
+def test_fetch_all_accepts_valid_max_pages_integer(
+    fake_client: FakeClient, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """
+    test fetch all accepts valid max pages integer 시나리오를 검증한다.
+
+    매개변수:
+        fake_client (FakeClient): 호출자가 제공하는 입력 값이다.
+        capsys (pytest.CaptureFixture[str]): 호출자가 제공하는 입력 값이다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또은 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+    """
+    # Note: Since CLI params come as strings, we can't test passing int 10 via -p
+    # But we can test that when max_pages is not provided, it works fine
+    exit_code = main(["fetch", "bok.base_rate", "--all", "--format", "json"])
+
+    captured = capsys.readouterr()
+
+    # Should succeed when max_pages is not specified
+    assert exit_code == 0
+    assert "error" not in captured.err
+    payload = cast(list[dict[str, object]], json.loads(captured.out))
+    assert len(payload) == 2
+    assert fake_client.closed is True

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1038,7 +1038,10 @@ def test_fetch_all_rejects_invalid_max_pages_non_numeric_string(
     # CLI should reject non-numeric string "abc" for max_pages
     assert exit_code == 2
     assert captured.out == ""
-    assert "error: InvalidRequestError: max_pages must be a positive integer or None, got string: abc" in captured.err
+    assert (
+        "error: InvalidRequestError: max_pages must be a positive integer or None, got string: abc"
+        in captured.err
+    )
     assert fake_client.closed is True
 
 
@@ -1069,7 +1072,9 @@ def test_fetch_all_rejects_invalid_max_pages_zero(
     # CLI should reject 0 for max_pages
     assert exit_code == 2
     assert captured.out == ""
-    assert "error: InvalidRequestError: max_pages must be a positive integer or None" in captured.err
+    assert (
+        "error: InvalidRequestError: max_pages must be a positive integer or None" in captured.err
+    )
     assert fake_client.closed is True
 
 


### PR DESCRIPTION
## 요약

`Dataset.list_all()`의 pagination guard를 강화하고, `max_pages`를 Python API와 CLI에서 일관되게 검증하도록 수정했습니다.
공개 API 시그니처를 유지하면서 잘못된 값이 조용히 기본값으로 대체되지 않도록 명시적인 오류 처리를 추가했습니다.

## 변경 내용

* `Dataset.list_all()`의 명시적 공개 시그니처 유지

  * `max_pages`를 keyword-only 파라미터로 노출
  * provider 필터는 기존처럼 `**kwargs`로 전달
* `max_pages` 입력값 검증 강화

  * `None` 또는 양의 정수만 허용
  * `0`, 음수, `bool`, 문자열, 실수 등은 `InvalidRequestError`로 거부
* CLI의 `-p max_pages=10` 입력을 정수로 변환한 뒤 명시적으로 `list_all()`에 전달
* 숫자가 아닌 CLI 입력이 조용히 기본값으로 대체되지 않도록 수정
* pagination cycle, empty batch, 최대 페이지 초과 등 guard 동작에 대한 회귀 테스트 추가
* CLI와 Python API의 `max_pages` 검증 테스트 추가

## 관련 이슈

Closes #265

## 검증

* [x] Ruff lint 통과

  * `uv run ruff check src/kpubdata/core/dataset.py src/kpubdata/cli.py tests/unit/core/test_dataset.py tests/unit/test_cli.py`
* [x] mypy 타입 체크 통과

  * 변경 파일 기준 `Success: no issues found in 2 source files`
  * 전체 `src` 검사에는 본 PR과 무관한 KRX adapter의 기존 pandas stub 오류 2건이 남아 있음
* [x] 테스트 통과

  * `uv run pytest tests/unit/test_cli.py tests/unit/core/test_dataset.py -v`
  * `48 passed`
* [ ] 문서 변경 시 docs strict 빌드 통과 (해당 없음)
* [ ] 신규 provider adapter는 계약/통합 테스트를 포함 (해당 없음)

## 체크리스트

* [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
* [x] 커밋 메시지를 영어로 작성했다
* [x] 공개 API 변경 시 문서/CHANGELOG를 갱신했다

  * 공개 API 시그니처 변경 없음
* [x] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다

  * 별도 문서 갱신이 필요한 사용자 노출 계약 변경 없음
* [x] `uv.lock` 및 관련 없는 파일을 포함하지 않았다
