### PR TITLE
refactor: simplify catalog exception propagation

### DIFF
--- a/src/kpubdata/catalog.py
+++ b/src/kpubdata/catalog.py
@@ -12,7 +12,7 @@ from typing import cast
 
 from kpubdata.core.models import DatasetRef
 from kpubdata.core.protocol import ProviderAdapter
-from kpubdata.exceptions import DatasetNotFoundError, ProviderNotRegisteredError
+from kpubdata.exceptions import DatasetNotFoundError
 from kpubdata.registry import ProviderRegistry
 
 logger = logging.getLogger("kpubdata.catalog")

--- a/src/kpubdata/catalog.py
+++ b/src/kpubdata/catalog.py
@@ -282,10 +282,7 @@ class Catalog:
     def _get_adapter(self, provider: str) -> ProviderAdapter:
         """레지스트리에서 Provider 어댑터를 가져오거나 정규 예외를 발생시킨다."""
 
-        try:
-            return cast(ProviderAdapter, self._registry.get(provider))
-        except ProviderNotRegisteredError:
-            raise
+        return cast(ProviderAdapter, self._registry.get(provider))
 
     @staticmethod
     def _split_dataset_id(dataset_id: str) -> tuple[str, str]:


### PR DESCRIPTION
## 요약

`Catalog._get_adapter()`에서 `ProviderNotRegisteredError`를 그대로 다시 발생시키기만 하던 불필요한 `try-except` 블록을 제거했습니다.
예외 타입과 traceback은 그대로 유지하면서 예외 전파 경로를 단순화합니다.

## 변경 내용

* `_get_adapter()`의 불필요한 `try-except` 제거
* `ProviderRegistry.get()`에서 발생한 `ProviderNotRegisteredError`를 자연스럽게 전파
* 기존 예외 타입, 메시지, traceback 및 공개 API 계약 유지

## 관련 이슈

Closes #266

## 검증

* [x] 변경 범위가 `src/kpubdata/catalog.py` 한 파일인지 확인
* [x] `ProviderNotRegisteredError` 발생 경로 유지 확인
* [x] 예외 래핑이나 `raise ... from None` 사용 없음
* [x] 관련 없는 파일 및 `uv.lock` 변경 없음

## 체크리스트

* [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
* [x] 커밋 메시지를 영어로 작성했다
* [x] 공개 API 변경 없음
* [x] 사용자 노출 기능 변경 없음
* [x] 관련 없는 파일을 포함하지 않았다
