### PR TITLE
SGIS provider 기본 등록 누락 수정 (#332)

### DIFF
--- a/src/kpubdata/providers/manifest.py
+++ b/src/kpubdata/providers/manifest.py
@@ -21,4 +21,5 @@ BUILTIN_PROVIDERS: tuple[tuple[str, str, str], ...] = (
     ("localdata", "kpubdata.providers.localdata.adapter", "LocaldataAdapter"),
     ("semas", "kpubdata.providers.semas.adapter", "SemasAdapter"),
     ("krx", "kpubdata.providers.krx", "KrxAdapter"),
+    ("sgis", "kpubdata.providers.sgis", "SgisAdapter"),
 )

--- a/tests/unit/test_client_coverage.py
+++ b/tests/unit/test_client_coverage.py
@@ -6,10 +6,13 @@
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from kpubdata.client import Client
 from kpubdata.core.models import DatasetRef, Query, RecordBatch, SchemaDescriptor
+from kpubdata.providers.manifest import BUILTIN_PROVIDERS
 
 
 class _Adapter:
@@ -287,6 +290,24 @@ def test_builtin_dataset_binding_works() -> None:
 
     assert ds.id == "datago.village_fcst"
     assert ds.provider == "datago"
+
+
+def test_sgis_boundary_dataset_binding_works_without_network() -> None:
+    client = Client()
+
+    ds = client.dataset("sgis.boundary.sido")
+
+    assert ds.id == "sgis.boundary.sido"
+    assert ds.provider == "sgis"
+
+
+def test_supported_data_supported_providers_are_builtin() -> None:
+    supported_data = Path(__file__).parents[2] / "SUPPORTED_DATA.md"
+    text = supported_data.read_text(encoding="utf-8")
+    documented = set(re.findall(r"\| 지원 \| [^|]+ \| [^|]+ \| [^|]+ \(`([^`]+)`\)", text))
+    builtin = {provider for provider, _, _ in BUILTIN_PROVIDERS}
+
+    assert documented <= builtin
 
 
 # test user adapter overrides builtin 테스트가 검증하는 시나리오를 설명한다.


### PR DESCRIPTION
## 요약
- SGIS adapter를 builtin provider manifest에 등록합니다.
- `Client().dataset("sgis.boundary.sido")`가 네트워크 호출 없이 resolve되는 회귀 테스트를 추가합니다.
- `SUPPORTED_DATA.md`의 지원 provider가 builtin manifest에 등록되어 있는지 확인하는 정합 테스트를 추가합니다.

## 검증
- uv run --extra dev python -m pytest tests/unit/test_client_coverage.py -k 'sgis_boundary_dataset_binding_works_without_network or supported_data_supported_providers_are_builtin'
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check .
- uv run --extra dev mypy src
- uv run --extra dev python -m pytest
- uv run --extra dev python -m build
- uv run --extra docs mkdocs build --strict

Closes #332