### PR TITLE
fix: credential별 캐시 키 격리 (#263)

### DIFF
--- a/src/kpubdata/transport/cache.py
+++ b/src/kpubdata/transport/cache.py
@@ -23,7 +23,6 @@ class _CachePayload(TypedDict, total=False):
     body_b64: str
 
 
-_REDACTED_VALUE = "[REDACTED]"
 _SENSITIVE_CACHE_KEY_NAMES = {
     "servicekey",
     "service_key",
@@ -192,9 +191,9 @@ def _normalize_mapping(values: Mapping[str, object] | None) -> list[tuple[str, s
 
     normalized_items: list[tuple[str, str]] = []
     for key, value in values.items():
-        normalized_value = (
-            _REDACTED_VALUE if key.casefold() in _SENSITIVE_CACHE_KEY_NAMES else str(value)
-        )
+        normalized_value = str(value)
+        if key.casefold() in _SENSITIVE_CACHE_KEY_NAMES:
+            normalized_value = hashlib.sha256(normalized_value.encode("utf-8")).hexdigest()
         normalized_items.append((key.casefold(), normalized_value))
     normalized_items.sort()
     return normalized_items

--- a/tests/unit/transport/test_cache.py
+++ b/tests/unit/transport/test_cache.py
@@ -121,10 +121,10 @@ def test_response_cache_missing_key_returns_none(tmp_path: Path) -> None:
     assert cache.get("missing") is None
 
 
-# test make cache key redacts secret values 테스트가 검증하는 시나리오를 설명한다.
-def test_make_cache_key_redacts_secret_values() -> None:
+# test make cache key isolates secret values 테스트가 검증하는 시나리오를 설명한다.
+def test_make_cache_key_isolates_secret_values() -> None:
     """
-    test make cache key redacts secret values 시나리오를 검증한다.
+    test make cache key isolates secret values 시나리오를 검증한다.
 
     반환값:
         None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
@@ -154,7 +154,7 @@ def test_make_cache_key_redacts_secret_values() -> None:
         {"Accept": "application/json", "Authorization": "Bearer bbb"},
     )
 
-    assert key_one == key_two
+    assert key_one != key_two
     assert key_one != key_three
 
 
@@ -185,13 +185,13 @@ def test_response_cache_filesystem_errors_are_swallowed(tmp_path: Path) -> None:
     cache.clear_expired()
 
 
-# test http transport get cache hit logs and skips network 테스트가 검증하는 시나리오를 설명한다.
-def test_http_transport_get_cache_hit_logs_and_skips_network(
+# test http transport get isolates cache by credential 테스트가 검증하는 시나리오를 설명한다.
+def test_http_transport_get_isolates_cache_by_credential(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
-    test http transport get cache hit logs and skips network 시나리오를 검증한다.
+    test http transport get isolates cache by credential 시나리오를 검증한다.
 
     매개변수:
         tmp_path (Path): 호출자가 제공하는 입력 값이다.
@@ -208,11 +208,13 @@ def test_http_transport_get_cache_hit_logs_and_skips_network(
     """
     cache = ResponseCache(base_dir=tmp_path)
     transport = HttpTransport(TransportConfig(max_retries=0), cache=cache, cache_ttl_seconds=60)
-    response = _response(content=b'{"cached": false}')
+    first_response = _response(content=b'{"credential": "first"}')
+    second_response = _response(content=b'{"credential": "second"}')
     caplog.set_level(logging.DEBUG, logger="kpubdata.transport")
 
     with patch(
-        "kpubdata.transport.http.httpx.Client.request", return_value=response
+        "kpubdata.transport.http.httpx.Client.request",
+        side_effect=[first_response, second_response],
     ) as request_mock:
         first = transport.request(
             "GET",
@@ -229,18 +231,17 @@ def test_http_transport_get_cache_hit_logs_and_skips_network(
             provider="datago",
         )
 
-    assert first.content == second.content == b'{"cached": false}'
-    assert request_mock.call_count == 1
+    assert first.content == b'{"credential": "first"}'
+    assert second.content == b'{"credential": "second"}'
+    assert request_mock.call_count == 2
 
-    miss_record = next(
+    miss_records = [
         record for record in caplog.records if record.getMessage() == "transport cache miss; stored"
-    )
-    hit_record = next(
-        record for record in caplog.records if record.getMessage() == "transport cache hit"
-    )
-    assert miss_record.__dict__["dataset_id"] == "datago.tour_kor_area"
-    assert hit_record.__dict__["provider"] == "datago"
-    assert miss_record.__dict__["cache_key"] == hit_record.__dict__["cache_key"]
+    ]
+    assert len(miss_records) == 2
+    assert miss_records[0].__dict__["dataset_id"] == "datago.tour_kor_area"
+    assert miss_records[1].__dict__["provider"] == "datago"
+    assert miss_records[0].__dict__["cache_key"] != miss_records[1].__dict__["cache_key"]
 
 
 # test http transport post is never cached 테스트가 검증하는 시나리오를 설명한다.


### PR DESCRIPTION
## 변경 사항

- 민감한 캐시 키 값(`serviceKey`, `Authorization` 등)을 공통 `[REDACTED]` 토큰으로 접지 않고 SHA-256 digest로 정규화합니다.
- 서로 다른 credential 요청이 같은 endpoint/query를 호출해도 별도 cache key를 갖도록 회귀 테스트를 갱신했습니다.
- raw credential 값은 cache key 파일명이나 로그 필드에 직접 포함되지 않습니다.

## 검증

- `uv run pytest tests/unit/transport/test_cache.py -q` -> 14 passed
- `uv run ruff check src/kpubdata/transport/cache.py tests/unit/transport/test_cache.py` -> passed
- `uv run ruff format --check src/kpubdata/transport/cache.py tests/unit/transport/test_cache.py` -> passed
- `uv run mypy src/kpubdata/transport/cache.py` -> passed
- `GIT_MASTER=1 git diff --check` -> passed

## 참고

- LSP diagnostics는 기존 세션과 동일하게 daemon timeout으로 완료되지 않았습니다.

Closes #263