### PR TITLE
chore: registry.py 타입 정리 및 중복 ssl import 제거 (#278, #280 salvage)

### DIFF
--- a/src/kpubdata/catalog.py
+++ b/src/kpubdata/catalog.py
@@ -8,7 +8,6 @@ import re
 import unicodedata
 from dataclasses import dataclass
 from difflib import SequenceMatcher
-from typing import cast
 
 from kpubdata.core.models import DatasetRef
 from kpubdata.core.protocol import ProviderAdapter
@@ -282,7 +281,7 @@ class Catalog:
     def _get_adapter(self, provider: str) -> ProviderAdapter:
         """레지스트리에서 Provider 어댑터를 가져오거나 정규 예외를 발생시킨다."""
 
-        return cast(ProviderAdapter, self._registry.get(provider))
+        return self._registry.get(provider)
 
     @staticmethod
     def _split_dataset_id(dataset_id: str) -> tuple[str, str]:

--- a/src/kpubdata/client.py
+++ b/src/kpubdata/client.py
@@ -156,13 +156,13 @@ class Client:
             "Registering external provider adapter",
             extra={"adapter_type": type(adapter).__name__},
         )
-        self._registry.register(adapter)
+        self._registry.register(cast(ProviderAdapter, adapter))
 
     def iter_authenticated_providers(self) -> tuple[ProviderAdapter, ...]:
         """API 키가 필요한 Provider 어댑터만 모아 튜플로 반환한다."""
         providers: list[ProviderAdapter] = []
         for provider_name in self._registry:
-            adapter = cast(ProviderAdapter, self._registry.get(provider_name))
+            adapter = self._registry.get(provider_name)
             if _requires_api_key(adapter):
                 providers.append(adapter)
         return tuple(providers)

--- a/src/kpubdata/registry.py
+++ b/src/kpubdata/registry.py
@@ -7,11 +7,11 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from threading import RLock
-from typing import Any
 
 from kpubdata.core.models import DatasetRef
+from kpubdata.core.protocol import ProviderAdapter
 from kpubdata.exceptions import CapabilityContractError, ProviderNotRegisteredError
 
 logger = logging.getLogger("kpubdata.registry")
@@ -31,8 +31,8 @@ class ProviderRegistry:
 
     def __init__(self) -> None:
         """비어 있는 eager/lazy 어댑터 레지스트리를 초기화한다."""
-        self._adapters: dict[str, Any] = {}
-        self._lazy: dict[str, Any] = {}
+        self._adapters: dict[str, ProviderAdapter] = {}
+        self._lazy: dict[str, Callable[[], ProviderAdapter]] = {}
         self._lock = RLock()
 
     def __repr__(self) -> str:
@@ -42,7 +42,7 @@ class ProviderRegistry:
             lazy_names = sorted(self._lazy.keys())
         return f"ProviderRegistry(eager={eager_names}, lazy={lazy_names})"
 
-    def register(self, adapter: Any, *, validate_capabilities: bool = True) -> None:
+    def register(self, adapter: ProviderAdapter, *, validate_capabilities: bool = True) -> None:
         """어댑터 인스턴스를 등록한다. 프로토콜 준수 여부를 검증한다.
 
         ``validate_capabilities=True``(기본값)이면 등록 시점에 ``list_datasets()``를
@@ -74,7 +74,9 @@ class ProviderRegistry:
             extra={"provider": provider_name, "adapter_type": type(adapter).__name__},
         )
 
-    def register_lazy(self, name: str, factory: Any, *, skip_if_exists: bool = False) -> None:
+    def register_lazy(
+        self, name: str, factory: Callable[[], ProviderAdapter], *, skip_if_exists: bool = False
+    ) -> None:
         """호출 가능한 팩토리를 통해 지연 로딩 어댑터를 등록한다.
 
         ``skip_if_exists``가 True이면 Provider 이름이 이미 등록된 경우(eager 또는 lazy)
@@ -104,7 +106,7 @@ class ProviderRegistry:
             extra={"provider": normalized_name},
         )
 
-    def get(self, name: str) -> Any:
+    def get(self, name: str) -> ProviderAdapter:
         """Provider 이름으로 어댑터를 가져온다."""
         normalized_name = name.strip().lower()
         with self._lock:
@@ -155,7 +157,7 @@ class ProviderRegistry:
         return iter(sorted(names))
 
     @staticmethod
-    def _validate_adapter(adapter: Any) -> None:
+    def _validate_adapter(adapter: ProviderAdapter) -> None:
         """어댑터가 필요한 프로토콜 메서드를 갖는지 확인한다."""
         name = getattr(adapter, "name", None)
         if not isinstance(name, str) or not name.strip():
@@ -177,7 +179,7 @@ class ProviderRegistry:
             raise TypeError(f"Adapter '{name}' has non-callable required methods: {non_callable}")
 
     @staticmethod
-    def _validate_capability_contract(adapter: Any) -> None:
+    def _validate_capability_contract(adapter: ProviderAdapter) -> None:
         """어댑터의 catalogue가 정직한 capability 선언을 하는지 fail-fast로 검증한다.
 
         ``list_datasets()`` 호출 자체가 실패하면 catalogue 로딩이 깨진 상태이므로

--- a/src/kpubdata/transport/http.py
+++ b/src/kpubdata/transport/http.py
@@ -16,16 +16,13 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 import httpx
 from typing_extensions import override
 
 from kpubdata.exceptions import TransportError, TransportTimeoutError
 from kpubdata.transport.cache import ResponseCache, make_cache_key
-
-if TYPE_CHECKING:
-    import ssl
 
 logger = logging.getLogger("kpubdata.transport")
 _SENSITIVE_PARAM_KEYS = {


### PR DESCRIPTION
## 배경

@Launa-0 님이 올려주신 스택형 PR #323, #326에서 **실제로 유효한 수정만** 추려 현재 main 기준으로 깔끔히 재적용했습니다.

원본 PR들(#323–#327)은 브랜치가 서로 겹겹이 쌓여(stacked) 이미 main에 반영된 변경(park_info 데이터셋, KPUBDATA_CACHE_TTL 에러 처리, AGENTS.md 구조 업데이트)을 중복 포함하고 있어 그대로 머지할 수 없었습니다. 이 PR은 그중 아직 필요하고 검증을 통과하는 두 가지만 담습니다.

## 변경 내용

- **`registry.py` (#280)**: `typing.Any`를 제거하고 `ProviderAdapter` / `Callable[[], ProviderAdapter]`로 어댑터 저장소와 공개 메서드 시그니처의 타입을 명확히 했습니다.
- **`transport/http.py` (#278)**: 중복된 `if TYPE_CHECKING: import ssl` 블록을 제거했습니다. `ssl`은 모듈 상단에서 무조건 import되어 런타임에 사용되므로 해당 블록은 불필요했습니다.

## 검증

- `ruff check` / `ruff format --check` 통과
- `mypy` 통과
- 유닛 테스트 863 passed

## 크레딧

원 기여자 @Launa-0 님을 커밋 `Co-authored-by`로 명시했습니다.

## 참고

- #276 (config.py `from_env`의 `Any` 제거)은 이 PR에서 제외했습니다. `**overrides`를 `KPubDataConfig(...)` 생성자로 그대로 전달하기 때문에 `object`로 바꾸면 mypy가 실패합니다. 별도로 `TypedDict`/`Unpack` 기반의 적절한 타이핑이 필요합니다 (추적 이슈 참고).