### PR TITLE
fix: lazy provider materialization race 수정 (#262)

### DIFF
--- a/src/kpubdata/registry.py
+++ b/src/kpubdata/registry.py
@@ -115,25 +115,25 @@ class ProviderRegistry:
                 return adapter
 
             factory = self._lazy.pop(normalized_name, None)
+            if factory is None:
+                logger.debug("Provider lookup failed", extra={"provider": normalized_name})
+                raise ProviderNotRegisteredError(f"Provider '{name}' is not registered")
 
-        if factory is None:
-            logger.debug("Provider lookup failed", extra={"provider": normalized_name})
-            raise ProviderNotRegisteredError(f"Provider '{name}' is not registered")
-
-        logger.debug(
-            "Materializing lazy provider adapter",
-            extra={"provider": normalized_name},
-        )
-        lazy_adapter = factory()
-        self._validate_adapter(lazy_adapter)
-        self._validate_capability_contract(lazy_adapter)
-        adapter_name = str(lazy_adapter.name).strip().lower()
-        if adapter_name != normalized_name:
-            raise TypeError(
-                f"Lazy adapter name mismatch: expected '{normalized_name}', got '{adapter_name}'"
+            logger.debug(
+                "Materializing lazy provider adapter",
+                extra={"provider": normalized_name},
             )
+            lazy_adapter = factory()
+            self._validate_adapter(lazy_adapter)
+            self._validate_capability_contract(lazy_adapter)
+            adapter_name = str(lazy_adapter.name).strip().lower()
+            if adapter_name != normalized_name:
+                msg = (
+                    f"Lazy adapter name mismatch: expected '{normalized_name}', "
+                    f"got '{adapter_name}'"
+                )
+                raise TypeError(msg)
 
-        with self._lock:
             self._adapters[normalized_name] = lazy_adapter
         logger.debug(
             "Materialized lazy provider adapter",

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from threading import Event, Thread
+
 import pytest
 
 from kpubdata.exceptions import ProviderNotRegisteredError
@@ -256,6 +258,50 @@ class TestProviderRegistry:
         assert "lazy" in reg
         adapter = reg.get("lazy")
         assert adapter.name == "lazy"
+
+    def test_concurrent_lazy_get_waits_for_materialization(self) -> None:
+        reg = ProviderRegistry()
+        factory_started = Event()
+        release_factory = Event()
+        second_started = Event()
+        factory_calls: list[int] = []
+        adapters: list[object] = []
+        lookup_errors: list[ProviderNotRegisteredError] = []
+
+        def factory() -> FakeAdapter:
+            factory_calls.append(1)
+            factory_started.set()
+            release_factory.wait(timeout=5)
+            return FakeAdapter("lazy")
+
+        def first_lookup() -> None:
+            adapters.append(reg.get("lazy"))
+
+        def second_lookup() -> None:
+            second_started.set()
+            try:
+                adapters.append(reg.get("lazy"))
+            except ProviderNotRegisteredError as exc:
+                lookup_errors.append(exc)
+
+        reg.register_lazy("lazy", factory)
+        first_thread = Thread(target=first_lookup)
+        second_thread = Thread(target=second_lookup)
+
+        first_thread.start()
+        assert factory_started.wait(timeout=5)
+        second_thread.start()
+        assert second_started.wait(timeout=5)
+        release_factory.set()
+        first_thread.join(timeout=5)
+        second_thread.join(timeout=5)
+
+        assert not first_thread.is_alive()
+        assert not second_thread.is_alive()
+        assert lookup_errors == []
+        assert factory_calls == [1]
+        assert len(adapters) == 2
+        assert adapters[0] is adapters[1]
 
     # test validate rejects bad adapter 테스트가 검증하는 시나리오를 설명한다.
     def test_validate_rejects_bad_adapter(self) -> None:


### PR DESCRIPTION
## 변경 사항

- `ProviderRegistry.get()`에서 lazy factory를 꺼낸 뒤 materialization이 끝날 때까지 registry lock을 유지합니다.
- 첫 lazy materialization 중 같은 provider를 조회하는 다른 스레드가 transient `ProviderNotRegisteredError`를 받지 않고, materialized adapter를 재사용하도록 보장합니다.
- 동시 lazy 조회 회귀 테스트를 추가했습니다.

## 검증

- `uv run pytest tests/unit/test_registry.py::TestProviderRegistry::test_concurrent_lazy_get_waits_for_materialization -q` -> passed
- `uv run pytest tests/unit/test_registry.py tests/unit/test_registry_coverage.py -q` -> 23 passed
- `uv run ruff check src/kpubdata/registry.py tests/unit/test_registry.py` -> passed
- `uv run ruff format --check src/kpubdata/registry.py tests/unit/test_registry.py` -> passed
- `uv run mypy src/kpubdata/registry.py` -> passed
- `GIT_MASTER=1 git diff --check` -> passed

## 참고

- LSP diagnostics는 기존 세션과 동일하게 daemon timeout으로 완료되지 않았습니다.

Closes #262