### PR TITLE
fix: bound HTTP response reads (#271)

### DIFF
--- a/src/kpubdata/transport/http.py
+++ b/src/kpubdata/transport/http.py
@@ -37,6 +37,7 @@ _SENSITIVE_PARAM_KEYS = {
     "password",
     "key",
 }
+_DEFAULT_MAX_RESPONSE_BYTES = 50 * 1024 * 1024
 
 
 @dataclass
@@ -51,6 +52,7 @@ class TransportConfig:
     ssl_context: ssl.SSLContext | None = None
     cache: ResponseCache | None = None
     cache_ttl_seconds: int = 86400
+    max_response_bytes: int | None = _DEFAULT_MAX_RESPONSE_BYTES
 
 
 @dataclass(frozen=True)
@@ -96,6 +98,7 @@ class HttpTransport:
                 headers=_merge_headers(config.headers, requirements.headers),
                 cache=config.cache,
                 cache_ttl_seconds=config.cache_ttl_seconds,
+                max_response_bytes=config.max_response_bytes,
             ),
             requirements=requirements,
         )
@@ -201,6 +204,9 @@ class HttpTransport:
         if self._config.retry_backoff_factor < 0:
             msg = "retry_backoff_factor must be >= 0"
             raise ValueError(msg)
+        if self._config.max_response_bytes is not None and self._config.max_response_bytes < 1:
+            msg = "max_response_bytes must be >= 1 or None"
+            raise ValueError(msg)
 
         total_attempts = self._config.max_retries + 1
         # 메서드/URL/헤더 조합이 안전할 때만 캐시 키를 만들고 GET 응답을 재사용한다.
@@ -255,7 +261,7 @@ class HttpTransport:
                         },
                     )
 
