### PR TITLE
fix: validate canonical query inputs (#264)

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -100,6 +100,25 @@ Dataset metadata may expose provider-specific pagination styles through
 `DatasetRef.query_support.pagination`, including `offset`, `cursor`, and
 index-window based `index` pagination.
 
+#### Query validation
+
+`list()` validates canonical query parameters and raises `InvalidRequestError` for invalid values before provider invocation:
+
+| Parameter | Accepted values |
+|---|---|
+| `page` | `None` or positive integer (`>= 1`) |
+| `page_size` | `None` or positive integer (`>= 1`) |
+| `cursor` | `None` or non-empty string |
+| `start_date`, `end_date` | `None` or non-empty string (provider-specific format) |
+| `fields`, `sort` | `None` or `list[str]` |
+
+Other kwargs are passed as provider-specific filters to the adapter. For example, `dataset.list(region="11", custom_param="value")` passes `{"region": "11", "custom_param": "value"}` as provider-specific filters.
+
+**Provider-specific rules** (enforced by adapters):
+- Required provider parameters (e.g., some datasets require `start_date`/`end_date`)
+- Provider-specific date formats (e.g., `YYYYMM` vs `YYYYMMDD`)
+- Provider-specific maximum page size
+
 ### Schema
 
 ```python

--- a/CANONICAL_MODEL.md
+++ b/CANONICAL_MODEL.md
@@ -272,6 +272,26 @@ Notes:
 - `filters` covers the normal case
 - `extra` exists so adapters can carry provider-native hints without contaminating the core model
 
+#### Validation
+
+Query validates common input shape and types at construction time, raising `InvalidRequestError` for invalid values:
+
+- `page`, `page_size`: must be positive integers (`>= 1`) or `None`; `bool`, zero, or negative values are rejected
+- `cursor`: must be a non-empty string or `None`
+- `start_date`, `end_date`: must be non-empty strings or `None`
+- `fields`, `sort`: must be lists of strings or `None`; elements are type-checked
+- `filters`, `extra`: must be dicts with string keys
+
+#### Canonical vs Provider-Specific Rules
+
+Canonical Query validates common input constraints. Provider-specific rules remain adapter responsibilities:
+
+- **Date representation** (e.g., `YYYYMM` vs `YYYYMMDD`): provider-specific, validated by adapters
+- **Required provider parameters** (e.g., specific datasets requiring `start_date`): validated by adapters
+- **Provider-specific ranges and semantics**: validated by adapters
+
+This separation ensures that invalid canonical inputs are rejected early (before provider invocation) while preserving provider flexibility for domain-specific constraints.
+
 ### 3.5 RecordBatch
 
 ```python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Canonical Query validation now prevents invalid canonical query values from reaching provider adapters (#264)
+- `Dataset.list()` now validates canonical query parameters (`page`, `page_size`, `cursor`, `start_date`, `end_date`, `fields`, `sort`) before adapter invocation
+- Canonical keys are now routed by name (not by type) to prevent bypass via type mismatch (e.g., `dataset.list(page="1")` now raises `InvalidRequestError` instead of falling through to filters)
+- Date fields now reject empty strings and whitespace-only values
+- All query validation errors now raise `InvalidRequestError` instead of generic `TypeError`/`ValueError`
+
+### Changed
+
+- Query validation now performs type checking and basic value validation at Query creation time
+- Empty cursor strings (`""`) are now rejected as invalid
+
 ## [0.5.0] - 2026-04-28
 
 ### Added

--- a/src/kpubdata/core/dataset.py
+++ b/src/kpubdata/core/dataset.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Generator
+from collections.abc import Generator, Mapping
 from typing import cast
 
 from typing_extensions import override
@@ -15,9 +15,59 @@ from kpubdata.exceptions import UnsupportedCapabilityError
 
 logger = logging.getLogger("kpubdata.dataset")
 
-_CANONICAL_QUERY_KEYS = frozenset(
-    {"page", "page_size", "cursor", "start_date", "end_date", "fields", "sort"}
-)
+
+def _build_query(kwargs: Mapping[str, object]) -> Query:
+    """
+    Build a Query from kwargs, separating canonical fields from provider-specific filters.
+
+    Canonical query parameters (extracted as direct Query fields):
+        page, page_size, cursor, start_date, end_date, fields, sort
+
+    All other kwargs are preserved in Query.filters for provider-specific handling.
+
+    Args:
+        kwargs: Raw keyword arguments from Dataset.list()
+
+    Returns:
+        Query with canonical fields populated and remaining kwargs in filters.
+    """
+    page: object = None
+    page_size: object = None
+    cursor: object = None
+    start_date: object = None
+    end_date: object = None
+    fields: object = None
+    sort: object = None
+    filters: dict[str, object] = {}
+
+    for key, value in kwargs.items():
+        if key == "page":
+            page = value
+        elif key == "page_size":
+            page_size = value
+        elif key == "cursor":
+            cursor = value
+        elif key == "start_date":
+            start_date = value
+        elif key == "end_date":
+            end_date = value
+        elif key == "fields":
+            fields = value
+        elif key == "sort":
+            sort = value
+        else:
+            filters[key] = value
+
+    return Query(
+        filters=filters,
+        page=cast(int | None, page),
+        page_size=cast(int | None, page_size),
+        cursor=cast(str | None, cursor),
+        start_date=cast(str | None, start_date),
+        end_date=cast(str | None, end_date),
+        fields=cast(list[str] | None, fields),
+        sort=cast(list[str] | None, sort),
+    )
 
 
 class Dataset:
@@ -86,64 +136,21 @@ class Dataset:
                 operation=Operation.LIST.value,
             )
 
-        page: int | None = None
-        page_size: int | None = None
-        cursor: str | None = None
-        start_date: str | None = None
-        end_date: str | None = None
-        fields_list: list[str] | None = None
-        sort_list: list[str] | None = None
-        filters: dict[str, object] = {}
+        query = _build_query(kwargs)
 
-        for key, value in kwargs.items():
-            if key == "page" and isinstance(value, int):
-                page = value
-            elif key == "page_size" and isinstance(value, int):
-                page_size = value
-            elif key == "cursor" and isinstance(value, str):
-                cursor = value
-            elif key == "start_date" and isinstance(value, str):
-                start_date = value
-            elif key == "end_date" and isinstance(value, str):
-                end_date = value
-            elif (
-                key == "fields"
-                and isinstance(value, list)
-                and all(isinstance(item, str) for item in cast(list[object], value))
-            ):
-                fields_list = cast(list[str], value)
-            elif (
-                key == "sort"
-                and isinstance(value, list)
-                and all(isinstance(item, str) for item in cast(list[object], value))
-            ):
-                sort_list = cast(list[str], value)
-            else:
-                filters[key] = value
-
-        query = Query(
-            filters=filters,
-            page=page,
-            page_size=page_size,
-            cursor=cursor,
-            start_date=start_date,
-            end_date=end_date,
-            fields=fields_list,
-            sort=sort_list,
-        )
         logger.debug(
             "Dataset.list dispatching",
             extra={
                 "dataset_id": self._ref.id,
                 "provider": self._ref.provider,
-                "page": page,
-                "page_size": page_size,
-                "cursor": cursor,
-                "start_date": start_date,
-                "end_date": end_date,
-                "fields": fields_list,
-                "sort": sort_list,
-                "filter_keys": sorted(filters.keys()),
+                "page": query.page,
+                "page_size": query.page_size,
+                "cursor": query.cursor,
+                "start_date": query.start_date,
+                "end_date": query.end_date,
+                "fields": query.fields,
+                "sort": query.sort,
+                "filter_keys": sorted(query.filters.keys()),
             },
         )
         batch = self._adapter.query_records(self._ref, query)

--- a/src/kpubdata/core/dataset.py
+++ b/src/kpubdata/core/dataset.py
@@ -16,7 +16,6 @@ from kpubdata.exceptions import InvalidRequestError, UnsupportedCapabilityError
 logger = logging.getLogger("kpubdata.dataset")
 
 
-
 def _build_query(kwargs: Mapping[str, object]) -> Query:
     """
     Build a Query from kwargs, separating canonical fields from provider-specific filters.
@@ -69,6 +68,8 @@ def _build_query(kwargs: Mapping[str, object]) -> Query:
         fields=cast(list[str] | None, fields),
         sort=cast(list[str] | None, sort),
     )
+
+
 _DEFAULT_MAX_PAGES = 1000
 
 

--- a/src/kpubdata/core/models.py
+++ b/src/kpubdata/core/models.py
@@ -9,6 +9,7 @@ from types import MappingProxyType
 
 from kpubdata.core.capability import Operation, QuerySupport, _dataclass
 from kpubdata.core.representation import Representation
+from kpubdata.exceptions import InvalidRequestError
 
 
 def _empty_proxy() -> MappingProxyType[str, object]:
@@ -74,6 +75,104 @@ class Query:
     fields: list[str] | None = None
     sort: list[str] | None = None
     extra: dict[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Query 생성 시 canonical-level 타입 검증을 수행한다."""
+        self._validate_page()
+        self._validate_page_size()
+        self._validate_cursor()
+        self._validate_dates()
+        self._validate_fields()
+        self._validate_sort()
+        self._validate_dict_type(self.filters, "filters")
+        self._validate_dict_type(self.extra, "extra")
+
+    def _validate_page(self) -> None:
+        """page 필드가 유효한 정수인지 검증한다."""
+        if self.page is None:
+            return
+        if isinstance(self.page, bool):
+            raise InvalidRequestError("page must be an integer, not bool")
+        if not isinstance(self.page, int):
+            raise InvalidRequestError(
+                f"page must be an integer or None, got {type(self.page).__name__}"
+            )
+        if self.page < 1:
+            raise InvalidRequestError("page must be a positive integer (>= 1)")
+
+    def _validate_page_size(self) -> None:
+        """page_size 필드가 유효한 정수인지 검증한다."""
+        if self.page_size is None:
+            return
+        if isinstance(self.page_size, bool):
+            raise InvalidRequestError("page_size must be an integer, not bool")
+        if not isinstance(self.page_size, int):
+            raise InvalidRequestError(
+                f"page_size must be an integer or None, got {type(self.page_size).__name__}"
+            )
+        if self.page_size < 1:
+            raise InvalidRequestError("page_size must be a positive integer (>= 1)")
+
+    def _validate_cursor(self) -> None:
+        """cursor 필드가 문자열인지 검증한다."""
+        if self.cursor is None:
+            return
+        if not isinstance(self.cursor, str):
+            raise InvalidRequestError(
+                f"cursor must be a string or None, got {type(self.cursor).__name__}"
+            )
+        if self.cursor == "":
+            raise InvalidRequestError("cursor must be a non-empty string")
+
+    def _validate_dates(self) -> None:
+        """날짜 필드가 문자열이고 비어있지 않은지 검증한다."""
+        for field_name, value in (("start_date", self.start_date), ("end_date", self.end_date)):
+            if value is None:
+                continue
+            if not isinstance(value, str):
+                raise InvalidRequestError(
+                    f"{field_name} must be a string or None, got {type(value).__name__}"
+                )
+            if value == "" or value.isspace():
+                raise InvalidRequestError(f"{field_name} must be a non-empty string")
+
+    def _validate_fields(self) -> None:
+        """fields 필드가 문자열 리스트인지 검증한다."""
+        if self.fields is None:
+            return
+        if not isinstance(self.fields, list):
+            raise InvalidRequestError(
+                f"fields must be a list of strings or None, got {type(self.fields).__name__}"
+            )
+        for i, item in enumerate(self.fields):
+            if not isinstance(item, str):
+                raise InvalidRequestError(
+                    f"fields must contain only strings, got {type(item).__name__} at index {i}"
+                )
+
+    def _validate_sort(self) -> None:
+        """sort 필드가 문자열 리스트인지 검증한다."""
+        if self.sort is None:
+            return
+        if not isinstance(self.sort, list):
+            raise InvalidRequestError(
+                f"sort must be a list of strings or None, got {type(self.sort).__name__}"
+            )
+        for i, item in enumerate(self.sort):
+            if not isinstance(item, str):
+                raise InvalidRequestError(
+                    f"sort must contain only strings, got {type(item).__name__} at index {i}"
+                )
+
+    def _validate_dict_type(self, value: dict[str, object], field_name: str) -> None:
+        """dict 필드의 키가 문자열인지 검증한다."""
+        if not isinstance(value, dict):
+            raise InvalidRequestError(f"{field_name} must be a dict, got {type(value).__name__}")
+        for key in value:
+            if not isinstance(key, str):
+                raise InvalidRequestError(
+                    f"{field_name} keys must be strings, got {type(key).__name__}"
+                )
 
 
 @_dataclass(slots=True)

--- a/tests/unit/core/test_dataset.py
+++ b/tests/unit/core/test_dataset.py
@@ -8,151 +8,49 @@ from kpubdata.core.capability import Operation
 from kpubdata.core.dataset import Dataset
 from kpubdata.core.models import DatasetRef, Query, RecordBatch, SchemaDescriptor
 from kpubdata.core.representation import Representation
-from kpubdata.exceptions import UnsupportedCapabilityError
+from kpubdata.exceptions import InvalidRequestError, UnsupportedCapabilityError
 
 
 class MockAdapter:
     """Adapter that records calls for assertion."""
 
     def __init__(self) -> None:
-        """
-        인스턴스가 사용할 내부 상태를 초기화한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-        """
         self.last_query: Query | None = None
         self.last_raw_op: str | None = None
         self.batches: list[RecordBatch] = []
 
     @property
     def name(self) -> str:
-        """
-        name 동작을 수행한다.
-
-        반환값:
-            str: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-        """
         return "mock"
 
     def list_datasets(self) -> list[DatasetRef]:
-        """
-        list datasets 동작을 수행한다.
-
-        반환값:
-            list[DatasetRef]: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-        """
         return []
 
     def search_datasets(self, text: str) -> list[DatasetRef]:
-        """
-        search datasets 동작을 수행한다.
-
-        매개변수:
-            text (str): 호출자가 제공하는 입력 값이다.
-
-        반환값:
-            list[DatasetRef]: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-        """
         _ = text
         return []
 
     def get_dataset(self, dataset_key: str) -> DatasetRef:
-        """
-        get dataset 동작을 수행한다.
-
-        매개변수:
-            dataset_key (str): 호출자가 제공하는 입력 값이다.
-
-        반환값:
-            DatasetRef: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-        """
         _ = dataset_key
         return _ref()
 
     def query_records(self, dataset: DatasetRef, query: Query) -> RecordBatch:
-        """
-        query records 동작을 수행한다.
-
-        매개변수:
-            dataset (DatasetRef): 호출자가 제공하는 입력 값이다.
-            query (Query): 호출자가 제공하는 입력 값이다.
-
-        반환값:
-            RecordBatch: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-        """
         self.last_query = query
         if self.batches:
             return self.batches.pop(0)
         return RecordBatch(items=[{"k": "v"}], dataset=dataset)
 
     def get_schema(self, dataset: DatasetRef) -> SchemaDescriptor | None:
-        """
-        get schema 동작을 수행한다.
-
-        매개변수:
-            dataset (DatasetRef): 호출자가 제공하는 입력 값이다.
-
-        반환값:
-            SchemaDescriptor | None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-        """
         _ = dataset
         return None
 
     def call_raw(self, dataset: DatasetRef, operation: str, params: dict[str, object]) -> object:
-        """
-        call raw 동작을 수행한다.
-
-        매개변수:
-            dataset (DatasetRef): 호출자가 제공하는 입력 값이다.
-            operation (str): 호출자가 제공하는 입력 값이다.
-            params (dict[str, object]): 호출자가 제공하는 입력 값이다.
-
-        반환값:
-            object: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-        """
         _ = dataset, params
         self.last_raw_op = operation
         return {"raw": True}
 
 
 def _ref(ops: frozenset[Operation] | None = None) -> DatasetRef:
-    """
-    내부 헬퍼로서 ref 처리를 담당한다.
-
-    매개변수:
-        ops (frozenset[Operation] | None): 호출자가 제공하는 입력 값이다.
-
-    반환값:
-        DatasetRef: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-    예외:
-        구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-    """
     return DatasetRef(
         id="mock.test",
         provider="mock",
@@ -164,30 +62,9 @@ def _ref(ops: frozenset[Operation] | None = None) -> DatasetRef:
 
 
 class TestDataset:
-    """
-    TestDataset 관련 역할을 캡슐화하는 클래스.
+    """Tests for Dataset binding and capability checks."""
 
-    이 클래스는 ``tests/unit/core/test_dataset.py`` 모듈 안에서 TestDataset의 상태와 동작을 함께 관리한다.
-    주요 메서드: test_list, test_list_unsupported, test_list_all_unsupported, test_call_raw, test_repr.
-
-    속성 설명:
-        생성자와 클래스 본문에서 정의한 속성은 하위 메서드가 공통 문맥으로 재사용한다.
-    """
-
-    # test list 테스트가 검증하는 시나리오를 설명한다.
     def test_list(self) -> None:
-        """
-        test list 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         adapter = MockAdapter()
         ds = Dataset(ref=_ref(), adapter=adapter)
         result = ds.list(code="11680")
@@ -195,96 +72,31 @@ class TestDataset:
         assert adapter.last_query is not None
         assert adapter.last_query.filters["code"] == "11680"
 
-    # test list unsupported 테스트가 검증하는 시나리오를 설명한다.
     def test_list_unsupported(self) -> None:
-        """
-        test list unsupported 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         adapter = MockAdapter()
         ds = Dataset(ref=_ref(frozenset({Operation.RAW})), adapter=adapter)
         with pytest.raises(UnsupportedCapabilityError, match="list"):
             _ = ds.list()
 
-    # test list all unsupported 테스트가 검증하는 시나리오를 설명한다.
     def test_list_all_unsupported(self) -> None:
-        """
-        test list all unsupported 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         adapter = MockAdapter()
         ds = Dataset(ref=_ref(frozenset({Operation.RAW})), adapter=adapter)
         with pytest.raises(UnsupportedCapabilityError, match="list"):
             _ = list(ds.list_all())
 
-    # test call raw 테스트가 검증하는 시나리오를 설명한다.
     def test_call_raw(self) -> None:
-        """
-        test call raw 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         adapter = MockAdapter()
         ds = Dataset(ref=_ref(), adapter=adapter)
         result = ds.call_raw("list", param="value")
         assert result == {"raw": True}
         assert adapter.last_raw_op == "list"
 
-    # test repr 테스트가 검증하는 시나리오를 설명한다.
     def test_repr(self) -> None:
-        """
-        test repr 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         adapter = MockAdapter()
         ds = Dataset(ref=_ref(), adapter=adapter)
         assert "mock.test" in repr(ds)
 
-    # test list separates canonical query fields 테스트가 검증하는 시나리오를 설명한다.
     def test_list_separates_canonical_query_fields(self) -> None:
-        """
-        test list separates canonical query fields 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         adapter = MockAdapter()
         ds = Dataset(ref=_ref(), adapter=adapter)
 
@@ -303,20 +115,7 @@ class TestDataset:
         assert adapter.last_query.page_size == 50
         assert adapter.last_query.filters == {"region": "서울"}
 
-    # test list canonical fields not in filters 테스트가 검증하는 시나리오를 설명한다.
     def test_list_canonical_fields_not_in_filters(self) -> None:
-        """
-        test list canonical fields not in filters 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         adapter = MockAdapter()
         ds = Dataset(ref=_ref(), adapter=adapter)
 
@@ -328,20 +127,7 @@ class TestDataset:
         assert adapter.last_query.sort == ["name"]
         assert adapter.last_query.filters == {}
 
-    # test list only filters no canonical 테스트가 검증하는 시나리오를 설명한다.
     def test_list_only_filters_no_canonical(self) -> None:
-        """
-        test list only filters no canonical 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         adapter = MockAdapter()
         ds = Dataset(ref=_ref(), adapter=adapter)
 
@@ -352,20 +138,7 @@ class TestDataset:
         assert adapter.last_query.start_date is None
         assert adapter.last_query.filters == {"lawd_code": "11680", "deal_ym": "202503"}
 
-    # test list all yields multiple batches 테스트가 검증하는 시나리오를 설명한다.
     def test_list_all_yields_multiple_batches(self) -> None:
-        """
-        test list all yields multiple batches 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         adapter = MockAdapter()
         dataset_ref = _ref()
         adapter.batches = [
@@ -379,20 +152,7 @@ class TestDataset:
 
         assert [batch.items[0]["page"] for batch in batches] == [1, 2, 3]
 
-    # test list all stops when next page is none 테스트가 검증하는 시나리오를 설명한다.
     def test_list_all_stops_when_next_page_is_none(self) -> None:
-        """
-        test list all stops when next page is none 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         adapter = MockAdapter()
         dataset_ref = _ref()
         adapter.batches = [
@@ -408,20 +168,7 @@ class TestDataset:
         assert adapter.last_query.page == 2
         assert adapter.last_query.filters == {"code": "11680"}
 
-    # test list all single page 테스트가 검증하는 시나리오를 설명한다.
     def test_list_all_single_page(self) -> None:
-        """
-        test list all single page 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         adapter = MockAdapter()
         dataset_ref = _ref()
         adapter.batches = [RecordBatch(items=[{"page": 1}], dataset=dataset_ref, next_page=None)]
@@ -432,20 +179,7 @@ class TestDataset:
         assert len(batches) == 1
         assert batches[0].items == [{"page": 1}]
 
-    # test list all cursor pagination 테스트가 검증하는 시나리오를 설명한다.
     def test_list_all_cursor_pagination(self) -> None:
-        """
-        test list all cursor pagination 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         adapter = MockAdapter()
         dataset_ref = _ref()
         adapter.batches = [
@@ -463,20 +197,7 @@ class TestDataset:
         assert adapter.last_query.page is None
         assert adapter.last_query.filters == {"region": "서울"}
 
-    # test list all cursor single page 테스트가 검증하는 시나리오를 설명한다.
     def test_list_all_cursor_single_page(self) -> None:
-        """
-        test list all cursor single page 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         adapter = MockAdapter()
         dataset_ref = _ref()
         adapter.batches = [
@@ -488,3 +209,70 @@ class TestDataset:
 
         assert len(batches) == 1
         assert batches[0].items == [{"cursor": "a"}]
+
+
+class TestDatasetQueryValidation:
+    """Tests for Dataset.list() canonical query validation."""
+
+    @pytest.mark.parametrize(
+        "kwargs,expected_match",
+        [
+            ({"page": "1"}, "page"),
+            ({"page": 0}, "page"),
+            ({"page": -1}, "page"),
+            ({"page_size": 0}, "page_size"),
+            ({"page_size": -1}, "page_size"),
+            ({"cursor": 123}, "cursor"),
+            ({"cursor": ""}, "cursor"),
+            ({"start_date": 20240101}, "start_date"),
+            ({"start_date": ""}, "start_date"),
+            ({"start_date": "   "}, "start_date"),
+            ({"end_date": 20240101}, "end_date"),
+            ({"end_date": ""}, "end_date"),
+            ({"fields": "name"}, "fields"),
+            ({"sort": "date"}, "sort"),
+        ],
+    )
+    def test_invalid_canonical_params_rejected(self, kwargs: dict, expected_match: str) -> None:
+        """Invalid canonical parameters raise InvalidRequestError before adapter call."""
+        adapter = MockAdapter()
+        ds = Dataset(ref=_ref(), adapter=adapter)
+
+        with pytest.raises(InvalidRequestError, match=expected_match):
+            ds.list(**kwargs)
+
+        assert adapter.last_query is None
+
+    def test_valid_query_passes_through(self) -> None:
+        """Valid canonical query reaches adapter with correct fields."""
+        adapter = MockAdapter()
+        ds = Dataset(ref=_ref(), adapter=adapter)
+
+        result = ds.list(
+            page=1,
+            page_size=100,
+            start_date="202401",
+            end_date="202412",
+            fields=["name"],
+            sort=["date"],
+        )
+
+        assert adapter.last_query is not None
+        assert adapter.last_query.page == 1
+        assert adapter.last_query.page_size == 100
+        assert adapter.last_query.start_date == "202401"
+        assert adapter.last_query.end_date == "202412"
+        assert adapter.last_query.fields == ["name"]
+        assert adapter.last_query.sort == ["date"]
+        assert len(result) == 1
+
+    def test_provider_specific_filter_passes_through(self) -> None:
+        """Provider-specific filters are passed through unchanged."""
+        adapter = MockAdapter()
+        ds = Dataset(ref=_ref(), adapter=adapter)
+
+        result = ds.list(region="11", custom_param="value")
+
+        assert adapter.last_query is not None
+        assert adapter.last_query.filters == {"region": "11", "custom_param": "value"}
+        assert len(result) == 1

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -14,128 +14,40 @@ from kpubdata.core.models import (
     SchemaDescriptor,
 )
 from kpubdata.core.representation import Representation
+from kpubdata.exceptions import InvalidRequestError
 
 
 class TestOperation:
-    """
-    TestOperation 관련 역할을 캡슐화하는 클래스.
+    """Tests for Operation enum."""
 
-    이 클래스는 ``tests/unit/core/test_models.py`` 모듈 안에서 TestOperation의 상태와 동작을 함께 관리한다.
-    주요 메서드: test_values, test_str_mixin.
-
-    속성 설명:
-        생성자와 클래스 본문에서 정의한 속성은 하위 메서드가 공통 문맥으로 재사용한다.
-    """
-
-    # test values 테스트가 검증하는 시나리오를 설명한다.
     def test_values(self) -> None:
-        """
-        test values 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         assert Operation.LIST.value == "list"
         assert Operation.GET.value == "get"
         assert Operation.RAW.value == "raw"
 
-    # test str mixin 테스트가 검증하는 시나리오를 설명한다.
     def test_str_mixin(self) -> None:
-        """
-        test str mixin 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         assert str(Operation.LIST) == "Operation.LIST" or "list" in str(Operation.LIST)
 
 
 class TestRepresentation:
-    """
-    TestRepresentation 관련 역할을 캡슐화하는 클래스.
+    """Tests for Representation enum."""
 
-    이 클래스는 ``tests/unit/core/test_models.py`` 모듈 안에서 TestRepresentation의 상태와 동작을 함께 관리한다.
-    주요 메서드: test_values.
-
-    속성 설명:
-        생성자와 클래스 본문에서 정의한 속성은 하위 메서드가 공통 문맥으로 재사용한다.
-    """
-
-    # test values 테스트가 검증하는 시나리오를 설명한다.
     def test_values(self) -> None:
-        """
-        test values 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         assert Representation.API_JSON.value == "api_json"
         assert Representation.API_XML.value == "api_xml"
 
 
 class TestQuerySupport:
-    """
-    TestQuerySupport 관련 역할을 캡슐화하는 클래스.
+    """Tests for QuerySupport dataclass."""
 
-    이 클래스는 ``tests/unit/core/test_models.py`` 모듈 안에서 TestQuerySupport의 상태와 동작을 함께 관리한다.
-    주요 메서드: test_defaults, test_frozen.
-
-    속성 설명:
-        생성자와 클래스 본문에서 정의한 속성은 하위 메서드가 공통 문맥으로 재사용한다.
-    """
-
-    # test defaults 테스트가 검증하는 시나리오를 설명한다.
     def test_defaults(self) -> None:
-        """
-        test defaults 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         qs = QuerySupport()
         assert qs.pagination == PaginationMode.NONE
         assert qs.filterable_fields == frozenset()
         assert qs.time_range is False
         assert qs.max_page_size is None
 
-    # test frozen 테스트가 검증하는 시나리오를 설명한다.
     def test_frozen(self) -> None:
-        """
-        test frozen 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         qs = QuerySupport(pagination=PaginationMode.OFFSET)
         try:
             qs.pagination = PaginationMode.CURSOR  # type: ignore[misc]
@@ -145,29 +57,9 @@ class TestQuerySupport:
 
 
 class TestDatasetRef:
-    """
-    TestDatasetRef 관련 역할을 캡슐화하는 클래스.
-
-    이 클래스는 ``tests/unit/core/test_models.py`` 모듈 안에서 TestDatasetRef의 상태와 동작을 함께 관리한다.
-    주요 메서드: _make_ref, test_supports, test_frozen, test_raw_metadata_immutable, test_repr.
-
-    속성 설명:
-        생성자와 클래스 본문에서 정의한 속성은 하위 메서드가 공통 문맥으로 재사용한다.
-    """
+    """Tests for DatasetRef dataclass."""
 
     def _make_ref(self, **kwargs: object) -> DatasetRef:
-        """
-        내부 헬퍼로서 make ref 처리를 담당한다.
-
-        매개변수:
-            **kwargs (object): 호출자가 제공하는 입력 값이다.
-
-        반환값:
-            DatasetRef: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-        """
         defaults: dict[str, object] = {
             "id": "test.dataset",
             "provider": "test",
@@ -179,38 +71,12 @@ class TestDatasetRef:
         defaults.update(kwargs)
         return DatasetRef(**defaults)  # type: ignore[arg-type]
 
-    # test supports 테스트가 검증하는 시나리오를 설명한다.
     def test_supports(self) -> None:
-        """
-        test supports 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         ref = self._make_ref()
         assert ref.supports(Operation.LIST) is True
         assert ref.supports(Operation.GET) is False
 
-    # test frozen 테스트가 검증하는 시나리오를 설명한다.
     def test_frozen(self) -> None:
-        """
-        test frozen 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         ref = self._make_ref()
         try:
             ref.id = "changed"  # type: ignore[misc]
@@ -218,75 +84,23 @@ class TestDatasetRef:
         except AttributeError:
             pass
 
-    # test raw metadata immutable 테스트가 검증하는 시나리오를 설명한다.
     def test_raw_metadata_immutable(self) -> None:
-        """
-        test raw metadata immutable 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         ref = self._make_ref()
         assert isinstance(ref.raw_metadata, MappingProxyType)
 
-    # test repr 테스트가 검증하는 시나리오를 설명한다.
     def test_repr(self) -> None:
-        """
-        test repr 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         ref = self._make_ref()
         r = repr(ref)
         assert "test.dataset" in r
         assert "test" in r
 
-    # test metadata defaults 테스트가 검증하는 시나리오를 설명한다.
     def test_metadata_defaults(self) -> None:
-        """
-        test metadata defaults 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         ref = self._make_ref()
         assert ref.description is None
         assert ref.tags == ()
         assert ref.source_url is None
 
-    # test metadata populated 테스트가 검증하는 시나리오를 설명한다.
     def test_metadata_populated(self) -> None:
-        """
-        test metadata populated 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         ref = self._make_ref(
             description="Weather forecast data",
             tags=("weather", "forecast"),
@@ -296,20 +110,7 @@ class TestDatasetRef:
         assert ref.tags == ("weather", "forecast")
         assert ref.source_url == "https://data.go.kr/example"
 
-    # test metadata frozen 테스트가 검증하는 시나리오를 설명한다.
     def test_metadata_frozen(self) -> None:
-        """
-        test metadata frozen 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         ref = self._make_ref(description="test", tags=("a",), source_url="http://x")
         try:
             ref.description = "changed"  # type: ignore[misc]
@@ -324,75 +125,330 @@ class TestDatasetRef:
 
 
 class TestQuery:
-    """
-    TestQuery 관련 역할을 캡슐화하는 클래스.
+    """Tests for Query dataclass."""
 
-    이 클래스는 ``tests/unit/core/test_models.py`` 모듈 안에서 TestQuery의 상태와 동작을 함께 관리한다.
-    주요 메서드: test_defaults, test_with_filters.
-
-    속성 설명:
-        생성자와 클래스 본문에서 정의한 속성은 하위 메서드가 공통 문맥으로 재사용한다.
-    """
-
-    # test defaults 테스트가 검증하는 시나리오를 설명한다.
     def test_defaults(self) -> None:
-        """
-        test defaults 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         q = Query()
         assert q.filters == {}
         assert q.page is None
         assert q.extra == {}
 
-    # test with filters 테스트가 검증하는 시나리오를 설명한다.
     def test_with_filters(self) -> None:
-        """
-        test with filters 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         q = Query(filters={"key": "value"}, page=1, page_size=10)
         assert q.filters["key"] == "value"
         assert q.page == 1
 
+    def test_all_fields_valid(self) -> None:
+        q = Query(
+            filters={"region": "11"},
+            page=1,
+            page_size=100,
+            cursor="next-token",
+            start_date="202401",
+            end_date="202412",
+            fields=["name", "date"],
+            sort=["date"],
+            extra={"provider_option": True},
+        )
+        assert q.filters == {"region": "11"}
+        assert q.page == 1
+        assert q.page_size == 100
+        assert q.cursor == "next-token"
+        assert q.start_date == "202401"
+        assert q.end_date == "202412"
+        assert q.fields == ["name", "date"]
+        assert q.sort == ["date"]
+        assert q.extra == {"provider_option": True}
+
+
+class TestQueryPageValidation:
+    """Tests for Query page field validation."""
+
+    def test_valid(self) -> None:
+        q = Query(page=1)
+        assert q.page == 1
+
+    def test_none_allowed(self) -> None:
+        q = Query(page=None)
+        assert q.page is None
+
+    def test_zero_rejected(self) -> None:
+        try:
+            Query(page=0)
+            raise AssertionError("page=0 should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "page must be a positive integer" in str(e)
+
+    def test_negative_rejected(self) -> None:
+        try:
+            Query(page=-1)
+            raise AssertionError("page=-1 should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "page must be a positive integer" in str(e)
+
+    def test_bool_rejected(self) -> None:
+        try:
+            Query(page=True)
+            raise AssertionError("page=True should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "page must be an integer, not bool" in str(e)
+
+    def test_string_rejected(self) -> None:
+        try:
+            Query(page="1")
+            raise AssertionError("page='1' should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "page must be an integer or None" in str(e)
+
+
+class TestQueryPageSizeValidation:
+    """Tests for Query page_size field validation."""
+
+    def test_valid(self) -> None:
+        q = Query(page_size=1)
+        assert q.page_size == 1
+
+    def test_none_allowed(self) -> None:
+        q = Query(page_size=None)
+        assert q.page_size is None
+
+    def test_zero_rejected(self) -> None:
+        try:
+            Query(page_size=0)
+            raise AssertionError("page_size=0 should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "page_size must be a positive integer" in str(e)
+
+    def test_negative_rejected(self) -> None:
+        try:
+            Query(page_size=-1)
+            raise AssertionError("page_size=-1 should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "page_size must be a positive integer" in str(e)
+
+    def test_bool_rejected(self) -> None:
+        try:
+            Query(page_size=True)
+            raise AssertionError("page_size=True should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "page_size must be an integer, not bool" in str(e)
+
+    def test_float_rejected(self) -> None:
+        try:
+            Query(page_size=1.5)
+            raise AssertionError("page_size=1.5 should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "page_size must be an integer or None" in str(e)
+
+    def test_string_rejected(self) -> None:
+        try:
+            Query(page_size="100")
+            raise AssertionError("page_size='100' should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "page_size must be an integer or None" in str(e)
+
+
+class TestQueryCursorValidation:
+    """Tests for Query cursor field validation."""
+
+    def test_valid(self) -> None:
+        q = Query(cursor="abc")
+        assert q.cursor == "abc"
+
+    def test_none_allowed(self) -> None:
+        q = Query(cursor=None)
+        assert q.cursor is None
+
+    def test_int_rejected(self) -> None:
+        try:
+            Query(cursor=123)
+            raise AssertionError("cursor=123 should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "cursor must be a string or None" in str(e)
+
+    def test_list_rejected(self) -> None:
+        try:
+            Query(cursor=[])
+            raise AssertionError("cursor=[] should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "cursor must be a string or None" in str(e)
+
+    def test_empty_string_rejected(self) -> None:
+        try:
+            Query(cursor="")
+            raise AssertionError("cursor='' should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "cursor must be a non-empty string" in str(e)
+
+
+class TestQueryDateValidation:
+    """Tests for Query date field validation."""
+
+    def test_valid_yyyymm_format(self) -> None:
+        q = Query(start_date="202401", end_date="202412")
+        assert q.start_date == "202401"
+        assert q.end_date == "202412"
+
+    def test_valid_yyyymmdd_format(self) -> None:
+        q = Query(start_date="20240102", end_date="20240108")
+        assert q.start_date == "20240102"
+        assert q.end_date == "20240108"
+
+    def test_none_allowed(self) -> None:
+        q = Query(start_date=None, end_date=None)
+        assert q.start_date is None
+        assert q.end_date is None
+
+    def test_int_rejected(self) -> None:
+        try:
+            Query(start_date=202401)
+            raise AssertionError("start_date=202401 should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "start_date must be a string or None" in str(e)
+
+    def test_list_rejected(self) -> None:
+        try:
+            Query(end_date=[])
+            raise AssertionError("end_date=[] should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "end_date must be a string or None" in str(e)
+
+    def test_empty_string_rejected(self) -> None:
+        try:
+            Query(start_date="")
+            raise AssertionError("start_date='' should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "start_date must be a non-empty string" in str(e)
+
+    def test_whitespace_rejected(self) -> None:
+        try:
+            Query(start_date="   ")
+            raise AssertionError("start_date='   ' should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "start_date must be a non-empty string" in str(e)
+
+
+class TestQueryFieldsValidation:
+    """Tests for Query fields field validation."""
+
+    def test_valid(self) -> None:
+        q = Query(fields=["a", "b"])
+        assert q.fields == ["a", "b"]
+
+    def test_empty_list(self) -> None:
+        q = Query(fields=[])
+        assert q.fields == []
+
+    def test_none_allowed(self) -> None:
+        q = Query(fields=None)
+        assert q.fields is None
+
+    def test_string_rejected(self) -> None:
+        try:
+            Query(fields="a")
+            raise AssertionError("fields='a' should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "fields must be a list of strings or None" in str(e)
+
+    def test_tuple_rejected(self) -> None:
+        try:
+            Query(fields=("a", "b"))
+            raise AssertionError("fields=('a', 'b') should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "fields must be a list of strings or None" in str(e)
+
+    def test_non_string_element_rejected(self) -> None:
+        try:
+            Query(fields=["a", 1])
+            raise AssertionError("fields=['a', 1] should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "fields must contain only strings" in str(e)
+            assert "at index 1" in str(e)
+
+
+class TestQuerySortValidation:
+    """Tests for Query sort field validation."""
+
+    def test_valid(self) -> None:
+        q = Query(sort=["date", "name"])
+        assert q.sort == ["date", "name"]
+
+    def test_empty_list(self) -> None:
+        q = Query(sort=[])
+        assert q.sort == []
+
+    def test_none_allowed(self) -> None:
+        q = Query(sort=None)
+        assert q.sort is None
+
+    def test_non_string_element_rejected(self) -> None:
+        try:
+            Query(sort=["date", None])
+            raise AssertionError("sort=['date', None] should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "sort must contain only strings" in str(e)
+
+
+class TestQueryFiltersValidation:
+    """Tests for Query filters field validation."""
+
+    def test_valid(self) -> None:
+        q = Query(filters={"a": 1})
+        assert q.filters == {"a": 1}
+
+    def test_empty_dict(self) -> None:
+        q = Query(filters={})
+        assert q.filters == {}
+
+    def test_nested_dict(self) -> None:
+        q = Query(filters={"a": {"nested": True}})
+        assert q.filters == {"a": {"nested": True}}
+
+    def test_list_rejected(self) -> None:
+        try:
+            Query(filters=[])
+            raise AssertionError("filters=[] should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "filters must be a dict" in str(e)
+
+    def test_non_string_key_rejected(self) -> None:
+        try:
+            Query(filters={1: "value"})
+            raise AssertionError("filters={1: 'value'} should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "filters keys must be strings" in str(e)
+
+
+class TestQueryExtraValidation:
+    """Tests for Query extra field validation."""
+
+    def test_valid(self) -> None:
+        q = Query(extra={"option": True})
+        assert q.extra == {"option": True}
+
+    def test_empty_dict(self) -> None:
+        q = Query(extra={})
+        assert q.extra == {}
+
+    def test_list_rejected(self) -> None:
+        try:
+            Query(extra=[])
+            raise AssertionError("extra=[] should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "extra must be a dict" in str(e)
+
+    def test_non_string_key_rejected(self) -> None:
+        try:
+            Query(extra={1: "value"})
+            raise AssertionError("extra={1: 'value'} should raise InvalidRequestError")
+        except InvalidRequestError as e:
+            assert "extra keys must be strings" in str(e)
+
 
 class TestRecordBatch:
-    """
-    TestRecordBatch 관련 역할을 캡슐화하는 클래스.
-
-    이 클래스는 ``tests/unit/core/test_models.py`` 모듈 안에서 TestRecordBatch의 상태와 동작을 함께 관리한다.
-    주요 메서드: _make_ref, test_len, test_iter, test_bool_empty, test_bool_nonempty.
-
-    속성 설명:
-        생성자와 클래스 본문에서 정의한 속성은 하위 메서드가 공통 문맥으로 재사용한다.
-    """
+    """Tests for RecordBatch dataclass."""
 
     def _make_ref(self) -> DatasetRef:
-        """
-        내부 헬퍼로서 make ref 처리를 담당한다.
-
-        반환값:
-            DatasetRef: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-        """
         return DatasetRef(
             id="test.ds",
             provider="test",
@@ -401,101 +457,28 @@ class TestRecordBatch:
             representation=Representation.API_JSON,
         )
 
-    # test len 테스트가 검증하는 시나리오를 설명한다.
     def test_len(self) -> None:
-        """
-        test len 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         batch = RecordBatch(items=[{"a": 1}, {"a": 2}], dataset=self._make_ref())
         assert len(batch) == 2
 
-    # test iter 테스트가 검증하는 시나리오를 설명한다.
     def test_iter(self) -> None:
-        """
-        test iter 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         items = [{"a": 1}, {"a": 2}]
         batch = RecordBatch(items=items, dataset=self._make_ref())
         assert list(batch) == items
 
-    # test bool empty 테스트가 검증하는 시나리오를 설명한다.
     def test_bool_empty(self) -> None:
-        """
-        test bool empty 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         batch = RecordBatch(items=[], dataset=self._make_ref())
         assert not batch
 
-    # test bool nonempty 테스트가 검증하는 시나리오를 설명한다.
     def test_bool_nonempty(self) -> None:
-        """
-        test bool nonempty 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         batch = RecordBatch(items=[{"a": 1}], dataset=self._make_ref())
         assert batch
 
 
 class TestSchemaDescriptor:
-    """
-    TestSchemaDescriptor 관련 역할을 캡슐화하는 클래스.
+    """Tests for SchemaDescriptor dataclass."""
 
-    이 클래스는 ``tests/unit/core/test_models.py`` 모듈 안에서 TestSchemaDescriptor의 상태와 동작을 함께 관리한다.
-    주요 메서드: test_fields.
-
-    속성 설명:
-        생성자와 클래스 본문에서 정의한 속성은 하위 메서드가 공통 문맥으로 재사용한다.
-    """
-
-    # test fields 테스트가 검증하는 시나리오를 설명한다.
     def test_fields(self) -> None:
-        """
-        test fields 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         ref = DatasetRef(
             id="t.d",
             provider="t",
@@ -510,30 +493,9 @@ class TestSchemaDescriptor:
 
 
 class TestFieldConstraints:
-    """
-    TestFieldConstraints 관련 역할을 캡슐화하는 클래스.
+    """Tests for FieldConstraints dataclass."""
 
-    이 클래스는 ``tests/unit/core/test_models.py`` 모듈 안에서 TestFieldConstraints의 상태와 동작을 함께 관리한다.
-    주요 메서드: test_all_defaults_none, test_populated, test_single_field, test_partial_population.
-
-    속성 설명:
-        생성자와 클래스 본문에서 정의한 속성은 하위 메서드가 공통 문맥으로 재사용한다.
-    """
-
-    # test all defaults none 테스트가 검증하는 시나리오를 설명한다.
     def test_all_defaults_none(self) -> None:
-        """
-        test all defaults none 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         fc = FieldConstraints()
         assert fc.max_length is None
         assert fc.min_value is None
@@ -542,20 +504,7 @@ class TestFieldConstraints:
         assert fc.allowed_values is None
         assert fc.format is None
 
-    # test populated 테스트가 검증하는 시나리오를 설명한다.
     def test_populated(self) -> None:
-        """
-        test populated 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         fc = FieldConstraints(
             max_length=100,
             min_value=0,
@@ -571,37 +520,11 @@ class TestFieldConstraints:
         assert fc.allowed_values == ("A", "B", "C")
         assert fc.format == "YYYYMM"
 
-    # test single field 테스트가 검증하는 시나리오를 설명한다.
     def test_single_field(self) -> None:
-        """
-        test single field 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         fc = FieldConstraints(max_length=10)
         assert fc.max_length == 10
 
-    # test partial population 테스트가 검증하는 시나리오를 설명한다.
     def test_partial_population(self) -> None:
-        """
-        test partial population 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         fc = FieldConstraints(format="date", allowed_values=("yes", "no"))
         assert fc.max_length is None
         assert fc.format == "date"
@@ -609,67 +532,20 @@ class TestFieldConstraints:
 
 
 class TestFieldDescriptorConstraints:
-    """
-    TestFieldDescriptorConstraints 관련 역할을 캡슐화하는 클래스.
+    """Tests for FieldDescriptor with constraints."""
 
-    이 클래스는 ``tests/unit/core/test_models.py`` 모듈 안에서 TestFieldDescriptorConstraints의 상태와 동작을 함께 관리한다.
-    주요 메서드: test_default_constraints_none, test_with_constraints, test_positional_raw_backward_compat.
-
-    속성 설명:
-        생성자와 클래스 본문에서 정의한 속성은 하위 메서드가 공통 문맥으로 재사용한다.
-    """
-
-    # test default constraints none 테스트가 검증하는 시나리오를 설명한다.
     def test_default_constraints_none(self) -> None:
-        """
-        test default constraints none 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         fd = FieldDescriptor(name="col")
         assert fd.constraints is None
 
-    # test with constraints 테스트가 검증하는 시나리오를 설명한다.
     def test_with_constraints(self) -> None:
-        """
-        test with constraints 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         fc = FieldConstraints(max_length=50, format="YYYYMM")
         fd = FieldDescriptor(name="date_col", type="string", constraints=fc)
         assert fd.constraints is not None
         assert fd.constraints.max_length == 50
         assert fd.constraints.format == "YYYYMM"
 
-    # test positional raw backward compat 테스트가 검증하는 시나리오를 설명한다.
     def test_positional_raw_backward_compat(self) -> None:
-        """
-        test positional raw backward compat 시나리오를 검증한다.
-
-        반환값:
-            None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
-
-        예외:
-            구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
-
-        예시:
-            테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
-        """
         proxy = MappingProxyType({"k": "v"})
         fd = FieldDescriptor("col", "Title", "string", "desc", True, proxy)
         assert fd.name == "col"


### PR DESCRIPTION
## 개요

Closes #264

잘못된 canonical Query 입력이 Provider adapter까지 전달되는 문제를 수정합니다.

## 주요 변경사항

* `Query.__post_init__`에 canonical 입력 검증 추가
* 검증 실패 시 `InvalidRequestError` 발생
* `page`, `page_size`의 타입 및 양수 범위 검증
* `cursor`, `start_date`, `end_date`의 타입 및 빈 문자열 검증
* `fields`, `sort`의 컨테이너 및 요소 타입 검증
* `filters`, `extra`의 매핑 타입 및 문자열 키 검증
* `Dataset.list()`에서 canonical 인자를 값의 타입이 아닌 키 이름 기준으로 분리
* `_build_query()` helper로 Query 생성 책임 캡슐화
* Provider별 필수 파라미터, 날짜 형식, 최대 페이지 크기 검증은 adapter 책임으로 유지
* `API_SPEC.md`, `CANONICAL_MODEL.md`, `CHANGELOG.md` 갱신

## 동작 예시

기존에는 잘못된 canonical 인자가 Provider-specific filter로 전달될 수 있었습니다.

```python
dataset.list(page="1")
```

이제 Provider 호출 전에 canonical Query 검증이 수행되어 명확한 예외가 발생합니다.

```text
InvalidRequestError: page must be an integer or None, got str
```

## 검증

* [x] `ruff check .`
* [x] `ruff format --check .`
* [x] `mypy src`
* [x] `pytest` — 1078 passed, 98 deselected
* [x] `python -m build`
* [x] `mkdocs build --strict`
* [x] `uv lock --check`
* [x] `git diff --check`
