### PR TITLE
feat: retry sleep 주입 지원 (#270)

### DIFF
--- a/src/kpubdata/transport/http.py
+++ b/src/kpubdata/transport/http.py
@@ -51,6 +51,7 @@ class TransportConfig:
     ssl_context: ssl.SSLContext | None = None
     cache: ResponseCache | None = None
     cache_ttl_seconds: int = 86400
+    retry_sleep: Callable[[float], None] | None = None
 
 
 @dataclass(frozen=True)
@@ -96,6 +97,7 @@ class HttpTransport:
                 headers=_merge_headers(config.headers, requirements.headers),
                 cache=config.cache,
                 cache_ttl_seconds=config.cache_ttl_seconds,
+                retry_sleep=config.retry_sleep,
             ),
             requirements=requirements,
         )
@@ -373,7 +375,8 @@ class HttpTransport:
                     **request_context,
                 },
             )
-            time.sleep(delay)
+            retry_sleep = self._config.retry_sleep or time.sleep
+            retry_sleep(delay)
 
         msg = "unreachable transport retry state"
         raise RuntimeError(msg)

--- a/src/kpubdata/transport/retry.py
+++ b/src/kpubdata/transport/retry.py
@@ -18,6 +18,7 @@ def with_retry(
     max_retries: int = 3,
     backoff_factor: float = 0.5,
     retryable_exceptions: tuple[type[BaseException], ...] = (),
+    sleep: Callable[[float], None] | None = None,
 ) -> T:
     """지수 백오프 재시도와 함께 ``fn``을 실행한다.
 
@@ -59,7 +60,8 @@ def with_retry(
                     "exception_type": type(exc).__name__,
                 },
             )
-            time.sleep(delay)
+            retry_sleep = sleep or time.sleep
+            retry_sleep(delay)
 
     msg = "unreachable retry state"
     raise RuntimeError(msg)

--- a/tests/unit/transport/test_http_coverage.py
+++ b/tests/unit/transport/test_http_coverage.py
@@ -161,6 +161,22 @@ def test_request_retries_on_request_error_then_succeeds() -> None:
     sleep_mock.assert_called_once_with(0.5)
 
 
+def test_request_uses_configured_retry_sleep() -> None:
+    delays: list[float] = []
+    transport = HttpTransport(
+        TransportConfig(max_retries=1, retry_backoff_factor=0.5, retry_sleep=delays.append)
+    )
+
+    with patch("kpubdata.transport.http.httpx.Client.request") as request_mock:
+        request_mock.side_effect = [_request_error(), _response(200)]
+
+        response = transport.request("GET", "https://example.test")
+
+    assert response.status_code == 200
+    assert request_mock.call_count == 2
+    assert delays == [0.5]
+
+
 # test request error exhaustion raises transport error 테스트가 검증하는 시나리오를 설명한다.
 def test_request_error_exhaustion_raises_transport_error() -> None:
     """

--- a/tests/unit/transport/test_retry.py
+++ b/tests/unit/transport/test_retry.py
@@ -72,6 +72,27 @@ class TestWithRetry:
         assert result == "ok"
         assert calls["count"] == 3
 
+    def test_retry_uses_injected_sleep(self) -> None:
+        calls = {"count": 0}
+        delays: list[float] = []
+
+        def flaky() -> str:
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise ValueError("transient")
+            return "ok"
+
+        result = with_retry(
+            flaky,
+            max_retries=1,
+            backoff_factor=0.25,
+            retryable_exceptions=(ValueError,),
+            sleep=delays.append,
+        )
+
+        assert result == "ok"
+        assert delays == [0.25]
+
     # test exhausted retries 테스트가 검증하는 시나리오를 설명한다.
     def test_exhausted_retries(self) -> None:
         """


### PR DESCRIPTION
## 변경 사항

- `with_retry()`에 `sleep` callable을 주입할 수 있게 했습니다. 기본값은 호출 시점의 `time.sleep`으로 유지됩니다.
- `TransportConfig.retry_sleep`을 추가해 `HttpTransport` retry delay도 호출자가 제어할 수 있게 했습니다.
- 기본 동작과 기존 `time.sleep` monkeypatch 기반 테스트 호환성은 유지했습니다.

## 커밋

- `feat: add injectable retry sleeper (#270)`
- `feat: add transport retry sleeper hook (#270)`

## 검증

- `uv run pytest tests/unit/transport/test_retry.py::TestWithRetry::test_retry_uses_injected_sleep tests/unit/transport/test_http_coverage.py::test_request_uses_configured_retry_sleep -q` -> 2 passed
- `uv run pytest tests/unit/transport/test_retry.py tests/unit/transport/test_retry_coverage.py tests/unit/transport/test_retry_after.py tests/unit/transport/test_http_coverage.py -q` -> 22 passed
- `uv run ruff check src/kpubdata/transport/http.py src/kpubdata/transport/retry.py tests/unit/transport/test_retry.py tests/unit/transport/test_http_coverage.py` -> passed
- `uv run ruff format --check src/kpubdata/transport/http.py src/kpubdata/transport/retry.py tests/unit/transport/test_retry.py tests/unit/transport/test_http_coverage.py` -> passed
- `uv run mypy src/kpubdata/transport/http.py src/kpubdata/transport/retry.py` -> passed
- `GIT_MASTER=1 git diff --check` -> passed

## 참고

- LSP diagnostics는 기존 세션과 동일하게 daemon timeout으로 완료되지 않았습니다.

Closes #270