-                response = self.client.request(
+                request = self.client.build_request(
                     method=method,
                     url=url,
                     params=params,
@@ -263,7 +269,18 @@ class HttpTransport:
                     content=content,
                     json=json_body,
                 )
-                _ = response.raise_for_status()
+                response = self.client.send(request, stream=True)
+                try:
+                    _ = response.raise_for_status()
+                    response = _read_limited_response(
+                        response,
+                        max_response_bytes=self._config.max_response_bytes,
+                        method=method,
+                        url=log_url,
+                    )
+                except Exception:
+                    response.close()
+                    raise
 
                 logger.debug(
                     "HTTP request success",
@@ -399,6 +416,49 @@ class HttpTransport:
 def _is_retryable_status(status_code: int) -> bool:
     """HTTP 상태 코드가 재시도 대상인지 반환한다."""
     return status_code == 429 or 500 <= status_code <= 599
+
+
+def _read_limited_response(
+    response: httpx.Response,
+    *,
+    max_response_bytes: int | None,
+    method: str,
+    url: str,
+) -> httpx.Response:
+    """응답 본문을 크기 제한 안에서 읽은 뒤 content-loaded Response로 반환한다."""
+    if max_response_bytes is not None:
+        content_length = response.headers.get("Content-Length")
+        if content_length is not None and _content_length_exceeds(
+            content_length, max_response_bytes
+        ):
+            raise TransportError(
+                f"Response body exceeded max_response_bytes={max_response_bytes}: {method} {url}"
+            )
+
+    body = bytearray()
+    for chunk in response.iter_bytes():
+        body.extend(chunk)
+        if max_response_bytes is not None and len(body) > max_response_bytes:
+            raise TransportError(
+                f"Response body exceeded max_response_bytes={max_response_bytes}: {method} {url}"
+            )
+
+    return httpx.Response(
+        status_code=response.status_code,
+        headers=response.headers,
+        content=bytes(body),
+        request=response.request,
+        extensions=response.extensions,
+        history=response.history,
+    )
+
+
+def _content_length_exceeds(content_length: str, max_response_bytes: int) -> bool:
+    """유효한 Content-Length가 제한보다 큰지 반환한다."""
+    try:
+        return int(content_length) > max_response_bytes
+    except ValueError:
+        return False
 
 
 def _request_context(*, dataset_id: str | None, provider: str | None) -> dict[str, str]:

--- a/tests/integration/test_transport_http.py
+++ b/tests/integration/test_transport_http.py
@@ -38,6 +38,7 @@ class Scenario(TypedDict, total=False):
     body: str | bytes
     content_type: str
     delay: float
+    omit_content_length: bool
 
 
 class MockThreadingHTTPServer(http.server.ThreadingHTTPServer):
@@ -151,7 +152,8 @@ class MockHandler(http.server.BaseHTTPRequestHandler):
 
         self.send_response(status)
         self.send_header("Content-Type", content_type)
-        self.send_header("Content-Length", str(len(payload)))
+        if not scenario.get("omit_content_length", False):
+            self.send_header("Content-Length", str(len(payload)))
         self.end_headers()
 
         try:
@@ -414,6 +416,32 @@ def test_no_retry_on_404(mock_server: MockServer, transport_config: TransportCon
 
     with HttpTransport(transport_config) as transport, pytest.raises(TransportError):
         _ = transport.request("GET", f"{mock_server.base_url}/not-found")
+
+    assert mock_server.hit_count == 1
+
+
+def test_content_length_over_limit_raises_transport_error(mock_server: MockServer) -> None:
+    mock_server.scenarios.append({"status": 200, "body": "0123456789"})
+    config = TransportConfig(max_retries=0, max_response_bytes=5)
+
+    with (
+        HttpTransport(config) as transport,
+        pytest.raises(TransportError, match="max_response_bytes"),
+    ):
+        _ = transport.request("GET", f"{mock_server.base_url}/too-large")
+
+    assert mock_server.hit_count == 1
+
+
+def test_streamed_body_over_limit_raises_transport_error(mock_server: MockServer) -> None:
+    mock_server.scenarios.append({"status": 200, "body": "0123456789", "omit_content_length": True})
+    config = TransportConfig(max_retries=0, max_response_bytes=5)
+
+    with (
+        HttpTransport(config) as transport,
+        pytest.raises(TransportError, match="max_response_bytes"),
+    ):
+        _ = transport.request("GET", f"{mock_server.base_url}/stream-too-large")
 
     assert mock_server.hit_count == 1
 

--- a/tests/unit/transport/test_cache.py
+++ b/tests/unit/transport/test_cache.py
@@ -211,9 +211,7 @@ def test_http_transport_get_cache_hit_logs_and_skips_network(
     response = _response(content=b'{"cached": false}')
     caplog.set_level(logging.DEBUG, logger="kpubdata.transport")
 
-    with patch(
-        "kpubdata.transport.http.httpx.Client.request", return_value=response
-    ) as request_mock:
+    with patch("kpubdata.transport.http.httpx.Client.send", return_value=response) as request_mock:
         first = transport.request(
             "GET",
             "https://example.test/resource",
@@ -264,9 +262,7 @@ def test_http_transport_post_is_never_cached(tmp_path: Path) -> None:
     transport = HttpTransport(TransportConfig(max_retries=0), cache=cache, cache_ttl_seconds=60)
     response = _response(method="POST", content=b'{"created": true}')
 
-    with patch(
-        "kpubdata.transport.http.httpx.Client.request", return_value=response
-    ) as request_mock:
+    with patch("kpubdata.transport.http.httpx.Client.send", return_value=response) as request_mock:
         _ = transport.request("POST", "https://example.test/resource", content=b"{}")
         _ = transport.request("POST", "https://example.test/resource", content=b"{}")
 
@@ -296,7 +292,7 @@ def test_http_transport_non_2xx_is_never_cached(tmp_path: Path) -> None:
     response = _response(status_code=404)
 
     with (
-        patch("kpubdata.transport.http.httpx.Client.request", return_value=response),
+        patch("kpubdata.transport.http.httpx.Client.send", return_value=response),
         pytest.raises(TransportError),
     ):
         _ = transport.request("GET", "https://example.test/resource")

--- a/tests/unit/transport/test_http_coverage.py
+++ b/tests/unit/transport/test_http_coverage.py
@@ -149,7 +149,7 @@ def test_request_retries_on_request_error_then_succeeds() -> None:
     transport = HttpTransport(TransportConfig(max_retries=1, retry_backoff_factor=0.5))
 
     with (
-        patch("kpubdata.transport.http.httpx.Client.request") as request_mock,
+        patch("kpubdata.transport.http.httpx.Client.send") as request_mock,
         patch("kpubdata.transport.http.time.sleep") as sleep_mock,
     ):
         request_mock.side_effect = [_request_error(), _response(200)]
@@ -178,7 +178,7 @@ def test_request_error_exhaustion_raises_transport_error() -> None:
     transport = HttpTransport(TransportConfig(max_retries=2, retry_backoff_factor=0.25))
 
     with (
-        patch("kpubdata.transport.http.httpx.Client.request", side_effect=_request_error()),
+        patch("kpubdata.transport.http.httpx.Client.send", side_effect=_request_error()),
         patch("kpubdata.transport.http.time.sleep") as sleep_mock,
         pytest.raises(TransportError, match="Request failed after 3 attempts"),
     ):

--- a/tests/unit/transport/test_logging.py
+++ b/tests/unit/transport/test_logging.py
@@ -63,7 +63,7 @@ def test_request_params_log_redacts_service_key(caplog: pytest.LogCaptureFixture
     response = _response_with_content(b'{"ok": true}', "application/json")
     caplog.set_level(logging.DEBUG, logger="kpubdata.transport")
 
-    with patch("kpubdata.transport.http.httpx.Client.request", return_value=response):
+    with patch("kpubdata.transport.http.httpx.Client.send", return_value=response):
         _ = transport.request(
             "GET",
             "https://example.test/resource",
@@ -98,7 +98,7 @@ def test_response_preview_logged_and_truncated(caplog: pytest.LogCaptureFixture)
     response = _response_with_content(long_text.encode("utf-8"), "text/plain; charset=utf-8")
     caplog.set_level(logging.DEBUG, logger="kpubdata.transport")
 
-    with patch("kpubdata.transport.http.httpx.Client.request", return_value=response):
+    with patch("kpubdata.transport.http.httpx.Client.send", return_value=response):
         _ = transport.request("GET", "https://example.test/resource")
 
     preview_records = [
@@ -208,7 +208,7 @@ def test_debug_gating_skips_sanitization_and_preview_helpers() -> None:
             "kpubdata.transport.http._response_preview",
             side_effect=AssertionError("_response_preview should not be called"),
         ),
-        patch("kpubdata.transport.http.httpx.Client.request", return_value=response),
+        patch("kpubdata.transport.http.httpx.Client.send", return_value=response),
     ):
         _ = transport.request("GET", "https://example.test/resource", params={"serviceKey": "x"})
 
@@ -234,7 +234,7 @@ def test_request_logs_include_dataset_context(caplog: pytest.LogCaptureFixture) 
     response = _response_with_content(b'{"ok": true}', "application/json")
     caplog.set_level(logging.DEBUG, logger="kpubdata.transport")
 
-    with patch("kpubdata.transport.http.httpx.Client.request", return_value=response):
+    with patch("kpubdata.transport.http.httpx.Client.send", return_value=response):
         _ = transport.request(
             "GET",
             "https://example.test/resource",
@@ -300,7 +300,7 @@ def test_exception_message_masks_sensitive_query_params() -> None:
     response = httpx.Response(status_code=403, request=httpx.Request("GET", secret_url))
 
     with (
-        patch("kpubdata.transport.http.httpx.Client.request", return_value=response),
+        patch("kpubdata.transport.http.httpx.Client.send", return_value=response),
         pytest.raises(TransportError) as excinfo,
     ):
         _ = transport.request("GET", secret_url)
@@ -333,7 +333,7 @@ def test_request_logs_mask_sensitive_url(caplog: pytest.LogCaptureFixture) -> No
     response = _response_with_content(b'{"ok": true}', "application/json")
     caplog.set_level(logging.DEBUG, logger="kpubdata.transport")
 
-    with patch("kpubdata.transport.http.httpx.Client.request", return_value=response):
+    with patch("kpubdata.transport.http.httpx.Client.send", return_value=response):
         _ = transport.request("GET", secret_url)
 
     start_records = [
@@ -365,7 +365,7 @@ def test_status_error_chain_suppressed_when_url_masked() -> None:
     response = httpx.Response(status_code=403, request=httpx.Request("GET", secret_url))
 
     with (
-        patch("kpubdata.transport.http.httpx.Client.request", return_value=response),
+        patch("kpubdata.transport.http.httpx.Client.send", return_value=response),
         pytest.raises(TransportError) as excinfo,
     ):
         _ = transport.request("GET", secret_url)
@@ -394,7 +394,7 @@ def test_timeout_chain_suppressed_when_url_masked() -> None:
     timeout_exc = httpx.TimeoutException("timed out", request=httpx.Request("GET", secret_url))
 
     with (
-        patch("kpubdata.transport.http.httpx.Client.request", side_effect=timeout_exc),
+        patch("kpubdata.transport.http.httpx.Client.send", side_effect=timeout_exc),
         pytest.raises(TransportTimeoutError) as excinfo,
     ):
         _ = transport.request("GET", secret_url)
@@ -423,7 +423,7 @@ def test_request_error_chain_suppressed_when_url_masked() -> None:
     request_exc = httpx.ConnectError("connect failed", request=httpx.Request("GET", secret_url))
 
     with (
-        patch("kpubdata.transport.http.httpx.Client.request", side_effect=request_exc),
+        patch("kpubdata.transport.http.httpx.Client.send", side_effect=request_exc),
         pytest.raises(TransportError) as excinfo,
     ):
         _ = transport.request("GET", secret_url)
@@ -452,7 +452,7 @@ def test_exception_chain_preserved_when_url_not_masked() -> None:
     response = httpx.Response(status_code=403, request=httpx.Request("GET", plain_url))
 
     with (
-        patch("kpubdata.transport.http.httpx.Client.request", return_value=response),
+        patch("kpubdata.transport.http.httpx.Client.send", return_value=response),
         pytest.raises(TransportError) as excinfo,
     ):
         _ = transport.request("GET", plain_url)

--- a/tests/unit/transport/test_retry_after.py
+++ b/tests/unit/transport/test_retry_after.py
@@ -53,7 +53,7 @@ def test_429_with_retry_after_seconds_uses_header_delay() -> None:
     transport = HttpTransport(TransportConfig(max_retries=1, retry_backoff_factor=0.5))
 
     with (
-        patch("kpubdata.transport.http.httpx.Client.request") as request_mock,
+        patch("kpubdata.transport.http.httpx.Client.send") as request_mock,
         patch("kpubdata.transport.http.time.sleep") as sleep_mock,
     ):
         request_mock.side_effect = [_response(429, retry_after="2"), _response(200)]
@@ -122,7 +122,7 @@ def test_429_with_retry_after_http_date_uses_computed_delay(
     transport = HttpTransport(TransportConfig(max_retries=1, retry_backoff_factor=0.5))
 
     with (
-        patch("kpubdata.transport.http.httpx.Client.request") as request_mock,
+        patch("kpubdata.transport.http.httpx.Client.send") as request_mock,
         patch("kpubdata.transport.http.time.sleep") as sleep_mock,
     ):
         request_mock.side_effect = [_response(429, retry_after=retry_after_header), _response(200)]
@@ -151,7 +151,7 @@ def test_429_with_invalid_retry_after_falls_back_to_exponential_backoff() -> Non
     transport = HttpTransport(TransportConfig(max_retries=1, retry_backoff_factor=0.75))
 
     with (
-        patch("kpubdata.transport.http.httpx.Client.request") as request_mock,
+        patch("kpubdata.transport.http.httpx.Client.send") as request_mock,
         patch("kpubdata.transport.http.time.sleep") as sleep_mock,
     ):
         request_mock.side_effect = [_response(429, retry_after="abc"), _response(200)]
@@ -179,7 +179,7 @@ def test_429_without_retry_after_uses_exponential_backoff() -> None:
     transport = HttpTransport(TransportConfig(max_retries=1, retry_backoff_factor=0.25))
 
     with (
-        patch("kpubdata.transport.http.httpx.Client.request") as request_mock,
+        patch("kpubdata.transport.http.httpx.Client.send") as request_mock,
         patch("kpubdata.transport.http.time.sleep") as sleep_mock,
     ):
         request_mock.side_effect = [_response(429), _response(200)]
@@ -207,7 +207,7 @@ def test_503_with_retry_after_respects_header_delay() -> None:
     transport = HttpTransport(TransportConfig(max_retries=1, retry_backoff_factor=0.5))
 
     with (
-        patch("kpubdata.transport.http.httpx.Client.request") as request_mock,
+        patch("kpubdata.transport.http.httpx.Client.send") as request_mock,
         patch("kpubdata.transport.http.time.sleep") as sleep_mock,
     ):
         request_mock.side_effect = [_response(503, retry_after="3"), _response(200)]
@@ -236,7 +236,7 @@ def test_non_retryable_status_does_not_retry_even_with_retry_after() -> None:
 
     with (
         patch(
-            "kpubdata.transport.http.httpx.Client.request",
+            "kpubdata.transport.http.httpx.Client.send",
             return_value=_response(400, retry_after="9"),
         ) as request_mock,
         patch("kpubdata.transport.http.time.sleep") as sleep_mock,


### PR DESCRIPTION
## Summary
- add TransportConfig.max_response_bytes with a 50 MiB default
- read HTTP responses through httpx streaming and fail with TransportError when Content-Length or streamed body exceeds the configured limit
- add integration coverage for both Content-Length precheck and streamed body overflow
- update unit tests to mock the streamed Client.send seam

Closes #271

## Verification
- uv run pytest tests/unit/transport tests/integration/test_transport_http.py -q
- uv run ruff check src/kpubdata/transport/http.py tests/integration/test_transport_http.py tests/unit/transport/test_cache.py tests/unit/transport/test_http_coverage.py tests/unit/transport/test_logging.py tests/unit/transport/test_retry_after.py
- uv run ruff format --check src/kpubdata/transport/http.py tests/integration/test_transport_http.py tests/unit/transport/test_cache.py tests/unit/transport/test_http_coverage.py tests/unit/transport/test_logging.py tests/unit/transport/test_retry_after.py
- uv run mypy src/kpubdata/transport/http.py
- GIT_MASTER=1 git diff --check

Note: LSP diagnostics were attempted but the LSP daemon timed out; project CLI gates above passed.