### PR TITLE
fix: datago.generic 외부 호스트 차단 (#261)

### DIFF
--- a/src/kpubdata/providers/datago/adapter.py
+++ b/src/kpubdata/providers/datago/adapter.py
@@ -229,8 +229,7 @@ class DataGoAdapter:
           * ``_service_key_param`` (str): service key 파라미터 이름을 재정의한다.
           * ``_format_param`` (str): 응답 형식 파라미터 이름을 재정의한다.
 
-        ``_base_url``이 ``*.data.go.kr`` 호스트를 가리키지 않으면 경고를 기록한다.
-        호출은 계속 진행되며, 이는 완화된 점검이다.
+        ``_base_url``은 ``*.data.go.kr`` 호스트만 허용한다.
         """
 
         logger.debug(
@@ -272,14 +271,18 @@ class DataGoAdapter:
 
             host = urlparse(base_url_override).hostname or ""
             if not host.endswith(".data.go.kr") and host != "data.go.kr":
-                logger.warning(
-                    "datago.generic called with non-data.go.kr host",
+                logger.debug(
+                    "Datago.generic rejected non-data.go.kr host",
                     extra={
                         "dataset_id": dataset.id,
                         "operation": operation,
-                        "base_url": base_url_override,
                         "host": host,
                     },
+                )
+                raise InvalidRequestError(
+                    "datago.generic '_base_url' host must be data.go.kr or a data.go.kr subdomain",
+                    provider="datago",
+                    dataset_id=dataset.id,
                 )
 
             url = f"{base_url_override.rstrip('/')}/{operation}"

--- a/tests/unit/providers/datago/test_generic.py
+++ b/tests/unit/providers/datago/test_generic.py
@@ -447,13 +447,10 @@ class TestDataGoGenericDataset:
                 },
             )
 
-    # test non data go kr host logs warning 테스트가 검증하는 시나리오를 설명한다.
-    def test_non_data_go_kr_host_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+    # test non data go kr host raises 테스트가 검증하는 시나리오를 설명한다.
+    def test_non_data_go_kr_host_raises(self) -> None:
         """
-        test non data go kr host logs warning 시나리오를 검증한다.
-
-        매개변수:
-            caplog (pytest.LogCaptureFixture): 호출자가 제공하는 입력 값이다.
+        test non data go kr host raises 시나리오를 검증한다.
 
         반환값:
             None: 계산 결과 또는 하위 호출의 반환값을 돌려준다.
@@ -464,19 +461,17 @@ class TestDataGoGenericDataset:
         예시:
             테스트 이름이 설명하는 기대 동작이 회귀 없이 유지되는지 확인한다.
         """
-        import logging
-
-        adapter, _ = _build_adapter([FakeResponse(_success_envelope())])
+        adapter, transport = _build_adapter([FakeResponse(_success_envelope())])
         dataset = adapter.get_dataset("generic")
 
-        with caplog.at_level(logging.WARNING, logger="kpubdata.provider.datago"):
+        with pytest.raises(InvalidRequestError, match="host"):
             adapter.call_raw(
                 dataset,
                 "getX",
                 {"_base_url": "http://example.com/foo"},
             )
 
-        assert any("non-data.go.kr host" in record.message for record in caplog.records)
+        assert transport.calls == []
 
     # test data go kr host no warning 테스트가 검증하는 시나리오를 설명한다.
     def test_data_go_kr_host_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## 변경 사항

- `datago.generic`의 `_base_url` 호스트를 `data.go.kr` 및 `*.data.go.kr`로 제한합니다.
- 허용되지 않은 호스트는 `InvalidRequestError`로 차단하고 transport 호출 전 종료합니다.
- 기존 warning-only 테스트를 blocking regression으로 갱신했습니다.

## 검증

- `uv run pytest tests/unit/providers/datago/test_generic.py::TestDataGoGenericDataset::test_non_data_go_kr_host_raises tests/unit/providers/datago/test_generic.py::TestDataGoGenericDataset::test_data_go_kr_host_no_warning -q` -> 2 passed
- `uv run pytest tests/unit/providers/datago/test_generic.py -q` -> 13 passed
- `uv run ruff check src/kpubdata/providers/datago/adapter.py tests/unit/providers/datago/test_generic.py` -> passed
- `uv run ruff format --check src/kpubdata/providers/datago/adapter.py tests/unit/providers/datago/test_generic.py` -> passed
- `uv run mypy src/kpubdata/providers/datago/adapter.py` -> passed
- `GIT_MASTER=1 git diff --check` -> passed

## 참고

- LSP diagnostics는 기존 세션과 동일하게 daemon timeout으로 완료되지 않았습니다.

Closes #261