### PR TITLE
fix: HTTP 로그/예외 메시지에서 API 키 노출 방지 (#260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- HTTP 전송 계층 로그/예외 메시지에서 API 키가 포함된 query parameter가 `[REDACTED]`로 마스킹되도록 수정 (#260)
 - Canonical Query validation now prevents invalid canonical query values from reaching provider adapters (#264)
 - `Dataset.list()` now validates canonical query parameters (`page`, `page_size`, `cursor`, `start_date`, `end_date`, `fields`, `sort`) before adapter invocation
 - Canonical keys are now routed by name (not by type) to prevent bypass via type mismatch (e.g., `dataset.list(page="1")` now raises `InvalidRequestError` instead of falling through to filters)

--- a/src/kpubdata/transport/http.py
+++ b/src/kpubdata/transport/http.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from typing import cast
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import httpx
 from typing_extensions import override
@@ -205,13 +206,16 @@ class HttpTransport:
         # 메서드/URL/헤더 조합이 안전할 때만 캐시 키를 만들고 GET 응답을 재사용한다.
         cache_key = self._make_cache_key(method=method, url=url, params=params, headers=headers)
         request_context = _request_context(dataset_id=dataset_id, provider=provider)
+        # 로그/예외에는 API 키가 query parameter로 포함될 수 있는 원본 URL 대신
+        # 민감 파라미터를 가린 URL만 사용한다.
+        log_url = _mask_url(url)
         if cache_key is not None and self._cache is not None:
             cached_body = self._cache.get(cache_key)
             if cached_body is not None:
                 logger.debug(
                     "transport cache hit",
                     extra={
-                        "url": url,
+                        "url": log_url,
                         "cache_key": cache_key,
                         **request_context,
                     },
@@ -229,7 +233,7 @@ class HttpTransport:
                     "HTTP request start",
                     extra={
                         "method": method,
-                        "url": url,
+                        "url": log_url,
                         "attempt": attempt,
                         "max_retries": self._config.max_retries,
                         **request_context,
@@ -241,7 +245,7 @@ class HttpTransport:
                         "HTTP request params",
                         extra={
                             "method": method,
-                            "url": url,
+                            "url": log_url,
                             "params": _sanitize_params(params),
                             **request_context,
                         },
@@ -261,7 +265,7 @@ class HttpTransport:
                     "HTTP request success",
                     extra={
                         "method": method,
-                        "url": url,
+                        "url": log_url,
                         "status_code": response.status_code,
                         "attempt": attempt,
                         **request_context,
@@ -289,7 +293,7 @@ class HttpTransport:
                     logger.debug(
                         "transport cache miss; stored",
                         extra={
-                            "url": url,
+                            "url": log_url,
                             "cache_key": cache_key,
                             **request_context,
                         },
@@ -301,7 +305,7 @@ class HttpTransport:
                     "HTTP request timeout",
                     extra={
                         "method": method,
-                        "url": url,
+                        "url": log_url,
                         "attempt": attempt,
                         "exception_type": type(exc).__name__,
                         **request_context,
@@ -309,7 +313,7 @@ class HttpTransport:
                 )
                 if attempt >= total_attempts:
                     raise TransportTimeoutError(
-                        f"Request timed out after {attempt} attempts: {method} {url}"
+                        f"Request timed out after {attempt} attempts: {method} {log_url}"
                     ) from exc
 
             except httpx.HTTPStatusError as exc:
@@ -318,7 +322,7 @@ class HttpTransport:
                     "HTTP status error",
                     extra={
                         "method": method,
-                        "url": url,
+                        "url": log_url,
                         "attempt": attempt,
                         "status_code": status_code,
                         **request_context,
@@ -326,7 +330,7 @@ class HttpTransport:
                 )
                 if not _is_retryable_status(status_code) or attempt >= total_attempts:
                     raise TransportError(
-                        f"HTTP status error {status_code} for {method} {url}"
+                        f"HTTP status error {status_code} for {method} {log_url}"
                     ) from exc
 
                 retry_after = cast(str | None, exc.response.headers.get("Retry-After"))
@@ -338,7 +342,7 @@ class HttpTransport:
                     "HTTP request error",
                     extra={
                         "method": method,
-                        "url": url,
+                        "url": log_url,
                         "attempt": attempt,
                         "exception_type": type(exc).__name__,
                         **request_context,
@@ -346,7 +350,7 @@ class HttpTransport:
                 )
                 if attempt >= total_attempts:
                     raise TransportError(
-                        f"Request failed after {attempt} attempts: {method} {url}"
+                        f"Request failed after {attempt} attempts: {method} {log_url}"
                     ) from exc
 
             delay: float
@@ -359,7 +363,7 @@ class HttpTransport:
                 "Retrying HTTP request",
                 extra={
                     "method": method,
-                    "url": url,
+                    "url": log_url,
                     "attempt": attempt,
                     "delay_seconds": delay,
                     **request_context,
@@ -431,6 +435,32 @@ def _sanitize_params(params: dict[str, str] | None) -> dict[str, str]:
         else:
             sanitized[key] = str(value)
     return sanitized
+
+
+def _mask_url(url: str) -> str:
+    """민감한 query parameter 값을 가린 로그/예외용 URL 문자열을 만든다.
+
+    API 키 등이 query parameter로 전달되는 Provider(datago 등)의 경우,
+    URL 자체를 로그나 예외 메시지에 그대로 포함하면 키가 노출된다.
+    민감한 키가 없으면 원본 URL을 그대로 돌려주고, 있을 때만 마스킹된 URL을
+    재구성한다. 파싱할 수 없는 URL은 키 노출을 막기 위해 ``"[invalid url]"``로
+    대체한다.
+    """
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return "[invalid url]"
+    if not parts.query:
+        return url
+
+    query_items = parse_qsl(parts.query, keep_blank_values=True)
+    masked_items = [
+        (key, "[REDACTED]" if key.casefold() in _SENSITIVE_PARAM_KEYS else value)
+        for key, value in query_items
+    ]
+    if masked_items == query_items:
+        return url
+    return urlunsplit(parts._replace(query=urlencode(masked_items, safe="[]")))
 
 
 def _cache_headers_subset(headers: dict[str, str] | None) -> dict[str, str]:

--- a/src/kpubdata/transport/http.py
+++ b/src/kpubdata/transport/http.py
@@ -209,6 +209,10 @@ class HttpTransport:
         # 로그/예외에는 API 키가 query parameter로 포함될 수 있는 원본 URL 대신
         # 민감 파라미터를 가린 URL만 사용한다.
         log_url = _mask_url(url)
+        # 마스킹이 실제로 적용된 경우 원본 httpx 예외를 __cause__에 남기면
+        # 예외 체인(traceback/에러 트래커)을 통해 민감 URL이 새어나갈 수 있으므로
+        # 예외 체이닝을 끊는다. 마스킹이 없는 경우 디버깅 편의를 위해 체인을 유지한다.
+        url_masked = log_url != url
         if cache_key is not None and self._cache is not None:
             cached_body = self._cache.get(cache_key)
             if cached_body is not None:
@@ -314,7 +318,7 @@ class HttpTransport:
                 if attempt >= total_attempts:
                     raise TransportTimeoutError(
                         f"Request timed out after {attempt} attempts: {method} {log_url}"
-                    ) from exc
+                    ) from (None if url_masked else exc)
 
             except httpx.HTTPStatusError as exc:
                 status_code = exc.response.status_code
@@ -331,7 +335,7 @@ class HttpTransport:
                 if not _is_retryable_status(status_code) or attempt >= total_attempts:
                     raise TransportError(
                         f"HTTP status error {status_code} for {method} {log_url}"
-                    ) from exc
+                    ) from (None if url_masked else exc)
 
                 retry_after = cast(str | None, exc.response.headers.get("Retry-After"))
                 if retry_after is not None:
@@ -351,7 +355,7 @@ class HttpTransport:
                 if attempt >= total_attempts:
                     raise TransportError(
                         f"Request failed after {attempt} attempts: {method} {log_url}"
-                    ) from exc
+                    ) from (None if url_masked else exc)
 
             delay: float
             if retry_delay is not None:

--- a/tests/unit/transport/test_logging.py
+++ b/tests/unit/transport/test_logging.py
@@ -15,7 +15,7 @@ import httpx
 import pytest
 
 import kpubdata.transport.http as http_module
-from kpubdata.exceptions import TransportError
+from kpubdata.exceptions import TransportError, TransportTimeoutError
 from kpubdata.transport.http import HttpTransport, TransportConfig
 
 
@@ -343,3 +343,118 @@ def test_request_logs_mask_sensitive_url(caplog: pytest.LogCaptureFixture) -> No
     logged_url = cast(str, cast(Any, start_records[0]).url)
     assert "super-secret" not in logged_url
     assert logged_url == "https://api.example.test/data?serviceKey=[REDACTED]&query=station"
+
+
+# test status error chain suppressed when url masked 테스트가 검증하는 시나리오를 설명한다.
+def test_status_error_chain_suppressed_when_url_masked() -> None:
+    """
+    test status error chain suppressed when url masked 시나리오를 검증한다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        마스킹이 적용된 URL에서 HTTPStatusError가 발생하면 __cause__/__context__를
+        남기지 않아 원본 httpx 예외에 든 민감 URL이 traceback에 노출되지 않는다.
+    """
+    transport = HttpTransport(TransportConfig(max_retries=0))
+    secret_url = "https://api.example.test/data?serviceKey=super-secret&query=station"
+    response = httpx.Response(status_code=403, request=httpx.Request("GET", secret_url))
+
+    with (
+        patch("kpubdata.transport.http.httpx.Client.request", return_value=response),
+        pytest.raises(TransportError) as excinfo,
+    ):
+        _ = transport.request("GET", secret_url)
+
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.__suppress_context__ is True
+
+
+# test timeout chain suppressed when url masked 테스트가 검증하는 시나리오를 설명한다.
+def test_timeout_chain_suppressed_when_url_masked() -> None:
+    """
+    test timeout chain suppressed when url masked 시나리오를 검증한다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        마스킹이 적용된 URL에서 TimeoutException이 발생하면 TransportTimeoutError가
+        원본 예외를 __cause__에 남기지 않는다.
+    """
+    transport = HttpTransport(TransportConfig(max_retries=0))
+    secret_url = "https://api.example.test/data?serviceKey=super-secret&query=station"
+    timeout_exc = httpx.TimeoutException("timed out", request=httpx.Request("GET", secret_url))
+
+    with (
+        patch("kpubdata.transport.http.httpx.Client.request", side_effect=timeout_exc),
+        pytest.raises(TransportTimeoutError) as excinfo,
+    ):
+        _ = transport.request("GET", secret_url)
+
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.__suppress_context__ is True
+
+
+# test request error chain suppressed when url masked 테스트가 검증하는 시나리오를 설명한다.
+def test_request_error_chain_suppressed_when_url_masked() -> None:
+    """
+    test request error chain suppressed when url masked 시나리오를 검증한다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        마스킹이 적용된 URL에서 RequestError가 발생하면 TransportError가
+        원본 예외를 __cause__에 남기지 않는다.
+    """
+    transport = HttpTransport(TransportConfig(max_retries=0))
+    secret_url = "https://api.example.test/data?serviceKey=super-secret&query=station"
+    request_exc = httpx.ConnectError("connect failed", request=httpx.Request("GET", secret_url))
+
+    with (
+        patch("kpubdata.transport.http.httpx.Client.request", side_effect=request_exc),
+        pytest.raises(TransportError) as excinfo,
+    ):
+        _ = transport.request("GET", secret_url)
+
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.__suppress_context__ is True
+
+
+# test exception chain preserved when url not masked 테스트가 검증하는 시나리오를 설명한다.
+def test_exception_chain_preserved_when_url_not_masked() -> None:
+    """
+    test exception chain preserved when url not masked 시나리오를 검증한다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        마스킹이 적용되지 않은 URL에서는 디버깅 편의를 위해 원본 httpx 예외를
+        __cause__에 그대로 유지한다.
+    """
+    transport = HttpTransport(TransportConfig(max_retries=0))
+    plain_url = "https://api.example.test/data?query=station"
+    response = httpx.Response(status_code=403, request=httpx.Request("GET", plain_url))
+
+    with (
+        patch("kpubdata.transport.http.httpx.Client.request", return_value=response),
+        pytest.raises(TransportError) as excinfo,
+    ):
+        _ = transport.request("GET", plain_url)
+
+    assert isinstance(excinfo.value.__cause__, httpx.HTTPStatusError)

--- a/tests/unit/transport/test_logging.py
+++ b/tests/unit/transport/test_logging.py
@@ -15,6 +15,7 @@ import httpx
 import pytest
 
 import kpubdata.transport.http as http_module
+from kpubdata.exceptions import TransportError
 from kpubdata.transport.http import HttpTransport, TransportConfig
 
 
@@ -249,3 +250,96 @@ def test_request_logs_include_dataset_context(caplog: pytest.LogCaptureFixture) 
         record = next(record for record in caplog.records if record.getMessage() == message)
         assert record.__dict__["dataset_id"] == "datago.village_fcst"
         assert record.__dict__["provider"] == "datago"
+
+
+# test mask url redacts sensitive query params 테스트가 검증하는 시나리오를 설명한다.
+def test_mask_url_redacts_sensitive_query_params() -> None:
+    """
+    test mask url redacts sensitive query params 시나리오를 검증한다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+    """
+    mask_url = cast(Callable[[str], str], http_module._mask_url)
+
+    masked = mask_url(
+        "https://api.example.test/data?serviceKey=secret&SERVICE_KEY=other&query=station"
+    )
+    assert masked == (
+        "https://api.example.test/data?serviceKey=[REDACTED]&SERVICE_KEY=[REDACTED]&query=station"
+    )
+    assert mask_url("https://api.example.test/data?query=station") == (
+        "https://api.example.test/data?query=station"
+    )
+    assert mask_url("https://api.example.test/data") == "https://api.example.test/data"
+    assert mask_url("https://[invalid") == "[invalid url]"
+
+
+# test exception message masks sensitive query params 테스트가 검증하는 시나리오를 설명한다.
+def test_exception_message_masks_sensitive_query_params() -> None:
+    """
+    test exception message masks sensitive query params 시나리오를 검증한다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+    """
+    transport = HttpTransport(TransportConfig(max_retries=0))
+    secret_url = "https://api.example.test/data?serviceKey=super-secret&query=station"
+    response = httpx.Response(status_code=403, request=httpx.Request("GET", secret_url))
+
+    with (
+        patch("kpubdata.transport.http.httpx.Client.request", return_value=response),
+        pytest.raises(TransportError) as excinfo,
+    ):
+        _ = transport.request("GET", secret_url)
+
+    message = str(excinfo.value)
+    assert "super-secret" not in message
+    assert "serviceKey=[REDACTED]" in message
+    assert "query=station" in message
+
+
+# test request logs mask sensitive url 테스트가 검증하는 시나리오를 설명한다.
+def test_request_logs_mask_sensitive_url(caplog: pytest.LogCaptureFixture) -> None:
+    """
+    test request logs mask sensitive url 시나리오를 검증한다.
+
+    매개변수:
+        caplog (pytest.LogCaptureFixture): 호출자가 제공하는 입력 값이다.
+
+    반환값:
+        None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
+
+    예외:
+        구현체 내부 또는 하위 의존성에서 발생한 예외를 그대로 전파할 수 있다.
+
+    예시:
+        테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
+    """
+    transport = HttpTransport(TransportConfig(max_retries=0))
+    secret_url = "https://api.example.test/data?serviceKey=super-secret&query=station"
+    response = _response_with_content(b'{"ok": true}', "application/json")
+    caplog.set_level(logging.DEBUG, logger="kpubdata.transport")
+
+    with patch("kpubdata.transport.http.httpx.Client.request", return_value=response):
+        _ = transport.request("GET", secret_url)
+
+    start_records = [
+        record for record in caplog.records if record.getMessage() == "HTTP request start"
+    ]
+    assert len(start_records) == 1
+    logged_url = cast(str, cast(Any, start_records[0]).url)
+    assert "super-secret" not in logged_url
+    assert logged_url == "https://api.example.test/data?serviceKey=[REDACTED]&query=station"


### PR DESCRIPTION
## 개요

이슈 #260 — HTTP 로그/예외 메시지에서 API 키 노출 방지 (P0 보안)

`transport/http.py`에서 요청 실패 시 로그 및 예외 메시지에 원본 URL이 그대로 포함되어, `service_key` 등 API 키가 query parameter로 전달되는 Provider(datago 계열)에서 키가 로그·에러 트래커·사용자 화면에 노출될 수 있었습니다.

## 변경 내용

- `_mask_url()` 유틸리티 추가: `urlsplit`/`parse_qsl`로 URL의 query parameter를 파싱해 민감 키(`serviceKey`, `api_key`, `token` 등)를 `[REDACTED]`로 마스킹
  - 민감 키가 없는 URL은 원본을 그대로 유지 (형식 불변)
  - 파싱 불가 URL은 `[invalid url]`로 대체 (키 노출 방지)
- `request()` 내 모든 로그 레코드(10곳)의 `url` 필드를 마스킹된 URL로 교체
- 예외 메시지 3곳(타임아웃, HTTP 상태 오류, 요청 실패)을 마스킹된 URL로 교체
- 실제 요청/캐시 키 계산에는 원본 URL을 그대로 사용 (동작 변경 없음)

## 테스트

- `_mask_url` 단위 테스트: 대소문자 무관 마스킹, 비민감 URL 불변, 파싱 불가 URL 대체
- 예외 메시지에서 키 미노출 검증 (HTTP 403 경로)
- 디버그 로그 `url` 필드 마스킹 검증

## 품질 게이트

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src`
- [x] `uv run pytest` (1116 passed)
- [x] `uv run python -m build`
- [x] `mkdocs build --strict`

Fixes #260
