### PR TITLE
docs: canonical model 계약 동기화 (#274)

### DIFF
--- a/CANONICAL_MODEL.md
+++ b/CANONICAL_MODEL.md
@@ -27,7 +27,8 @@ classDiagram
         +tuple tags
         +str source_url
         +Representation representation
-        +frozenset[Capability] capabilities
+        +frozenset[Operation] operations
+        +QuerySupport query_support
     }
     class Query {
         +dict filters
@@ -119,7 +120,7 @@ ref = DatasetRef(
     provider="datago",
     dataset_key="village_fcst",
     name="동네예보",
-    representation=Representation.OPENAPI,
+    representation=Representation.API_JSON,
     description="Korea Meteorological Administration short-range forecast",
     tags=("weather", "forecast"),
     source_url="https://www.data.go.kr",
@@ -169,62 +170,82 @@ for item in batch.items:
                               +-- [ FieldConstraints ] (제약 조건)
 ```
 
-## 6. Core types (Original)
+## 6. Core types
 
-### 3.1 Capability
+### 6.1 Operation and QuerySupport
 
 ```python
 from enum import Enum
 
-class Capability(str, Enum):
+class Operation(str, Enum):
     LIST = "list"
     GET = "get"
     SCHEMA = "schema"
     RAW = "raw"
-    PAGEABLE = "pageable"
-    FILTERABLE = "filterable"
-    SORTABLE = "sortable"
-    TIME_RANGE = "time_range"
     DOWNLOAD = "download"
-    REALTIME = "realtime"
+
+class PaginationMode(str, Enum):
+    OFFSET = "offset"
+    INDEX = "index"
+    CURSOR = "cursor"
+    NONE = "none"
+
+@dataclass(slots=True, frozen=True)
+class QuerySupport:
+    pagination: PaginationMode = PaginationMode.NONE
+    filterable_fields: frozenset[str] = frozenset()
+    sortable_fields: frozenset[str] = frozenset()
+    time_range: bool = False
+    max_page_size: int | None = None
 ```
 
-### 3.2 Representation
+`Operation` describes the canonical actions a dataset supports. Query-shape features that used to be modeled as capability enum values are now structured in `QuerySupport`.
+
+### 6.2 Representation
 
 ```python
 from enum import Enum
 
 class Representation(str, Enum):
-    OPENAPI = "openapi"
-    FILE = "file"
+    API_JSON = "api_json"
+    API_XML = "api_xml"
+    FILE_CSV = "file_csv"
+    FILE_EXCEL = "file_excel"
     SHEET = "sheet"
-    DOWNLOAD = "download"
     OTHER = "other"
 ```
 
 ```mermaid
 graph TD
-    subgraph Capabilities [Dataset Capabilities]
+    subgraph Operations [Dataset Operations]
         LIST[LIST: Browse multiple records]
         GET[GET: Fetch single record by ID]
         SCHEMA[SCHEMA: Metadata about fields]
         RAW[RAW: Provider escape hatch]
-        PAGEABLE[PAGEABLE: Supports pagination]
-        FILTERABLE[FILTERABLE: Supports filtering]
+        DOWNLOAD[DOWNLOAD: Download source artifact]
+    end
+
+    subgraph QuerySupport [Query Support]
+        PAGINATION[pagination: offset/index/cursor/none]
+        FILTERABLE[filterable_fields]
+        SORTABLE[sortable_fields]
+        TIME_RANGE[time_range]
     end
 
     subgraph Reps [Representations]
-        OPENAPI[OPENAPI: REST/HTTP API]
-        FILE[FILE: JSON/XML/CSV file]
+        API_JSON[API_JSON: JSON HTTP API]
+        API_XML[API_XML: XML HTTP API]
+        FILE_CSV[FILE_CSV: CSV file]
+        FILE_EXCEL[FILE_EXCEL: Excel file]
         SHEET[SHEET: Google/Excel sheet]
     end
 ```
 
-### 3.3 DatasetRef
+### 6.3 DatasetRef
 
 ```python
 from dataclasses import dataclass, field
-from typing import Any
+from types import MappingProxyType
 
 @dataclass(slots=True, frozen=True)
 class DatasetRef:
@@ -233,22 +254,26 @@ class DatasetRef:
     dataset_key: str
     name: str
     representation: Representation
+    operations: frozenset[Operation] = frozenset()
+    query_support: QuerySupport | None = None
+    raw_metadata: MappingProxyType[str, object] = field(default_factory=_empty_proxy)
     description: str | None = None
     tags: tuple[str, ...] = ()
     source_url: str | None = None
-    capabilities: frozenset[Capability] = frozenset()
-    raw_metadata: dict[str, Any] = field(default_factory=dict)
 ```
 
 Notes:
 
 - `id` is the stable bound identifier, e.g. `molit.apartment_trades`
 - `representation` matters because the same logical dataset may be offered in more than one form
+- `operations` is the honest set of supported canonical actions
+- `query_support` describes pagination, filtering, sorting, time-range, and max page-size metadata when known
 - `description` is a human-readable summary of what the dataset provides
 - `tags` are categorization keywords for discovery (e.g. `("weather", "forecast")`)
 - `source_url` links to the original API documentation or data portal page
+- `raw_metadata` is immutable provider-native discovery metadata for debugging and adapter internals
 
-### 3.4 Query
+### 6.4 Query
 
 ```python
 from dataclasses import dataclass, field
@@ -292,7 +317,7 @@ Canonical Query validates common input constraints. Provider-specific rules rema
 
 This separation ensures that invalid canonical inputs are rejected early (before provider invocation) while preserving provider flexibility for domain-specific constraints.
 
-### 3.5 RecordBatch
+### 6.5 RecordBatch
 
 ```python
 from dataclasses import dataclass, field
@@ -309,10 +334,11 @@ class RecordBatch:
     meta: dict[str, Any] = field(default_factory=dict)
 ```
 
-### 3.6 SchemaDescriptor
+### 6.6 SchemaDescriptor
 
 ```python
 from dataclasses import dataclass, field
+from types import MappingProxyType
 
 @dataclass(slots=True)
 class FieldConstraints:
@@ -331,13 +357,13 @@ class FieldDescriptor:
     description: str | None = None
     nullable: bool | None = None
     constraints: FieldConstraints | None = None
-    raw: dict[str, object] = field(default_factory=dict)
+    raw: MappingProxyType[str, object] = field(default_factory=_empty_object_proxy)
 
 @dataclass(slots=True)
 class SchemaDescriptor:
     dataset: DatasetRef
     fields: list[FieldDescriptor]
-    raw: dict[str, object] = field(default_factory=dict)
+    raw: MappingProxyType[str, object] = field(default_factory=_empty_object_proxy)
 ```
 
 ## 4. Error model
@@ -347,12 +373,16 @@ class PublicDataError(Exception): ...
 class ConfigError(PublicDataError): ...
 class AuthError(PublicDataError): ...
 class TransportError(PublicDataError): ...
-class TimeoutError(TransportError): ...
+class TransportTimeoutError(TransportError): ...
+class RateLimitError(TransportError): ...
+class ServiceUnavailableError(TransportError): ...
 class ParseError(PublicDataError): ...
 class InvalidRequestError(PublicDataError): ...
 class ProviderResponseError(PublicDataError): ...
 class UnsupportedCapabilityError(PublicDataError): ...
 class DatasetNotFoundError(PublicDataError): ...
+class ProviderNotRegisteredError(PublicDataError): ...
+class CapabilityContractError(PublicDataError): ...
 ```
 
 ## 5. Bound Dataset object

--- a/PROVIDER_ADAPTER_CONTRACT.md
+++ b/PROVIDER_ADAPTER_CONTRACT.md
@@ -16,7 +16,7 @@ Every adapter must be responsible for:
 - native-to-canonical result translation
 - provider-specific error translation
 - raw-call support
-- honest capability declaration
+- honest operation and query-support declaration
 
 ## 3. 어댑터란 무엇인가? (초보자용 설명)
 
@@ -110,8 +110,8 @@ API가 주는 에러 코드를 보고 `AuthError`, `RateLimitError` 등 KPubData
 - `tests/fixtures/`에 실제 API 응답 샘플을 저장합니다.
 - 유닛 테스트(`tests/unit/`)에서 이 샘플을 잘 파싱하는지 검증합니다.
 
-### 9단계: Capabilities(기능) 선언
-이 어댑터가 페이징(`PAGEABLE`)을 지원하는지, 검색(`FILTERABLE`)이 되는지 정직하게 써줍니다.
+### 9단계: Operations와 QuerySupport 선언
+이 어댑터가 어떤 정규 작업(`Operation.LIST`, `Operation.RAW` 등)을 지원하는지 `DatasetRef.operations`에 정직하게 선언합니다. 페이징, 검색, 정렬, 기간 조건 같은 질의 기능은 `QuerySupport`에 구조화해서 기록합니다.
 
 ```mermaid
 flowchart TD
@@ -123,7 +123,7 @@ flowchart TD
     S5 --> S6[6단계: call_raw 비상구 구현]
     S6 --> S7[7단계: 기관별 에러 처리]
     S7 --> S8[8단계: 피스처 및 테스트 작성]
-    S8 --> S9[9단계: 기능 Capabilities 선언]
+    S8 --> S9[9단계: Operations와 QuerySupport 선언]
 ```
 
 ## 5. 기존 어댑터 분석: `datago`
@@ -131,9 +131,9 @@ flowchart TD
 가장 모범적인 사례인 `datago` 어댑터를 참고하세요.
 
 - **`src/kpubdata/providers/datago/adapter.py`**:
-  - `_validate_envelope`: 응답이 깨졌는지, 에러가 들어있는지 공통으로 체크합니다.
+  - `_validate_envelope`: 표준 data.go.kr 응답이 깨졌는지, 에러가 들어있는지 공통으로 체크합니다.
   - `_normalize_items`: XML과 JSON에서 아이템 목록을 뽑아내는 복잡한 로직을 처리합니다.
-  - `_raise_for_result_code`: 기상청 등의 에러 코드(`01`, `02` 등)를 이해하기 쉬운 이름으로 바꿉니다.
+  - `_raise_for_result_code`: 기상청 등의 에러 코드(`01`, `02` 등)를 이해하기 쉬운 예외로 바꿉니다.
 
 **이 파일을 복사해서 새로운 어댑터를 만들기 시작하는 것을 추천합니다!**
 
@@ -175,9 +175,10 @@ classDiagram
 - **우선순위**: `list_all()`은 `next_cursor`가 존재할 경우 이를 우선적으로 사용하며, 없을 경우 `next_page`를 사용합니다.
 - **권장 방식**: 가급적 `total_count` 기반의 정밀한 계산 방식을 선호합니다. 하지만 전체 개수 정보를 알 수 없는 경우 `len(items) == page_size` 휴리스틱을 사용하는 것도 허용됩니다.
 
-## 5. Capability rules
+## 5. Operation and query-support rules
 
-- declare only what the adapter truly supports
+- declare only operations the adapter truly supports in `DatasetRef.operations`
+- describe pagination, filter, sort, time-range, and page-size support in `DatasetRef.query_support`
 - if an operation is unavailable, raise `UnsupportedCapabilityError`
 - do not silently emulate unsupported semantics unless documented
 
@@ -211,7 +212,7 @@ Do not destroy provider-native fields. Prefer one of these approaches:
 Every adapter must include:
 
 - unit tests for mapping/parsing
-- contract tests for declared capabilities
+- contract tests for declared operations and query-support behavior
 - fixture-based tests for representative success/failure responses
 
 ```mermaid
@@ -240,7 +241,7 @@ Otherwise, keep the complexity local to the adapter.
 5. implement `call_raw`
 6. map provider errors
 7. add fixtures and tests
-8. document capabilities and caveats
+8. document operations, query support, and caveats
 
 ---
 


### PR DESCRIPTION
## 변경 사항

- `CANONICAL_MODEL.md`를 현재 core 코드 기준으로 동기화했습니다.
  - `Capability` -> `Operation`
  - query 기능은 `QuerySupport`로 문서화
  - `Representation` enum 값을 `API_JSON`, `API_XML`, `FILE_CSV`, `FILE_EXCEL`, `SHEET`, `OTHER`로 갱신
  - `DatasetRef.operations`, `DatasetRef.query_support`, immutable `MappingProxyType` raw metadata 반영
  - error hierarchy의 `TransportTimeoutError`, `RateLimitError`, `ServiceUnavailableError`, `ProviderNotRegisteredError`, `CapabilityContractError` 반영
- `PROVIDER_ADAPTER_CONTRACT.md`의 capability 선언 안내를 `operations` + `QuerySupport` 기준으로 갱신했습니다.

## 검증

- `rg -n "Capability|capabilities|Representation\\.OPENAPI|OPENAPI|TimeoutError\\(|class TimeoutError|PAGEABLE|REALTIME|raw_metadata: dict|raw: dict|declared capabilities|DataGoEnvelopeParser|datago/envelope.py" CANONICAL_MODEL.md PROVIDER_ADAPTER_CONTRACT.md` -> stale model references 없음; 현재 예외명 일부만 의도적으로 매치
- `uv run mkdocs build --strict` -> passed
- `GIT_MASTER=1 git diff --check` -> passed

## 참고

- `uv run`이 `uv.lock` dependency constraints를 재동기화하려 했지만, 이 PR 범위가 아니라 diff에서 제외했습니다.

Closes #274